### PR TITLE
Keep Intel Macs off a source build of cryptography

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,6 +41,23 @@ dependencies = [
 # this directory, so there is nothing to build and no version to declare.
 package = false
 
+# Intel Macs must not build cryptography from source, and 49.0.0 is where they started having to.
+#
+# cryptography publishes macOS wheels for arm64 only from 49 onward; 48.0.0 is the last with a
+# universal2 wheel, and that one targets macOS 10.9. Without a wheel, the Intel release build
+# compiles it against whatever OpenSSL the runner has - Homebrew's, preinstalled on GitHub's
+# macOS images - and PyInstaller then bundles Homebrew's libcrypto.3.dylib. A bottle's minimum
+# macOS is baked in when Homebrew builds it, so the resulting binary demanded macOS 15 and
+# scripts/check_macos_min_version.py refused it. Which was correct: the macOS-local export route
+# needs macOS 14 or earlier, so a 15-only binary is useless to exactly the people who need an
+# Intel build.
+#
+# Scoped by marker so only Intel macOS is held back - every other platform keeps the current
+# release. Remove it if cryptography ever ships an x86_64 macOS wheel again.
+constraint-dependencies = [
+    "cryptography<49 ; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+]
+
 [tool.uv.sources]
 FindMy = { git = "https://github.com/parawanderer/FindMy.py", branch = "feat/icloud-keychain-export" }
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1,6 +1,13 @@
 version = 1
 revision = 3
 requires-python = ">=3.10"
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "platform_machine != 'x86_64' or sys_platform != 'darwin'",
+]
+
+[manifest]
+constraints = [{ name = "cryptography", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = "<49" }]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -516,8 +523,29 @@ toml = [
 
 [[package]]
 name = "cryptography"
+version = "48.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bc/ee4137cbbe105652c0ee4252792b78fc8e7afa4b8e61d9d5dc05a7f45731/cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1", size = 8008324, upload-time = "2026-06-09T22:31:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/3e768b4c3bc78201583fa35a0e18f640dd782ff41afba88f8545481a8874/cryptography-48.0.1-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:f817adc181390bd54f2f700107a7419040fb7c1bdf2fc26f36551a06a68c3345", size = 7989830, upload-time = "2026-06-09T22:31:07.8Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6c/00fa2a95997164c8b2072ce327c23d4ab20809ccc323ea5fab91e53a4bba/cryptography-48.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67", size = 7987408, upload-time = "2026-06-09T22:32:20.777Z" },
+]
+
+[[package]]
+name = "cryptography"
 version = "50.0.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine != 'x86_64' or sys_platform != 'darwin'",
+]
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
@@ -637,7 +665,8 @@ dependencies = [
     { name = "anisette" },
     { name = "beautifulsoup4" },
     { name = "bleak" },
-    { name = "cryptography" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "cryptography", version = "50.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "protobuf" },
     { name = "srp" },
     { name = "typing-extensions" },


### PR DESCRIPTION
Follow-up to #78. That removed Homebrew's Python — file count in the bundle dropped from 352 to 239 — but the Intel build still demanded macOS 15, still set by `libcrypto.3.dylib`.

### Cause

**`cryptography` publishes macOS wheels for arm64 only from 49.0.0 onward.** 48.0.0 is the last release with a `universal2` wheel, and that one targets macOS 10.9.

So on Intel there was nothing to install and uv built it from source — 94 seconds of it in the log — linking against the runner's OpenSSL, which is Homebrew's and preinstalled on GitHub's macOS images. PyInstaller bundled that dylib, and its minimum macOS is baked in at Homebrew's build time.

arm64 never hit this: it has a wheel, its bundle contains no `libcrypto` at all, and its minimum is 12.0 set by protobuf.

### Fix

A marker-scoped constraint, so only Intel macOS is held back and every other platform keeps the current release:

```toml
constraint-dependencies = [
    "cryptography<49 ; sys_platform == 'darwin' and platform_machine == 'x86_64'",
]
```

The lock now carries **48.0.1** with `macosx_10_9_universal2` wheels and **50.0.0** with the arm64 ones.

### Verified

Lock resolves, `uv sync --frozen` installs, 384 tests pass. **This machine is arm64**, so it takes the 50.0.0 branch — the Intel path can only be proved by CI. Run the workflow manually with `exporter-v1.1.0` after merging.

---

*Summary written by Claude Code.*