### PR TITLE
fix: f-string & dictionary size change errors

### DIFF
--- a/python/airtag_decryptor.py
+++ b/python/airtag_decryptor.py
@@ -20,14 +20,14 @@ from Crypto.Cipher import AES
 KEYCHAIN_LABEL = "BeaconStore"
 
 BASE_FOLDER = "com.apple.icloud.searchpartyd"
-INPUT_PATH = f"{os.getenv("HOME")}/Library/{BASE_FOLDER}"
+INPUT_PATH = f"{os.getenv('HOME')}/Library/{BASE_FOLDER}"
 
 # NOTE FROM AUTHOR: For my purposes these are sufficient.
 # You can add more if you need more, or remove the filter entirely below
 WHITELISTED_DIRS = { "OwnedBeacons", "BeaconNamingRecord" }
 
 # NOTE FROM AUTHOR: PROVIDE YOUR OWN OUTPUT PATH HERE IF DESIRED!!!
-OUTPUT_PATH = f"/Users/{os.getenv("USER")}/plist_decrypt_output"
+OUTPUT_PATH = f"/Users/{os.getenv('USER')}/plist_decrypt_output"
 
 
 def get_key(label: str):

--- a/python/wizard.py
+++ b/python/wizard.py
@@ -81,7 +81,7 @@ class WizardApp(tk.Tk):
             selectmode="multiple"
         )
 
-        self.options = [f"{"" if b.beacon_emoji is None else b.beacon_emoji + " "}{b.beacon_name} - {bid}" for bid, b in self.beacon_data.items()]
+        self.options = [f"{'' if b.beacon_emoji is None else b.beacon_emoji + ' '}{b.beacon_name} - {bid}" for bid, b in self.beacon_data.items()]
         self.options.sort()
 
         self.choices_select.insert(1, *self.options)
@@ -178,7 +178,7 @@ class WizardApp(tk.Tk):
 
 
         # cleanup any bad ones:
-        for beacon_id in m.keys():
+        for beacon_id in list(m.keys()):
             if m[beacon_id].beacon_naming_record is None:
                 # shouldn't happen, but clean up just in case
                 del m[beacon_id]


### PR DESCRIPTION
This pull request addresses two issues that I encountered when running it as a python script on MacOS:

1. f-string errors: I've updated the f-string syntax in both wizard.py and airtag_decryptor.py by switching from double quotes to single quotes.
2. Dictionary size change error: this error actually prevented me from using the latest release version of the Export Wizard. I've added a conversion of the dictionary into a list, which resolved it for me.
