### PR TITLE
Log the account's login state when it is stored, not only when read

### DIFF
--- a/app/src/main/python/main.py
+++ b/app/src/main/python/main.py
@@ -275,7 +275,16 @@ def exportToString(account: AppleAccount) -> str:
     Replaces the old account.export() pattern. In FindMy 0.9.x, AppleAccount uses to_json/from_json.
     The returned dict (AccountStateMapping) embeds the anisette provider state, so the
     server URL no longer needs to be supplied at restore time.
+
+    The login state is logged on the way out. A stored account that is not LOGGED_IN fails
+    every later fetch inside FindMy.py's own state check, before any request reaches Apple -
+    see issue #43, where an account was somehow persisted as REQUIRE_2FA and stayed that way
+    across a reinstall. Logging it here and at restore is what tells a bad *write* apart from
+    a bad *read*, and it is the only evidence anyone can produce: the stored account holds the
+    Apple ID password and is encrypted under a key that never leaves the device, so a user
+    cannot hand it over and should not be asked to. A state name is not sensitive.
     """
+    print(f"Storing account, login state: {account.login_state}")
     return json.dumps(account.to_json())
 
 
@@ -394,7 +403,15 @@ def getAccount(
         acc = AppleAccount.from_json(data)
         _preferLocalAnisette(acc, localAnisette)
 
-        print(f"Login State: {acc.login_state}")
+        print(f"Restored account, login state: {acc.login_state}")
+        if acc.login_state != LoginState.LOGGED_IN:
+            # Worth saying plainly rather than leaving to the traceback that follows minutes
+            # later from somewhere else entirely. This is the state that makes every fetch
+            # raise InvalidStateError with nothing sent.
+            print(
+                "Restored account is NOT logged in - every report fetch will fail its state "
+                "check before any request is made. See issue #43."
+            )
 
         return acc
     except Exception:


### PR DESCRIPTION
[#43](https://github.com/parawanderer/OpenTagViewer/issues/43) is an account persisted as `REQUIRE_2FA`. Every later fetch fails FindMy.py's `_require_login_state` check **before any request is made**, which is what makes it unlike the Anisette-shaped reports — nothing is attempted against Apple. Wiping app data and signing in again reproduced it, so it is deterministic rather than a flake.

`getAccount` already logged the state on restore. `exportToString` did not, so there was no way to tell a bad *write* from a bad *read*.

- store side: `Storing account, login state: ...`
- restore side: relabelled, plus an explicit line when it is not `LOGGED_IN`

This is the only evidence an affected user can produce — the stored account holds their Apple ID password and is encrypted under a non-exportable `AndroidKeyStore` key, so they cannot share it and should not be asked to. A state name is neither secret nor identifying, and it lands in the existing log-dump feature.

Not compiled or run on a device — this machine has no Android toolchain. Verified: flake8 clean, pyright clean apart from the pre-existing `NSKeyedUnArchiver` import, and the 52 Chaquopy bridge tests pass.

---

*Summary written by Claude Code.*