### PR TITLE
Say exporter-v where the release files still said macos-exporter-v

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -402,7 +402,11 @@ python scripts/add_strings.py --check         # fail if any locale is missing on
 
 ## Running the export wizard on a Mac
 
-Testing an export means a real Mac signed into iCloud, usually a VM. A fresh macOS install
+**This covers the macOS-local route only.** Exporting through iCloud needs no Mac and no VM —
+see [Running the exporter from the CLI](./docs/how-to-export-with-the-cli.md). What follows is
+for testing the path that reads Find My's own files, which still runs on macOS and nowhere else.
+
+Testing that export means a real Mac signed into iCloud, usually a VM. A fresh macOS install
 has **neither git nor python3** — both arrive with the Xcode Command Line Tools — so
 `scripts/bootstrap_macos.sh` does the lot: installs the tools, clones, creates a virtualenv,
 installs the dependencies and launches the wizard. It is safe to re-run.

--- a/python/exporter/version.py
+++ b/python/exporter/version.py
@@ -4,8 +4,9 @@ The exporter's version, and the strings that carry it into an export.
 **This is the single source of truth** - see rule 9 in AGENTS.md. It reaches the wizard's window
 title and, more importantly, every export as `via: <producer>:<version>`, which is how anyone
 looking at a zip afterwards works out what built it. Releases are tagged
-`macos-exporter-v<this>`, and `scripts/release_version.py` refuses to publish a release whose tag
-disagrees.
+`exporter-v<this>` - `macos-exporter-v` is the older spelling and still resolves, because tags
+already published keep their name - and `scripts/release_version.py` refuses to publish a release
+whose tag disagrees.
 
 **It lives here rather than in wizard.py so that reading it costs nothing.** The CLI is headless
 and the release check runs on a lint runner; importing the wizard for a version string would pull

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -39,8 +39,12 @@ Print the version the source declares:
 
 Check a release tag against it. Accepts a bare tag or a full ref, so `$GITHUB_REF` works:
 
-    python scripts/release_version.py --kind exporter --tag macos-exporter-v1.0.5
+    python scripts/release_version.py --kind exporter --tag exporter-v1.1.0
     python scripts/release_version.py --kind android --tag refs/tags/android-app-v1.0.5
+
+The exporter also answers to `macos-exporter-v`, which is what its tags were called while it
+only ran on macOS. Published tags keep their names, so that spelling has to keep resolving -
+but it is not the one to reach for when tagging something new.
 
 On success it prints the version, so a workflow can use it directly:
 


### PR DESCRIPTION
Rule 9 and `release_version.py` both make `exporter-v` the tag to use; `macos-exporter-v` still resolves for tags already published. Two files named the old spelling as the current one:

- `python/exporter/version.py` — docstring
- `scripts/release_version.py` — the usage example someone copies

Also scoped CONTRIBUTING's "Running the export wizard on a Mac", which opened by saying testing an export means a real Mac. True of that route, not of exporting.

Every `startsWith` / `also_accepts` matching the old prefix is untouched, as are the tests covering it.

Checked: `exporter-v1.1.0` and `macos-exporter-v1.1.0` both resolve to `1.1.0`; `scripts/test/` passes (100).

---

*Summary written by Claude Code.*