### PR TITLE
Build Intel on a runner that exists, and verify it runs on old macOS

### DIFF
--- a/.github/workflows/macos-exporter-python.yml
+++ b/.github/workflows/macos-exporter-python.yml
@@ -116,6 +116,12 @@ jobs:
     env:
       APP_VERSION: ${{ needs.test-release-version.outputs.app-version }}
 
+      # The wizard only works on macOS 14 and earlier - 15 tightened keychain access so the
+      # BeaconStore key cannot be read - so every machine this binary has to run on is older
+      # than the machine building it. Setting the target explicitly stops the toolchain
+      # stamping the runner's own OS version onto the result and locking out every user.
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -143,6 +149,14 @@ jobs:
           --icon=OpenTagViewer.icns \
           --noconfirm \
           ./main/wizard.py
+
+    # Verifies rather than assumes. A dependency built on the runner's own macOS - Homebrew
+    # bottles especially, which are not backward compatible - can raise the whole bundle's
+    # floor to the builder's OS version. That produces a binary which installs fine and then
+    # refuses to launch, on a user's Mac, with no traceback and nothing in any build log.
+    # Runs before the upload so a build nobody could use never reaches the release page.
+    - name: Check the build can run on the macOS the wizard supports
+      run: python3 scripts/check_macos_min_version.py python/dist
 
     - name: Prepare and Upload MacOS App
       working-directory: ./python
@@ -179,7 +193,11 @@ jobs:
 
   build-intel:
     needs: test-release-version
-    runs-on: macos-13 # Intel
+    # macos-13 no longer exists. GitHub's supported images are macOS 26, 15 and 14 (14 itself
+    # deprecated), so a job asking for macos-13 is never picked up - it sits queued until the
+    # six-hour timeout rather than failing, which is why the 1.0.5 release went out with only
+    # the ARM64 binary attached. macos-15-intel is the current standard-size x64 label.
+    runs-on: macos-15-intel # Intel
     environment: 'MacOS Exporter App CI'
 
     # The repository default is read-only, which is what turned a missing token into a 403 at
@@ -199,6 +217,12 @@ jobs:
     # name, and the version the app reports about itself cannot come apart.
     env:
       APP_VERSION: ${{ needs.test-release-version.outputs.app-version }}
+
+      # The wizard only works on macOS 14 and earlier - 15 tightened keychain access so the
+      # BeaconStore key cannot be read - so every machine this binary has to run on is older
+      # than the machine building it. Setting the target explicitly stops the toolchain
+      # stamping the runner's own OS version onto the result and locking out every user.
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
 
     steps:
     - name: Checkout code
@@ -227,6 +251,14 @@ jobs:
           --icon=OpenTagViewer.icns \
           --noconfirm \
           ./main/wizard.py
+
+    # Verifies rather than assumes. A dependency built on the runner's own macOS - Homebrew
+    # bottles especially, which are not backward compatible - can raise the whole bundle's
+    # floor to the builder's OS version. That produces a binary which installs fine and then
+    # refuses to launch, on a user's Mac, with no traceback and nothing in any build log.
+    # Runs before the upload so a build nobody could use never reaches the release page.
+    - name: Check the build can run on the macOS the wizard supports
+      run: python3 scripts/check_macos_min_version.py python/dist
 
     - name: Prepare and Upload MacOS App
       working-directory: ./python

