### PR TITLE
Keep the one location a newly imported tag actually has

### DIFF
--- a/app/src/main/python/main.py
+++ b/app/src/main/python/main.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any
+from typing import Any, NamedTuple
 import json
 import time
 import traceback
@@ -506,6 +506,19 @@ def _isAlignmentWide(accessory: FindMyAccessory, start, end) -> int:
         return 0
 
 
+class AccessoryFetch(NamedTuple):
+    """
+    What came back for one accessory, and whether the requested window was honoured.
+
+    `bounded_to_window` is False when the probe path ran. The probe walks backwards from now
+    until it finds anything at all, so what it returns is "the most recent location that still
+    exists" rather than "the locations inside the last N hours" - and the caller must not then
+    filter it to that window. See `_fetchReportsForAccessory`.
+    """
+    reports: list
+    bounded_to_window: bool
+
+
 def _fetchReportsForAccessory(account: AppleAccount, accessory: FindMyAccessory, start, end):
     """
     Fetch reports for one accessory, avoiding a full-history key search when possible.
@@ -524,6 +537,10 @@ def _fetchReportsForAccessory(account: AppleAccount, accessory: FindMyAccessory,
     the probe traverses the whole range, finds nothing, narrows nothing, and then the history
     fetch traverses it all over again - double the work, in the worst case rather than the
     best. Replacing the call avoids that.
+
+    Returns an `AccessoryFetch`, because the two paths mean different things: the history path
+    honours the requested window, the probe path does not and its result must survive the
+    caller's time filter.
     """
     width = _isAlignmentWide(accessory, start, end)
 
