### PR TITLE
Bump the Android app to 1.0.5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "dev.wander.android.opentagviewer"
         minSdk = 24
         targetSdk = 35
-        versionCode = 2
-        versionName = "1.0.4"
+        versionCode = 3
+        versionName = "1.0.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
```kotlin
versionCode = 3        // was 2
versionName = "1.0.5"  // was 1.0.4
```

Everything since `android-app-v1.0.4` (2025-07-22) is on `main` and unreleased — 35 commits touching `app/`: the fork merge, key alignment, and the import, history and map fixes found by running the finished branch on a phone.

## Why versionCode matters here

Android refuses to install an APK whose `versionCode` is not higher than the installed one. Shipping a new `versionName` without bumping it would leave existing users unable to update, and that failure appears on their phone rather than in any build — nothing in CI would catch it.

## Note for whoever cuts the release

The tag must be `android-app-v1.0.5`, matching `versionName`.

Unlike the macOS exporter, **nothing currently enforces that**. `scripts/exporter_version.py` fails a release whose tag disagrees with the source, and `test-release-version` runs it before either binary is built — but there is no equivalent for the Android app, so an Android tag can drift from `versionName` exactly the way the exporter's used to. Worth closing that asymmetry separately.

Release notes are drafted in `tmp/` (gitignored) and are not part of this PR.

## Verified

`./gradlew :app:assembleDebug` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)