--- a/scripts/check_macos_min_version.py
+++ b/scripts/check_macos_min_version.py
@@ -1,0 +1,146 @@
+"""Report the oldest macOS a built binary can run on, and fail if it is too new.
+
+The export wizard exists to be run on *old* Macs. macOS 15 tightened keychain access so the
+BeaconStore key can no longer be read automatically, so every user this app serves is on macOS
+14 or earlier - while the machine that builds it is whatever GitHub currently offers, which is
+now newer than that.
+
+A binary built on a newer macOS usually still runs on older ones, but only if the deployment
+target recorded in its Mach-O headers is low enough, and only if nothing it bundles was built
+with a higher one. Homebrew bottles are the classic trap: they are built for the builder's OS
+and are not backward compatible, so a single Homebrew dylib pulled into the bundle can make
+the whole app refuse to launch. That failure happens on a user's machine, at startup, with no
+traceback - the same shape as the `Abort trap: 6` this project already hit from the other
+direction on a test VM.
+
+So this reads what the binary actually declares instead of assuming:
+
+  * `LC_BUILD_VERSION` -> `minos`, on anything built with a modern toolchain
+  * `LC_VERSION_MIN_MACOSX` -> `version`, on older binaries
+
+The maximum across every Mach-O file in the bundle is the real floor: the app can only run
+where *all* of its parts can.
+
+Policy: always print the floor, and fail only when it exceeds the newest macOS the wizard
+supports. A hard failure means the build is unusable by the entire user base, which is worth
+stopping a release for. Anything lower is reported and left alone, because the exact floor
+depends on how the interpreter itself was built and is not ours to dictate.
+
+Usage
+-----
+    python scripts/check_macos_min_version.py python/dist/OpenTagViewer.app
+    python scripts/check_macos_min_version.py python/dist --max-supported 14.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# macOS 15 changed keychain access, so the wizard cannot work there. A build that will not
+# start on 14 cannot be used by anyone.
+DEFAULT_MAX_SUPPORTED = "14.0"
+
+MINOS = re.compile(r"^\s*minos\s+([0-9]+(?:\.[0-9]+)*)\s*$", re.MULTILINE)
+VERSION_MIN = re.compile(r"^\s*version\s+([0-9]+(?:\.[0-9]+)*)\s*$", re.MULTILINE)
+
+
+def parse_version(text: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in text.split("."))
+
+
+def format_version(version: tuple[int, ...]) -> str:
+    return ".".join(str(part) for part in version)
+
+
+def minimum_versions(otool_output: str) -> list[tuple[int, ...]]:
+    """Every minimum-macOS declaration in `otool -l` output, in either encoding."""
+    found = MINOS.findall(otool_output)
+
+    # LC_VERSION_MIN_MACOSX also has a `version` line; LC_BUILD_VERSION has `sdk` instead, so
+    # the two do not collide.
+    found += VERSION_MIN.findall(otool_output)
+
+    return [parse_version(value) for value in found]
+
+
+def highest_requirement(requirements: dict[Path, tuple[int, ...]]) -> tuple[Path, tuple[int, ...]] | None:
+    """The file demanding the newest macOS - the one that decides where the app can run."""
+    if not requirements:
+        return None
+    path = max(requirements, key=lambda p: requirements[p])
+    return path, requirements[path]
+
+
+def scan(target: Path) -> dict[Path, tuple[int, ...]]:
+    """Map every Mach-O file under `target` to the oldest macOS it will run on."""
+    files = [target] if target.is_file() else sorted(p for p in target.rglob("*") if p.is_file())
+
+    requirements: dict[Path, tuple[int, ...]] = {}
+    for path in files:
+        try:
+            result = subprocess.run(["otool", "-l", str(path)], capture_output=True, text=True,
+                                    check=False, encoding="utf-8", errors="replace")
+        except FileNotFoundError:
+            print("ERROR: otool not found. This check only runs on macOS.", file=sys.stderr)
+            raise SystemExit(2)
+
+        if result.returncode != 0:
+            continue  # not a Mach-O file
+
+        versions = minimum_versions(result.stdout)
+        if versions:
+            requirements[path] = max(versions)
+
+    return requirements
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
+    parser.add_argument("target", type=Path, help="a built binary, or a directory to walk")
+    parser.add_argument("--max-supported", default=DEFAULT_MAX_SUPPORTED,
+                        help=f"fail if the binary needs newer than this (default "
+                             f"{DEFAULT_MAX_SUPPORTED}, the newest macOS the wizard supports)")
+    args = parser.parse_args(argv)
+
+    if not args.target.exists():
+        print(f"ERROR: {args.target} does not exist", file=sys.stderr)
+        return 2
+
+    requirements = scan(args.target)
+    highest = highest_requirement(requirements)
+
+    if highest is None:
+        print(f"ERROR: found no Mach-O files under {args.target}", file=sys.stderr)
+        return 2
+
+    path, version = highest
+    limit = parse_version(args.max_supported)
+
+    print(f"Scanned {len(requirements)} Mach-O file(s) under {args.target}")
+    print(f"Oldest macOS this build can run on: {format_version(version)}")
+    print(f"  set by: {path}")
+
+    if version > limit:
+        print(
+            f"\nERROR: this build requires macOS {format_version(version)}, but the wizard is "
+            f"only usable on {args.max_supported} and earlier - macOS 15 tightened keychain "
+            f"access so the BeaconStore key cannot be read there.\n"
+            f"Nobody who needs this app could run this binary.\n"
+            f"\n"
+            f"The usual cause is a dependency built on the runner's own macOS - Homebrew "
+            f"bottles in particular are built for the builder's OS and are not backward "
+            f"compatible.\n"
+            f"Check what {path.name} pulled in, and that MACOSX_DEPLOYMENT_TARGET is set for "
+            f"the build.",
+            file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test/test_check_macos_min_version.py
+++ b/scripts/test/test_check_macos_min_version.py
@@ -1,0 +1,113 @@
+"""Tests for scripts/check_macos_min_version.py.
+
+The parsing runs on `otool` output, which only exists on macOS - so the tests feed it recorded
+output rather than shelling out, and run anywhere.
+
+What this guards is a release that installs and then refuses to launch on every machine its
+users have. That failure surfaces on a stranger's Mac at startup with no traceback, so the
+check has to be right in both directions: it must catch a bundle built for a too-new macOS,
+and it must not cry wolf on a normal one.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import check_macos_min_version as checker  # noqa: E402
+
+
+# Modern toolchains emit LC_BUILD_VERSION.
+BUILD_VERSION = """\
+Load command 8
+      cmd LC_BUILD_VERSION
+  cmdsize 32
+ platform 1
+    minos 11.0
+      sdk 15.0
+   ntools 1
+"""
+
+# Older binaries, and some prebuilt wheels, still use LC_VERSION_MIN_MACOSX.
+VERSION_MIN = """\
+Load command 9
+      cmd LC_VERSION_MIN_MACOSX
+  cmdsize 16
+  version 10.13
+      sdk 10.15
+"""
+
+
+def test_reads_the_minimum_from_a_modern_build_command():
+    assert checker.minimum_versions(BUILD_VERSION) == [(11, 0)]
+
+
+def test_reads_the_minimum_from_an_older_build_command():
+    assert checker.minimum_versions(VERSION_MIN) == [(10, 13)]
+
+
+def test_ignores_the_sdk_version():
+    """The SDK is what it was built *with*; minos is what it will run *on*."""
+    assert (15, 0) not in checker.minimum_versions(BUILD_VERSION)
+
+
+def test_a_file_with_no_version_command_reports_nothing():
+    assert checker.minimum_versions("Load command 0\n      cmd LC_SEGMENT_64\n") == []
+
+
+def test_a_fat_binary_reports_every_slice():
+    """A universal binary carries one load command per architecture."""
+    both = BUILD_VERSION + BUILD_VERSION.replace("minos 11.0", "minos 12.0")
+
+    assert sorted(checker.minimum_versions(both)) == [(11, 0), (12, 0)]
+
+
+# --- which file decides where the app can run -------------------------------------------
+
+def test_the_newest_requirement_wins():
+    """
+    The app runs only where all of its parts run, so one Homebrew dylib built on the runner's
+    own macOS sets the floor for the whole bundle.
+    """
+    requirements = {
+        Path("OpenTagViewer"): (11, 0),
+        Path("libtcl9.0.dylib"): (15, 0),
+        Path("libcrypto.dylib"): (11, 0),
+    }
+
+    highest = checker.highest_requirement(requirements)
+
+    assert highest is not None
+    path, version = highest
+    assert path == Path("libtcl9.0.dylib")
+    assert version == (15, 0)
+
+
+def test_no_mach_o_files_at_all_is_reported_rather_than_passing():
+    assert checker.highest_requirement({}) is None
+
+
+# --- version comparison ------------------------------------------------------------------
+
+def test_versions_compare_numerically_not_as_strings():
+    # "9.0" > "15.0" as strings, and 10.13 vs 10.9 is the classic one.
+    assert checker.parse_version("15.0") > checker.parse_version("9.0")
+    assert checker.parse_version("10.13") > checker.parse_version("10.9")
+
+
+def test_a_build_for_an_older_macos_is_fine():
+    assert checker.parse_version("11.0") <= checker.parse_version(checker.DEFAULT_MAX_SUPPORTED)
+
+
+def test_a_build_requiring_macos_15_is_not():
+    """
+    macOS 15 tightened keychain access, so the wizard cannot work there at all. A binary that
+    needs 15 is unusable by every single person who wants this app.
+    """
+    assert checker.parse_version("15.0") > checker.parse_version(checker.DEFAULT_MAX_SUPPORTED)
+
+
+def test_the_default_limit_matches_the_newest_macos_the_wizard_supports():
+    assert checker.DEFAULT_MAX_SUPPORTED == "14.0"


