### PR TITLE
Fix the same release-token bug in the Android release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,6 +16,12 @@ jobs:
     environment: 'Android Build Release'
     runs-on: ubuntu-latest
 
+    # The repository default is read-only, which is what turns a token that never arrives into
+    # a 403 at the very last step. Granting it here means the upload still works if the PAT is
+    # ever unset or expires - the action treats an empty token as unset and falls back to this.
+    permissions:
+      contents: write
+
     # Only run this for 'android-app-v<whatever>' tags!
     if: |
       github.event_name == 'release'
@@ -150,14 +156,20 @@ jobs:
           name: ${{ env.date_today }} - ${{ env.app_name }} - ${{ env.repository_name }} - APK(s) release generated
           path: ${{ env.main_project_module }}/build/outputs/apk/release/
 
+      # The token goes in `with:`, not `env:`. This action's `token` input defaults to
+      # ${{ github.token }}, and its own docs say "a non-empty explicit token overrides
+      # GITHUB_TOKEN" - so the default is always non-empty and an env var is ignored entirely.
+      # It then authenticates as the built-in token, whose contents permission is read-only
+      # here, and fails with 403 "Resource not accessible by integration" after the APK has
+      # already been built and signed. That is exactly how the 1.0.5 exporter release went out
+      # with no assets attached; this workflow had the same wiring and was never re-run.
       - name: Upload APK Release Asset to GitHub Release
         uses: softprops/action-gh-release@v2
         if: github.event_name == 'release'
         with:
           files: ${{ env.main_project_module }}/build/outputs/apk/release/${{ env.app_name }}-${{ steps.extract_version.outputs.APP_VERSION }}.apk
           name: ${{ env.app_name }} Android App ${{ steps.extract_version.outputs.APP_VERSION }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.ANDROID_BUILD_RELEASE_GITHUB_TOKEN }}
+          token: ${{ secrets.ANDROID_BUILD_RELEASE_GITHUB_TOKEN }}
 
       # Noted For Output [main_project_module]/build/outputs/bundle/release/
       # - name: Upload AAB (App Bundle) Release - ${{ env.repository_name }}


### PR DESCRIPTION
`build-release.yml` has the identical wiring that broke the exporter release:

```yaml
        env:
          GITHUB_TOKEN: ${{ secrets.ANDROID_BUILD_RELEASE_GITHUB_TOKEN }}
```

`softprops/action-gh-release@v2` takes its credential as the **`token` input**, which defaults to `${{ github.token }}`. Its own docs: *"a non-empty explicit token overrides GITHUB_TOKEN"* — the default is always non-empty, so an env var is ignored outright. The action then authenticates as the built-in token, which is read-only in this repository, and fails with 403 `Resource not accessible by integration`.

#54 fixed this for the macOS exporter, because that was the release being cut at the time. This workflow was never re-run, so it has been sitting on the same fault — and the next Android release would have failed at the very last step, **after** building and signing the APK.

Found while checking what stood between here and an Android release, rather than by running it.

## Fix

- token moved into `with:`
- `permissions: contents: write` on the job, so an unset or expired PAT degrades to a working upload rather than a 403

## Other workflows

`update-contributors.yml` also sets `GITHUB_TOKEN` as an environment variable, but that is the built-in token being handed to `scripts/fetch_contributors.py`, which reads it from the environment. Different thing, correct as written. No other instances.

## Still asymmetric, deliberately not fixed here

The exporter release verifies its tag against `VERSION` in the source before either binary builds (`scripts/exporter_version.py`, gated in `test-release-version`). The Android release has no equivalent, so an `android-app-v*` tag can drift from `versionName` the way the exporter's used to. Worth closing separately — this PR is only the thing that would break the next release outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)