### PR TITLE
Only read the minimum-OS field of the load command that declares it

### DIFF
--- a/scripts/check_macos_min_version.py
+++ b/scripts/check_macos_min_version.py
@@ -44,8 +44,8 @@ from pathlib import Path
 # start on 14 cannot be used by anyone.
 DEFAULT_MAX_SUPPORTED = "14.0"
 
-MINOS = re.compile(r"^\s*minos\s+([0-9]+(?:\.[0-9]+)*)\s*$", re.MULTILINE)
-VERSION_MIN = re.compile(r"^\s*version\s+([0-9]+(?:\.[0-9]+)*)\s*$", re.MULTILINE)
+CMD = re.compile(r"^cmd\s+(\S+)$")
+FIELD = re.compile(r"^(\S+)\s+([0-9]+(?:\.[0-9]+)*)$")
 
 
 def parse_version(text: str) -> tuple[int, ...]:
@@ -56,15 +56,39 @@ def format_version(version: tuple[int, ...]) -> str:
     return ".".join(str(part) for part in version)
 
 
+# Which field carries the minimum OS, per load command. Nothing else counts.
+MINIMUM_FIELDS = {
+    "LC_BUILD_VERSION": "minos",
+    "LC_VERSION_MIN_MACOSX": "version",
+}
+
+
 def minimum_versions(otool_output: str) -> list[tuple[int, ...]]:
-    """Every minimum-macOS declaration in `otool -l` output, in either encoding."""
-    found = MINOS.findall(otool_output)
+    """
+    Every minimum-macOS declaration in `otool -l` output, in either encoding.
 
-    # LC_VERSION_MIN_MACOSX also has a `version` line; LC_BUILD_VERSION has `sdk` instead, so
-    # the two do not collide.
-    found += VERSION_MIN.findall(otool_output)
+    Load commands have to be tracked rather than pattern-matched line by line, because several
+    of them carry a field that looks like a version. `LC_SOURCE_VERSION` in particular holds
+    values such as `1230.1`, and reading that as a macOS requirement failed a perfectly good
+    Apple Silicon build - claiming it needed "macOS 1230.1" - after the binary had already been
+    built. Only the field belonging to the right command means anything.
+    """
+    versions = []
+    command = None
 
-    return [parse_version(value) for value in found]
+    for line in otool_output.splitlines():
+        stripped = line.strip()
+
+        match = CMD.match(stripped)
+        if match:
+            command = match.group(1)
+            continue
+
+        field = FIELD.match(stripped)
+        if field and MINIMUM_FIELDS.get(command or "") == field.group(1):
+            versions.append(parse_version(field.group(2)))
+
+    return versions
 
 
 def highest_requirement(requirements: dict[Path, tuple[int, ...]]) -> tuple[Path, tuple[int, ...]] | None:

--- a/scripts/test/test_check_macos_min_version.py
+++ b/scripts/test/test_check_macos_min_version.py
@@ -57,6 +57,51 @@ def test_a_file_with_no_version_command_reports_nothing():
     assert checker.minimum_versions("Load command 0\n      cmd LC_SEGMENT_64\n") == []
 
 
+# Trimmed from a real Apple Silicon build. Three other load commands here carry something
+# that looks like a version, and one of them is LC_SOURCE_VERSION holding 1230.1.
+REALISTIC = """\
+Load command 9
+      cmd LC_BUILD_VERSION
+  cmdsize 32
+ platform 1
+    minos 11.0
+      sdk 15.0
+   ntools 1
+Load command 10
+      cmd LC_SOURCE_VERSION
+  cmdsize 16
+  version 1230.1
+Load command 11
+          cmd LC_LOAD_DYLIB
+      cmdsize 56
+         name /usr/lib/libSystem.B.dylib (offset 24)
+   time stamp 2 Thu Jan  1 01:00:02 1970
+      current version 1345.120.2
+compatibility version 1.0.0
+Load command 12
+      cmd LC_UUID
+  cmdsize 24
+"""
+
+
+def test_only_the_field_belonging_to_the_right_command_counts():
+    """
+    The bug this replaced: any line matching `version <number>` was taken as a macOS
+    requirement, so LC_SOURCE_VERSION's 1230.1 was read as "needs macOS 1230.1". That failed a
+    perfectly good Apple Silicon build after it had already been compiled, and left the
+    release with only the Intel binary attached.
+    """
+    assert checker.minimum_versions(REALISTIC) == [(11, 0)]
+
+
+def test_a_dylibs_current_version_is_not_a_macos_requirement():
+    assert (1345, 120, 2) not in checker.minimum_versions(REALISTIC)
+
+
+def test_the_source_version_is_not_a_macos_requirement():
+    assert (1230, 1) not in checker.minimum_versions(REALISTIC)
+
+
 def test_a_fat_binary_reports_every_slice():
     """A universal binary carries one load command per architecture."""
     both = BUILD_VERSION + BUILD_VERSION.replace("minos 11.0", "minos 12.0")


### PR DESCRIPTION
The check added in #56 failed the Apple Silicon build, claiming it required **macOS 1230.1**. The binary was fine; the parser was not.

```
build-intel         -> success    Oldest macOS this build can run on: 10.13
build-apple-silicon -> failure    Oldest macOS this build can run on: 1230.1
```

## Cause

`otool -l` output has several load commands carrying a field that looks like a version, and the regex took any line matching `version <number>`:

```
      cmd LC_BUILD_VERSION
    minos 11.0            ← the only one that means anything here
      cmd LC_SOURCE_VERSION
  version 1230.1          ← taken as a macOS requirement
          cmd LC_LOAD_DYLIB
      current version 1345.120.2
```

Only `LC_BUILD_VERSION`'s `minos` and `LC_VERSION_MIN_MACOSX`'s `version` say anything about the OS a binary can run on. Load commands are now tracked as the output is read, and a field only counts when it belongs to the command that gives it meaning.

## The failure mode was the wrong way round

A check that wrongly *fails* blocks a good build after all the expensive work is done. That is what happened: `macos-exporter-v1.0.5` ended up with only the Intel binary attached — the inverse of the problem #56 set out to fix.

I wrote the threshold logic carefully (fail only above macOS 14, so a marginal build is reported rather than blocked) and then undermined it with a parser that could invent a number out of an unrelated field. Worth noting the tests passed: they used isolated snippets of the two commands I had in mind, so nothing exercised a file containing the others. They now run against realistic output carrying all three version-shaped fields.

## What the Intel build proved

It answers the question that started this: built on `macos-15-intel`, the binary reports a floor of **macOS 10.13** — well below the 13 and 14 its users are on. The deployment target holds, and no Homebrew dylib raised the floor.

So building Intel on macOS 15 is safe, and now there is a check that says so on every release without inventing failures.

## After merging

The release needs redoing once more so both binaries attach — delete the release and tag, recreate at `main`, as before. The Intel artifact from the current run is still worth testing on the macOS 14 VM in the meantime; it is a genuine, correctly built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)