### PR DESCRIPTION
## `macos-13` no longer exists

From the runner-images README's supported list:

| OS | Arch | Labels |
| --- | --- | --- |
| macOS 26 | x64 | `macos-latest-large`, `macos-26-intel`, `macos-26-large` |
| macOS 15 | x64 | `macos-15-large`, `macos-15-intel` |
| macOS 14 | both | **deprecated** — actions/runner-images#13518 |

No `macos-13`. A job requesting it is never picked up — it sits **queued until the six-hour timeout** rather than failing, which is why it looked stuck rather than broken, and why `macos-exporter-v1.0.5` published with only the ARM64 binary attached.

Now `macos-15-intel`.

## Which creates the real problem

The wizard only works on **macOS 14 and earlier** — 15 tightened keychain access so the BeaconStore key cannot be read automatically. So every machine this binary has to run on is *older* than the machine building it.

A binary built on newer macOS usually still runs on older ones, but only if the deployment target in its Mach-O headers is low enough, and only if nothing it bundles was built with a higher one. **Homebrew bottles are the trap**: built for the builder's OS, not backward compatible, and one such dylib raises the floor for the entire bundle. Note this workflow runs `brew install python-tk` during the build.

The result would install fine and then refuse to launch, on a user's Mac, with no traceback and nothing in any build log — the same shape as the `Abort trap: 6` this project already hit from the other direction on a test VM.

## So it is verified rather than assumed

- both jobs set `MACOSX_DEPLOYMENT_TARGET=11.0`
- `scripts/check_macos_min_version.py` reads what the built bundle actually declares — `LC_BUILD_VERSION` → `minos`, or `LC_VERSION_MIN_MACOSX` → `version` on older binaries — takes the highest across every Mach-O file in the bundle, and fails if it exceeds macOS 14

It runs **before** the upload, so a build nobody could use never reaches the release page.

Failing only above 14 is deliberate: that is the line between "some users cannot run this" and "no user can run this", and only the second is worth stopping a release for. The exact floor below that depends on how the interpreter itself was built and is reported rather than dictated.

## Tests

11, against recorded `otool` output so they run anywhere rather than only on macOS. Both directions are covered — it has to catch a bundle built for a too-new macOS *and* not cry wolf on a normal one — plus the classic `10.13` vs `10.9` string-comparison trap.

## Still worth checking by hand

This makes an Intel build *probably* runnable on 11–14; it does not prove it. The conclusive test is running the artifact on an actual older Mac — there is a macOS 14 VM already set up for exactly this (see CONTRIBUTING.md).

`macos-14` is left alone here, though it is deprecated too. Moving the ARM jobs at the same time would muddy what that VM test proves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)