### PR TITLE
Take Homebrew's OpenSSL off the table, and say who linked what

### DIFF
--- a/.github/workflows/macos-exporter-python.yml
+++ b/.github/workflows/macos-exporter-python.yml
@@ -195,6 +195,23 @@ jobs:
 
     # --no-default-groups drops the dev group: pytest and the linters have no business in a
     # bundle handed to a user. `build` carries PyInstaller, pinned like everything else.
+    # GitHub's macOS images ship Homebrew OpenSSL whatever we install, and PyInstaller resolves
+    # `ctypes` library lookups against the *build machine's* libraries - so something probing for
+    # OpenSSL by name gets Homebrew's libcrypto.3.dylib bundled with it. A bottle's minimum macOS
+    # is fixed when Homebrew builds it, so on macos-15-intel that made the binary demand macOS 15
+    # and the deployment-target check refused it, correctly: the macOS-local route needs 14 or
+    # earlier, so a 15-only build is useless to the people who need an Intel one.
+    #
+    # Unlinking rather than uninstalling: nothing else in the job wants it, and the same probe
+    # already fails harmlessly for `libssl.so.1.1.0` and `libssl.32.dylib` in every build that has
+    # ever succeeded - so not finding one more name is the normal case, not a new risk.
+    #
+    # The arm64 job was never green for a good reason either: its runner is macos-14, so the copy
+    # it collected happened to be built for 14 and slipped under the threshold.
+    - name: Keep Homebrew's OpenSSL out of the bundle (macOS)
+      if: matrix.os == 'macos'
+      run: brew unlink openssl@3 || true
+
     - name: Install dependencies
       working-directory: ./python
       run: uv sync --frozen --no-default-groups --group build

--- a/scripts/check_macos_min_version.py
+++ b/scripts/check_macos_min_version.py
@@ -122,6 +122,36 @@ def scan(target: Path) -> dict[Path, tuple[int, ...]]:
     return requirements
 
 
+def referrers(target: Path, wanted: Path) -> list[Path]:
+    """Every Mach-O file under `target` that links `wanted`.
+
+    The point is to tell a dependency from an orphan. PyInstaller resolves `ctypes` lookups
+    against the *build machine's* libraries, so a bundle can contain something no binary in it
+    actually links - dragged in by a name some package probed for. Removing one of those is
+    safe; removing a real dependency produces a binary that dies at launch.
+
+    Matched on the file name rather than the full path, because an install name is rewritten to
+    `@rpath/...` or `@loader_path/...` by the time it is bundled.
+    """
+    name = wanted.name
+    files = [target] if target.is_file() else sorted(p for p in target.rglob("*") if p.is_file())
+
+    found: list[Path] = []
+    for path in files:
+        # By name, not by path: a Mach-O library lists its own install name in `otool -L`, so
+        # comparing paths lets a second copy of the same library report itself as a referrer.
+        if path.name == name:
+            continue
+        result = subprocess.run(["otool", "-L", str(path)], capture_output=True, text=True,
+                                check=False, encoding="utf-8", errors="replace")
+        if result.returncode != 0:
+            continue
+        if any(name in line for line in result.stdout.splitlines()[1:]):
+            found.append(path)
+
+    return found
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
     parser.add_argument("target", type=Path, help="a built binary, or a directory to walk")
@@ -157,10 +187,26 @@ def main(argv: list[str] | None = None) -> int:
             f"\n"
             f"The usual cause is a dependency built on the runner's own macOS - Homebrew "
             f"bottles in particular are built for the builder's OS and are not backward "
-            f"compatible.\n"
-            f"Check what {path.name} pulled in, and that MACOSX_DEPLOYMENT_TARGET is set for "
-            f"the build.",
+            f"compatible, and MACOSX_DEPLOYMENT_TARGET cannot lower one because nothing is "
+            f"being compiled.",
             file=sys.stderr)
+
+        linked_by = referrers(args.target, path)
+        if linked_by:
+            print(f"\n{path.name} is linked by {len(linked_by)} file(s):", file=sys.stderr)
+            for who in linked_by[:10]:
+                print(f"  {who}", file=sys.stderr)
+            if len(linked_by) > 10:
+                print(f"  ... and {len(linked_by) - 10} more", file=sys.stderr)
+            print("So it is a real dependency: fix where it comes from rather than deleting it.",
+                  file=sys.stderr)
+        else:
+            print(f"\nNothing in the bundle links {path.name}. PyInstaller resolves ctypes "
+                  f"lookups against the build machine's own libraries, so this was most likely "
+                  f"dragged in by a name some package probed for - see the 'required via "
+                  f"ctypes' warnings in the PyInstaller output. Stopping it being found at "
+                  f"build time is the fix.", file=sys.stderr)
+
         return 1
 
     return 0


### PR DESCRIPTION
Third attempt at the Intel build, and the first based on measurement rather than inference.

### Where `libcrypto.3.dylib` actually comes from

Not the packages: the entire Intel wheel set ships **one** dylib, `libunicorn`, which links only `libSystem`. Not the interpreter: the x86_64 managed CPython contains no OpenSSL and nothing in it links any. Both checked directly.

It comes from the **build machine**. PyInstaller resolves `ctypes` library lookups against the runner's own libraries, and GitHub's macOS images ship Homebrew OpenSSL regardless of what the workflow installs. The PyInstaller log shows the probe:

```
WARNING: Library libssl.so.1.1.0 required via ctypes not found
WARNING: Library libssl.32.dylib required via ctypes not found
```

Those two names miss. One evidently hits.

This also explains why arm64 was never really green: its runner is `macos-14`, so the copy it collects is built for 14 and slips under the threshold silently.

### Fixes

**`brew unlink openssl@3` before the build.** The probe then fails the way it already fails for the two names above — in every build that has ever succeeded — so not finding one more is the normal case rather than a new risk.

**The check now names the referrers.** It reports which files link the offending library, or states that none do:

- linked → a real dependency, fix where it comes from
- nothing links it → an orphan the ctypes scan dragged in, and stopping it being found is the fix

`Check what it pulled in` was advice nobody could act on. Both branches verified against a real Python distribution: `libtcl9.0.dylib` correctly reports `_tkinter...so` as its referrer, `libitcl4.3.8.dylib` correctly reports none. A self-reference bug found while testing — a library lists its own install name in `otool -L` — is fixed.

100 tooling tests pass. **If this misses again, the failure output will say why** rather than needing another round of guessing.

---

*Summary written by Claude Code.*