### PR TITLE
Make Espresso waits say what they are waiting for

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,42 @@ Three consequences worth knowing:
 - `./gradlew testDebugUnitTest` is close to meaningless: there is exactly one JVM test and it
   asserts `2 + 2 == 4`. Everything real is instrumented. Do not report "tests pass" off it.
 
+### Writing an Espresso test that is not flaky
+
+**Never call `onView(...)` bare when the screen may still be settling, and never retry a click
+until it stops throwing.** Both mistakes pass on a fast machine and fail in CI, which is how
+this repo went red three runs in a row.
+
+Use `Eventually` (in `app/src/androidTest/.../Eventually.java`). It has exactly two methods,
+and picking the wrong one is the bug:
+
+| | Use for | Why |
+| --- | --- | --- |
+| `Eventually.check(() -> …)` | assertions, and waiting for a view to appear | Espresso waits for the main thread to go idle and **nothing else**; every step in this app runs on an Rx scheduler and hops back, so a check made the instant a click returns asks about work that has not started |
+| `Eventually.perform(what, tookEffect, () -> …)` | **anything that changes the screen** | see below |
+
+`perform` exists because retrying-until-no-exception cannot tell two opposite things apart:
+
+- the tap **missed** — the soft keyboard was still over the button — and must be retried
+- the tap **worked**, and what it started has already torn the screen down, so Espresso throws
+  `NoActivityResumedException` from the very same call
+
+Retrying the second turns one success into fifty failures. Only the test knows what "it
+worked" means, so it says — usually by asking a fake what it was called with:
+
+```java
+Eventually.perform("the sign in button", () -> apple.timesCalled("login") > 0,
+        () -> onView(withId(R.id.login_button_main)).perform(click()));
+```
+
+Two more rules that came out of the same failures:
+
+- **One `ViewAction` per `perform` when the action might finish the flow.**
+  `perform(replaceText(code), closeSoftKeyboard())` fails on the *second* action, because the
+  first one completed the sign-in and there is no activity left to close a keyboard on.
+- **A `GONE` view still matches `withId`.** "Not on screen" is `matches(not(isDisplayed()))`,
+  never an expected `NoMatchingViewException`.
+
 ### Showing a UI test to a person
 
 A UI test runs at machine speed — a whole sign-in is over in about three seconds and looks

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/AnisetteApkPickerFlowTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/AnisetteApkPickerFlowTest.java
@@ -118,7 +118,7 @@ public class AnisetteApkPickerFlowTest {
     public void appleChangingTheLibrariesOffersTheChoice() {
         openTheAnisetteSettings();
 
-        eventually(() -> onView(withId(R.id.anisetteOwnApkContainer)).inRoot(isDialog())
+        Eventually.check(() -> onView(withId(R.id.anisetteOwnApkContainer)).inRoot(isDialog())
                 .check(matches(isDisplayed())));
         onView(withId(R.id.anisetteChooseApkButton)).inRoot(isDialog())
                 .check(matches(isDisplayed()));
@@ -135,10 +135,10 @@ public class AnisetteApkPickerFlowTest {
         stubThePickerWith(null);
         openTheAnisetteSettings();
 
-        eventually(() -> onView(withId(R.id.anisetteChooseApkButton)).inRoot(isDialog())
+        Eventually.check(() -> onView(withId(R.id.anisetteChooseApkButton)).inRoot(isDialog())
                 .perform(click()));
 
-        eventually(() -> intended(hasAction(Intent.ACTION_OPEN_DOCUMENT)));
+        Eventually.check(() -> intended(hasAction(Intent.ACTION_OPEN_DOCUMENT)));
     }
 
     /**
@@ -153,7 +153,7 @@ public class AnisetteApkPickerFlowTest {
         stubThePickerWith(aZipPretendingToBeAppleMusic());
         openTheAnisetteSettings();
 
-        eventually(() -> onView(withId(R.id.anisetteChooseApkButton)).inRoot(isDialog())
+        Eventually.check(() -> onView(withId(R.id.anisetteChooseApkButton)).inRoot(isDialog())
                 .perform(click()));
 
         // Give the import - which reads and hashes the file - time to finish and be rejected.
@@ -178,10 +178,10 @@ public class AnisetteApkPickerFlowTest {
         stubThePickerWith(aZipPretendingToBeAppleMusic());
         openTheAnisetteSettings();
 
-        eventually(() -> onView(withId(R.id.anisetteChooseApkButton)).inRoot(isDialog())
+        Eventually.check(() -> onView(withId(R.id.anisetteChooseApkButton)).inRoot(isDialog())
                 .perform(click()));
 
-        eventually(() -> onView(withId(R.id.anisetteApkRejection)).inRoot(isDialog())
+        Eventually.check(() -> onView(withId(R.id.anisetteApkRejection)).inRoot(isDialog())
                 .check(matches(allOf(isDisplayed(),
                         withText(containsString("libc++_shared.so"))))));
     }
@@ -198,10 +198,10 @@ public class AnisetteApkPickerFlowTest {
         stubThePickerWith(aZipPretendingToBeAppleMusic());
         openTheAnisetteSettings();
 
-        eventually(() -> onView(withId(R.id.anisetteChooseApkButton)).inRoot(isDialog())
+        Eventually.check(() -> onView(withId(R.id.anisetteChooseApkButton)).inRoot(isDialog())
                 .perform(click()));
 
-        eventually(() -> onView(withId(R.id.anisetteLocalProgress)).inRoot(isDialog())
+        Eventually.check(() -> onView(withId(R.id.anisetteLocalProgress)).inRoot(isDialog())
                 .check(matches(not(isDisplayed()))));
     }
 
@@ -216,7 +216,7 @@ public class AnisetteApkPickerFlowTest {
         stubThePickerWith(null);
         openTheAnisetteSettings();
 
-        eventually(() -> onView(withId(R.id.anisetteChooseApkButton)).inRoot(isDialog())
+        Eventually.check(() -> onView(withId(R.id.anisetteChooseApkButton)).inRoot(isDialog())
                 .perform(click()));
         settle();
 
@@ -231,7 +231,7 @@ public class AnisetteApkPickerFlowTest {
         this.scenario = ActivityScenario.launch(SettingsActivity.class);
         TestPace.afterAStep();
 
-        eventually(() -> onView(withId(R.id.setting_app_anisette_server))
+        Eventually.check(() -> onView(withId(R.id.setting_app_anisette_server))
                 .perform(click()));
         TestPace.afterAStep();
     }
@@ -302,24 +302,4 @@ public class AnisetteApkPickerFlowTest {
         }
     }
 
-    /** See AppleLoginFlowTest.eventually - the same reason, and the same RuntimeException catch. */
-    private static void eventually(final Runnable assertion) {
-        Throwable last = null;
-
-        for (int attempt = 0; attempt < 50; attempt++) {
-            try {
-                assertion.run();
-                return;
-            } catch (final AssertionError | RuntimeException error) {
-                last = error;
-                getInstrumentation().waitForIdleSync();
-                SystemClock.sleep(100);
-            }
-        }
-
-        if (last instanceof RuntimeException) {
-            throw (RuntimeException) last;
-        }
-        throw (AssertionError) last;
-    }
 }

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/AppleLoginFallbackFlowTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/AppleLoginFallbackFlowTest.java
@@ -115,7 +115,7 @@ public class AppleLoginFallbackFlowTest {
     public void aDeviceThatCannotManageOnItsOwnGetsTheServerFieldBack() {
         launch();
 
-        eventually(() -> onView(withId(R.id.anisetteRemoteSection))
+        Eventually.check(() -> onView(withId(R.id.anisetteRemoteSection))
                 .perform(scrollTo()).check(matches(isDisplayed())));
         onView(withId(R.id.anisetteLoginFallbackReason)).perform(scrollTo()).check(matches(isDisplayed()));
     }
@@ -125,14 +125,14 @@ public class AppleLoginFallbackFlowTest {
     public void theyCanStillSignInThroughAServer() {
         launch();
 
-        eventually(() -> onView(withId(R.id.go_to_maininfo))
+        Eventually.check(() -> onView(withId(R.id.go_to_maininfo))
                 .perform(scrollTo()).check(matches(isDisplayed())));
-        eventually(() -> onView(withId(R.id.go_to_maininfo)).perform(scrollTo(), click()));
+        Eventually.check(() -> onView(withId(R.id.go_to_maininfo)).perform(scrollTo(), click()));
         TestPace.afterAStep();
 
         signIn();
 
-        eventually(() -> intended(hasComponent(MapsActivity.class.getName())));
+        Eventually.check(() -> intended(hasComponent(MapsActivity.class.getName())));
     }
 
     /**
@@ -144,12 +144,12 @@ public class AppleLoginFallbackFlowTest {
     public void theConfiguredServerIsWhatTheSignInActuallyUses() {
         launch();
 
-        eventually(() -> onView(withId(R.id.go_to_maininfo))
+        Eventually.check(() -> onView(withId(R.id.go_to_maininfo))
                 .perform(scrollTo()).check(matches(isDisplayed())));
-        eventually(() -> onView(withId(R.id.go_to_maininfo)).perform(scrollTo(), click()));
+        Eventually.check(() -> onView(withId(R.id.go_to_maininfo)).perform(scrollTo(), click()));
         signIn();
 
-        eventually(() -> assertNotNull(apple.serverUrlUsed()));
+        Eventually.check(() -> assertNotNull(apple.serverUrlUsed()));
         assertTrue("a real URL, not a placeholder", apple.serverUrlUsed().startsWith("http"));
         assertTrue("the server should have been checked before letting anybody past",
                 server.calls() > 0);
@@ -170,7 +170,7 @@ public class AppleLoginFallbackFlowTest {
         launch();
 
         // Straight to the account form - no welcome step, no server to choose.
-        eventually(() -> onView(withId(R.id.email_or_phone_input_field))
+        Eventually.check(() -> onView(withId(R.id.email_or_phone_input_field))
                 .perform(scrollTo()).check(matches(isDisplayed())));
 
         assertEquals("nothing should have asked a server anything", 0, server.calls());
@@ -191,10 +191,10 @@ public class AppleLoginFallbackFlowTest {
     @Test
     public void aSignInThroughAServerIsRecordedAsRemote() {
         launch();
-        eventually(() -> onView(withId(R.id.go_to_maininfo)).perform(click()));
+        Eventually.check(() -> onView(withId(R.id.go_to_maininfo)).perform(click()));
         signIn();
 
-        eventually(() -> assertEquals(UserSettings.ANISETTE_REMOTE,
+        Eventually.check(() -> assertEquals(UserSettings.ANISETTE_REMOTE,
                 storedSettings().getAnisetteMode()));
     }
 
@@ -211,7 +211,7 @@ public class AppleLoginFallbackFlowTest {
     }
 
     private void signIn() {
-        eventually(() -> onView(withId(R.id.email_or_phone_input_field))
+        Eventually.check(() -> onView(withId(R.id.email_or_phone_input_field))
                 .perform(scrollTo()).check(matches(isDisplayed())));
 
         onView(withId(R.id.email_or_phone_input_field)).perform(scrollTo(), replaceText(EMAIL));
@@ -221,31 +221,14 @@ public class AppleLoginFallbackFlowTest {
                 .perform(scrollTo(), replaceText(PASSWORD), closeSoftKeyboard());
         TestPace.afterAStep();
 
-        // Retried: closeSoftKeyboard() asks the IME to go away and does not wait for it, so a
-        // click issued immediately can land while the keyboard is still over the button.
-        eventually(() -> onView(withId(R.id.login_button_main)).perform(scrollTo(), click()));
+        // Two opposite hazards meet on this button. closeSoftKeyboard() does not wait for the
+        // IME to go, so a tap can land on the keyboard and needs retrying - but a tap that
+        // works signs the user straight in and tears this screen down, which Espresso reports
+        // from the same call. "Did Apple get asked to sign in" separates them; nothing about
+        // the exception or the view state can.
+        Eventually.perform("the sign in button", () -> apple.timesCalled("login") > 0,
+                () -> onView(withId(R.id.login_button_main)).perform(scrollTo(), click()));
         TestPace.afterAStep();
-    }
-
-    /** See {@code AppleLoginFlowTest.eventually} - the same reason applies here. */
-    private static void eventually(final Runnable assertion) {
-        Throwable last = null;
-
-        for (int attempt = 0; attempt < 50; attempt++) {
-            try {
-                assertion.run();
-                return;
-            } catch (final AssertionError | RuntimeException error) {
-                last = error;
-                getInstrumentation().waitForIdleSync();
-                SystemClock.sleep(100);
-            }
-        }
-
-        if (last instanceof RuntimeException) {
-            throw (RuntimeException) last;
-        }
-        throw (AssertionError) last;
     }
 
 

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/AppleLoginFlowTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/AppleLoginFlowTest.java
@@ -160,16 +160,16 @@ public class AppleLoginFlowTest {
         signIn();
 
         // Apple asked for a second factor, so the choice of how to receive it comes next.
-        eventually(() -> onView(withText(R.string.two_factor_authentication))
+        Eventually.check(() -> onView(withText(R.string.two_factor_authentication))
                 .check(matches(isDisplayed())));
         chooseTheTextTo(FakeAppleAuthService.PHONE_TWO);
 
-        eventually(() -> onView(withId(R.id.twofa_sent_info_text)).check(matches(isDisplayed())));
+        Eventually.check(() -> onView(withId(R.id.twofa_sent_info_text)).check(matches(isDisplayed())));
         pasteTheCode(CODE);
 
-        eventually(() -> assertEquals("the code has to reach Apple exactly as typed",
+        Eventually.check(() -> assertEquals("the code has to reach Apple exactly as typed",
                 CODE, apple.submittedCode()));
-        eventually(() -> intended(hasComponent(MapsActivity.class.getName())));
+        Eventually.check(() -> intended(hasComponent(MapsActivity.class.getName())));
     }
 
     /**
@@ -188,7 +188,7 @@ public class AppleLoginFlowTest {
 
         pasteTheCode(CODE);
 
-        eventually(() -> assertEquals(CODE, apple.submittedCode()));
+        Eventually.check(() -> assertEquals(CODE, apple.submittedCode()));
         assertEquals("submitted once, not once per box", 1, apple.timesCalled("submitCode"));
     }
 
@@ -201,7 +201,7 @@ public class AppleLoginFlowTest {
 
         pasteTheCode(CODE);
 
-        eventually(() -> assertNotNull(apple.codeSubmittedAgainst()));
+        Eventually.check(() -> assertNotNull(apple.codeSubmittedAgainst()));
         assertEquals("the code belongs to the number Apple texted",
                 FakeAppleAuthService.PHONE_TWO,
                 ((AuthMethodPhone) apple.codeSubmittedAgainst()).getPhoneNumber());
@@ -225,7 +225,7 @@ public class AppleLoginFlowTest {
         launch();
         signIn();
 
-        eventually(() -> assertEquals("the mode has to be written down once there is a session",
+        Eventually.check(() -> assertEquals("the mode has to be written down once there is a session",
                 UserSettings.ANISETTE_LOCAL, storedSettings().getAnisetteMode()));
         assertFalse("nobody should be offered an upgrade to what they just signed in with",
                 storedSettings().shouldOfferLocalAnisette(true));
@@ -240,7 +240,7 @@ public class AppleLoginFlowTest {
         launch();
         signIn();
 
-        eventually(() -> intended(hasComponent(MapsActivity.class.getName())));
+        Eventually.check(() -> intended(hasComponent(MapsActivity.class.getName())));
         assertEquals("nothing should have asked for a code",
                 0, apple.timesCalled("requestCode"));
     }
@@ -259,7 +259,7 @@ public class AppleLoginFlowTest {
         launch();
         signIn();
 
-        eventually(() -> onView(withId(R.id.login_error_container)).check(matches(isDisplayed())));
+        Eventually.check(() -> onView(withId(R.id.login_error_container)).check(matches(isDisplayed())));
         onView(withId(R.id.login_maininfo_container)).check(matches(isDisplayed()));
         onView(withId(R.id.login_button_main)).check(matches(isDisplayed()));
     }
@@ -275,7 +275,7 @@ public class AppleLoginFlowTest {
         chooseTheTextTo(FakeAppleAuthService.PHONE_ONE);
         pasteTheCode("000000");
 
-        eventually(() -> onView(withId(R.id.verification_code_error_msg_container))
+        Eventually.check(() -> onView(withId(R.id.verification_code_error_msg_container))
                 .check(matches(isDisplayed())));
         onView(withId(R.id.login_2fa_container)).check(matches(isDisplayed()));
     }
@@ -294,7 +294,7 @@ public class AppleLoginFlowTest {
         launch();
         signIn();
 
-        eventually(() -> onView(withId(R.id.twofactorauth_choice_trusted_device))
+        Eventually.check(() -> onView(withId(R.id.twofactorauth_choice_trusted_device))
                 .check(matches(isDisplayed())));
     }
 
@@ -313,7 +313,7 @@ public class AppleLoginFlowTest {
         launch();
         signIn();
 
-        eventually(() -> assertSame("local Anisette has to reach the sign-in",
+        Eventually.check(() -> assertSame("local Anisette has to reach the sign-in",
                 fakeAnisette, apple.anisetteUsed()));
         assertNotNull("Python needs a fallback URL even when it is not used",
                 apple.serverUrlUsed());
@@ -332,32 +332,6 @@ public class AppleLoginFlowTest {
         TestPace.afterAStep();
     }
 
-    /**
-     * Retry an assertion until it holds, or give up.
-     *
-     * <p>Espresso waits for the main thread to go idle, and for nothing else. Every step of
-     * signing in runs on an RxJava scheduler and hops back, so an assertion made the instant
-     * a click returns is asking about work that has not started yet. This is a real property
-     * of the screen rather than a test defect - the alternative, an IdlingResource, would mean
-     * threading test-only bookkeeping through production Rx chains.
-     */
-    private static void eventually(final Runnable assertion) {
-        AssertionError last = null;
-
-        for (int attempt = 0; attempt < 50; attempt++) {
-            try {
-                assertion.run();
-                return;
-            } catch (final AssertionError error) {
-                last = error;
-                getInstrumentation().waitForIdleSync();
-                SystemClock.sleep(100);
-            }
-        }
-
-        throw last;
-    }
-
     private void signIn() {
         onView(withId(R.id.email_or_phone_input_field)).perform(replaceText(EMAIL));
         TestPace.afterAStep();
@@ -366,16 +340,16 @@ public class AppleLoginFlowTest {
                 .perform(replaceText(PASSWORD), closeSoftKeyboard());
         TestPace.afterAStep();
 
-        // Retried: closeSoftKeyboard() asks the IME to go away and does not wait for it, so a
-        // click issued straight after can land while the keyboard is still over the button.
-        // Fast machines hide it in time and slow ones do not, which is why this passed locally
-        // and failed in CI.
-        eventually(() -> onView(withId(R.id.login_button_main)).perform(click()));
+        // Retried until Apple was actually asked, not until nothing throws. The keyboard may
+        // still be over the button (retry), or the tap may have worked and already finished a
+        // sign-in that tears this screen down (stop). See Eventually.perform.
+        Eventually.perform("the sign in button", () -> apple.timesCalled("login") > 0,
+                () -> onView(withId(R.id.login_button_main)).perform(click()));
         TestPace.afterAStep();
     }
 
     private void chooseTheTextTo(final String phoneNumber) {
-        eventually(() -> onView(withText(
+        Eventually.check(() -> onView(withText(
                 getInstrumentation().getTargetContext()
                         .getString(R.string.auth_by_sms_to_x, phoneNumber)))
                 .perform(click()));

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/Eventually.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/Eventually.java
@@ -1,0 +1,114 @@
+package dev.wander.android.opentagviewer;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
+import android.os.SystemClock;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * Waiting for a screen that Espresso cannot wait for by itself.
+ *
+ * <p>Espresso waits for the main thread to go idle and for nothing else. Every interesting step
+ * in this app runs on an RxJava scheduler and hops back, so an assertion made the instant a
+ * click returns is asking about work that has not started. That is a property of the app, not
+ * a defect in the test - the alternative, an IdlingResource, would mean threading test-only
+ * bookkeeping through production Rx chains.
+ *
+ * <p><b>Why this is one class rather than a helper in each test.</b> It used to be copied into
+ * three of them. When a flake was found and fixed in one copy, the identical code in the others
+ * kept failing in CI, which is how this went red three times running.
+ */
+public final class Eventually {
+
+    private Eventually() {}
+
+    private static final int ATTEMPTS = 50;
+    private static final long PAUSE_MS = 100;
+
+    /**
+     * Retry an assertion until it holds.
+     *
+     * <p>Catches {@code RuntimeException} as well as {@code AssertionError}, because Espresso
+     * reports "the view is not there yet" as {@code PerformException} and
+     * {@code NoMatchingViewException}, neither of which is an assertion failure.
+     */
+    public static void check(final Runnable assertion) {
+        Throwable last = null;
+
+        for (int attempt = 0; attempt < ATTEMPTS; attempt++) {
+            try {
+                assertion.run();
+                return;
+            } catch (final AssertionError | RuntimeException problem) {
+                last = problem;
+                settle();
+            }
+        }
+
+        rethrow(last);
+    }
+
+    /**
+     * Do something until it has actually taken effect, then stop.
+     *
+     * <p><b>Use this rather than {@link #check} for anything that changes the screen.</b>
+     * Retrying until nothing throws cannot tell two opposite situations apart:
+     *
+     * <ul>
+     *   <li>the tap missed - the keyboard was still over the button, say - and must be retried
+     *   <li>the tap worked, and what it started has already finished and torn the screen down,
+     *       so Espresso throws {@code NoActivityResumedException} from the very same call
+     * </ul>
+     *
+     * <p>Retrying the second turns one success into fifty failures. Only the caller knows what
+     * "it worked" means, so the caller says.
+     *
+     * @param what       named in the failure, so a timeout says which step never landed
+     * @param tookEffect asked before and after each attempt. Anything observable will do - a
+     *                   fake having been called, a value having been stored
+     */
+    public static void perform(final String what, final BooleanSupplier tookEffect,
+                               final Runnable action) {
+        Throwable last = null;
+
+        for (int attempt = 0; attempt < ATTEMPTS; attempt++) {
+            if (tookEffect.getAsBoolean()) {
+                return;
+            }
+
+            try {
+                action.run();
+            } catch (final AssertionError | RuntimeException problem) {
+                last = problem;
+            }
+
+            // Checked again straight away: the action may have both worked and thrown, which
+            // is the whole reason this method exists.
+            if (tookEffect.getAsBoolean()) {
+                return;
+            }
+            settle();
+        }
+
+        if (last != null) {
+            rethrow(last);
+        }
+        throw new AssertionError(what + " never took effect");
+    }
+
+    private static void settle() {
+        getInstrumentation().waitForIdleSync();
+        SystemClock.sleep(PAUSE_MS);
+    }
+
+    private static void rethrow(final Throwable last) {
+        if (last instanceof RuntimeException) {
+            throw (RuntimeException) last;
+        }
+        if (last instanceof AssertionError) {
+            throw (AssertionError) last;
+        }
+        throw new AssertionError("gave up waiting", last);
+    }
+}


### PR DESCRIPTION
Fixes the instrumented job failing on `main` after #62.

Three CI failures in a row, all the same shape, none of them product bugs.

## What was wrong

**The waiting helper was copied into three test classes.** A flake was found and
fixed in one; the identical code in the others kept failing. That is literally
what happened — the keyboard-over-the-button fix went into one login test, and
CI then failed on its sibling.

**The retry was also wrong in a way copying could only spread.** Retrying until
nothing throws cannot tell two opposite situations apart:

- the tap **missed** — the soft keyboard was still over the button — and must be
  retried
- the tap **worked**, and what it started has already torn the screen down, so
  Espresso throws `NoActivityResumedException` from the very same call

Retrying the second turns one success into fifty failures. That is what broke
the post-merge run: `theConfiguredServerIsWhatTheSignInActuallyUses` signs in
immediately, so the click that worked also ended the activity.

## The fix

One `Eventually` class, two methods, and picking the wrong one is the bug:

- `Eventually.check(...)` — assertions and waiting for views. Espresso waits for
  the main thread and nothing else, while every step here runs on an Rx
  scheduler.
- `Eventually.perform(what, tookEffect, action)` — anything that changes the
  screen. The caller states what "it worked" means, usually a fake having been
  called, and it stops the moment that holds regardless of what was thrown.

```java
Eventually.perform("the sign in button", () -> apple.timesCalled("login") > 0,
        () -> onView(withId(R.id.login_button_main)).perform(click()));
```

Documented in AGENTS.md, along with two rules from the same failures: one
`ViewAction` per `perform` when the action may finish the flow, and a `GONE`
view still matches `withId`.

## Verification

Two consecutive full runs on the managed device, 106 tests, no failures. Since
the whole point is that this used to pass locally and fail in CI, the run on
this PR is the one that counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