@@ -542,9 +559,9 @@ def _fetchReportsForAccessory(account: AppleAccount, accessory: FindMyAccessory,
             print("No reports found for this accessory; leaving alignment untouched and "
                   "skipping the history fetch.")
 
-        return [latest] if latest is not None else []
+        return AccessoryFetch([latest] if latest is not None else [], bounded_to_window=False)
 
-    return account.fetch_location_history(accessory)
+    return AccessoryFetch(account.fetch_location_history(accessory), bounded_to_window=True)
 
 
 def _chunk(items, size):
@@ -807,7 +824,8 @@ def getLastReports(
             # which meant no beacon's updated alignment was persisted - so every later
             # fetch started from the same wide range again and never converged.
             try:
-                reports = _fetchReportsForAccessory(account, airtag, start_dt, now_dt) or []
+                fetched = _fetchReportsForAccessory(account, airtag, start_dt, now_dt)
+                reports = fetched.reports or []
             except Exception:
                 failures += 1
                 print(f"Fetch failed for {beaconId}, continuing with the rest: "
@@ -816,8 +834,17 @@ def getLastReports(
 
             print(f"Got {len(reports)} raw reports for {beaconId}")
 
-            filtered = _filterReportsByTimeRange(reports, start_ms, now_ms)
-            print(f"  -> {len(filtered)} reports after filtering to last {hoursBack}h")
+            if fetched.bounded_to_window:
+                filtered = _filterReportsByTimeRange(reports, start_ms, now_ms)
+                print(f"  -> {len(filtered)} reports after filtering to last {hoursBack}h")
+            else:
+                # The probe ignored the window on purpose - it walks back until it finds
+                # anything - so filtering to it here would throw away the only location we
+                # have. A tag that has sat in a drawer for two days would come back from an
+                # import showing nothing, despite the fetch having just found it.
+                filtered = reports
+                print(f"  -> keeping {len(filtered)} latest-known report(s) without applying "
+                      f"the {hoursBack}h window; alignment was not yet established")
 
             res[beaconId] = {
                 "reports": _serializeReports(filtered),

--- a/app/src/test/python/test_main.py
+++ b/app/src/test/python/test_main.py
@@ -214,7 +214,8 @@ def test_wide_window_fetches_latest_instead_of_history():
 
     assert account.fetch_location_calls == 1
     assert account.fetch_history_calls == 0, "must not also search the whole history"
-    assert out == [report]
+    assert out.reports == [report]
+    assert not out.bounded_to_window, "the probe ignores the window, and says so"
 
 
 def test_narrow_window_uses_the_normal_history_fetch():
@@ -228,7 +229,8 @@ def test_narrow_window_uses_the_normal_history_fetch():
 
     assert account.fetch_history_calls == 1
     assert account.fetch_location_calls == 0
-    assert out == history
+    assert out.reports == history
+    assert out.bounded_to_window, "a history fetch honours the requested window"
 
 
 def test_wide_window_with_no_reports_does_not_then_search_the_history():
@@ -245,7 +247,85 @@ def test_wide_window_with_no_reports_does_not_then_search_the_history():
 
     assert account.fetch_location_calls == 1
     assert account.fetch_history_calls == 0, "must not traverse the same empty range twice"
-    assert out == []
+    assert out.reports == []
+
+
+class _FakeAirtag:
+    """Only what getLastReports touches after the fetch."""
+
+    def to_json(self):
+        return {"aligned": True}
+
+
+class _FakeRequest:
+    def __init__(self, beacon_id):
+        self._id = beacon_id
+
+    def getBeaconId(self):
+        return self._id
+
+    def getAccessoryJson(self):
+        return "{}"
+
+
+class _FakeRequestList:
+    """Stands in for the Java List<AccessoryRequest> the bridge is handed."""
+
+    def __init__(self, requests):
+        self._requests = requests
+
+    def size(self):
+        return len(self._requests)
+
+    def get(self, i):
+        return self._requests[i]
+
+
+def _runGetLastReports(monkeypatch, fetch_result, hours_back=24):
+    monkeypatch.setattr(
+        main.FindMyAccessory, "from_json", staticmethod(lambda _json: _FakeAirtag()))
+    monkeypatch.setattr(
+        main, "_fetchReportsForAccessory", lambda *args, **kwargs: fetch_result)
+
+    return main.getLastReports(
+        account=object(),
+        idToAccessoryData=_FakeRequestList([_FakeRequest("beacon-1")]),
+        hoursBack=hours_back)
+
+
+def test_a_newly_imported_tag_keeps_a_location_older_than_the_window(monkeypatch):
+    """
+    The bug this fixes. A tag with no alignment record never honours the requested window -
+    the probe walks backwards until it finds anything at all - so filtering its result to the
+    last 24 hours threw away the only location the app had just successfully found.
+
+    A tag that had sat in a drawer for two days came back from an import reading "no last
+    location known", despite the fetch having located it.
+    """
+    now = datetime.now(tz=timezone.utc)
+    two_days_old = FakeReport(now - timedelta(days=2))
+
+    out = _runGetLastReports(
+        monkeypatch, main.AccessoryFetch([two_days_old], bounded_to_window=False))
+
+    assert len(out["beacon-1"]["reports"]) == 1, \
+        "the latest known location must survive, however old it is"
+
+
+def test_an_aligned_tag_still_has_its_history_bounded_to_the_window(monkeypatch):
+    """
+    The other half: once alignment is known the fetch returns everything Apple holds, and the
+    window is what makes "the last 24 hours" true. Keeping everything here would quietly widen
+    every refresh.
+    """
+    now = datetime.now(tz=timezone.utc)
+    recent = FakeReport(now - timedelta(hours=1))
+    too_old = FakeReport(now - timedelta(days=2))
+
+    out = _runGetLastReports(
+        monkeypatch, main.AccessoryFetch([recent, too_old], bounded_to_window=True))
+
+    assert len(out["beacon-1"]["reports"]) == 1, "the two-day-old report should be dropped"
 
 
 def test_unknown_width_falls_back_to_the_history_fetch():
@@ -264,7 +344,7 @@ def test_unknown_width_falls_back_to_the_history_fetch():
     out = main._fetchReportsForAccessory(account, BrokenAccessory(), now - timedelta(hours=24), now)
 
     assert account.fetch_history_calls == 1
-    assert out == history
+    assert out.reports == history
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
A tag with no key alignment record never honours the requested time window, and the code then
filtered its result to that window anyway. The location it had just found was thrown away.

## Why the window is not honoured in the first place

Without an alignment record a `FindMyAccessory` starts at index 0 from its pairing date, so a
history fetch searches the tag's whole life — ~50,000 indices for an 18-month-old AirTag, which
at Apple's ~290-keys-per-request limit is hundreds of round trips. That is the account-flagging
risk from #30.

So `_fetchReportsForAccessory` asks for the **latest location** instead, which walks backwards
from now and stops at the first hit. One round trip, and alignment narrows as a side effect.
Deliberate, and documented in the function.

What comes back is therefore *"the most recent location that still exists"*, which may be days
old — not *"the locations inside the last 24 hours"*.

## The bug

`getLastReports` filtered it to the last 24 hours regardless.

A tag whose newest report was older than a day — one that has sat in a drawer since the export —
was located successfully on import and then had that location discarded. The user saw **"No last
location known"** on a tag the app had just found, and it stayed that way until a later refresh
happened to run after alignment had narrowed.

## The fix

`_fetchReportsForAccessory` now returns an `AccessoryFetch` saying which path it took. The
history path honours the window and is still filtered; the probe path is not.

Filtering is unchanged in `getReports`, where a range was explicitly asked for.

## Tests

`test_a_newly_imported_tag_keeps_a_location_older_than_the_window` fails without the change, and
its counterpart asserts an aligned tag's history is still bounded — keeping everything there
would quietly widen every refresh. **54 Python tests pass.**

Found by reading the fetch path after a question about what a fresh import actually scans, not
from a bug report — so there is no reproduction from a real device, only from the code and its
tests.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*This pull request description was written by Claude Code.*
