### PR TITLE
Let add_strings.py remove a string too

### DIFF
--- a/.claude/skills/add-strings/SKILL.md
+++ b/.claude/skills/add-strings/SKILL.md
@@ -69,7 +69,26 @@ script cannot do what you need. It is slower and it is what the script exists to
 | `--locales` | Lists discovered locales and their files |
 | `<file.json>` | Adds strings; **errors** if any locale is missing or the name already exists |
 | `--fill <file.json>` | Adds only where missing — for back-filling what `--check` reported |
+| `--show <name>...` | Prints existing strings in the input format, ready to edit |
+| `--replace <file.json>` | Rewords strings that already exist; errors if one is not defined everywhere |
+| `--remove <name>...` | Deletes strings from every locale; errors if a name exists nowhere |
 | `--check` | Fails if any locale lacks a string the default locale has. Run before a PR |
+
+## Removing and renaming
+
+Do not hand-delete a string from ten files, for the same reason you do not hand-add one:
+
+```bash
+python scripts/add_strings.py --remove old_name
+```
+
+**Renaming is `--remove` then an ordinary add.** Nothing updates references — if a layout or
+menu still points at a removed string, `aapt` fails the build, which is how you want to find
+out.
+
+Rewording something that already exists is `--show` piped into a file, edited, then
+`--replace`. That refuses unless the string is defined in every locale, so a typo in the name
+fails instead of quietly doing nothing.
 
 ## Translating
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,6 +325,7 @@ python scripts/add_strings.py new.json        # add strings to every locale
 python scripts/add_strings.py --fill new.json # add only where missing, for back-filling
 python scripts/add_strings.py --show <name>…  # print current text, in the input format
 python scripts/add_strings.py --replace r.json # reword strings that already exist
+python scripts/add_strings.py --remove <name>… # delete strings from every locale
 python scripts/add_strings.py --check         # fail if any locale is missing a string
 ```
 
@@ -340,6 +341,17 @@ Two reasons this is the rule. A missed locale keeps the old wording and still pa
 `--check`, so nothing complains and the app says two different things in two languages. And
 the intermediate JSON puts all ten translations in one reviewable diff, instead of ten
 separate edits nobody reads to the end.
+
+**Deleting goes through `--remove`, and renaming is `--remove` followed by an ordinary add.**
+
+```bash
+python scripts/add_strings.py --remove export_tag
+```
+
+The same argument applies: a string missed in one locale is still valid XML and still passes
+`--check`, so an orphan sits there indefinitely. `--remove` refuses names that exist nowhere,
+so a typo fails loudly. It does **not** update references — if a layout or menu still points
+at a removed string, aapt fails the build, which is the intended way to find out.
 
 Translations are read **from a JSON file, never from a command-line argument**. That is not
 a style preference: passing non-ASCII text through shell quoting has twice corrupted it here,

--- a/scripts/add_strings.py
+++ b/scripts/add_strings.py
@@ -35,6 +35,15 @@ other modes read, edit it, then feed it back:
 --replace refuses unless the string is already defined in every locale, so a mistyped name
 fails instead of silently doing nothing.
 
+Removing strings, from every locale at once. Takes names rather than a JSON file, since there
+is nothing to translate:
+
+    python scripts/add_strings.py --remove export_tag old_unused_string
+
+Renaming is --remove followed by an ordinary add. Note that nothing here updates references:
+if a layout or menu still points at a removed string, aapt fails the build, which is the
+intended way to find out.
+
 Listing the locales it found:
 
     python scripts/add_strings.py --locales
@@ -401,6 +410,67 @@ def replace_strings(spec: dict, locales: list[str]) -> int:
     return 0
 
 
+def strip_one_locale(names: list[str], locale: str) -> tuple[str, int]:
+    """One locale's file contents with the given strings gone, and how many were removed."""
+    content = strings_file(locale).read_text(encoding="utf-8")
+    removed = 0
+
+    for name in names:
+        # Takes the whole line including its indentation and trailing newline, so removing a
+        # string does not leave a blank line where it used to be. DOTALL because a message can
+        # span lines; non-greedy so two strings cannot be swallowed as one match.
+        pattern = re.compile(
+            rf'[ \t]*<string name="{re.escape(name)}"[^>]*>.*?</string>[ \t]*\r?\n',
+            re.DOTALL)
+
+        content, count = pattern.subn("", content)
+        removed += count
+
+    return content, removed
+
+
+def remove_strings(names: list[str], locales: list[str]) -> int:
+    """Delete strings from every locale at once.
+
+    The counterpart to --replace, and needed for the same reason. Renaming a key or dropping a
+    string somebody decided against means ten near-identical deletions, and a missed one is
+    invisible: an orphaned string is still valid XML, still passes --check, and simply sits
+    there until somebody wonders what it was for.
+
+    Refuses to write unless the string exists somewhere, so a mistyped name fails loudly rather
+    than reporting a successful removal of nothing.
+    """
+    unknown = [
+        name for name in names
+        if not any(name in existing_names(strings_file(locale)) for locale in locales)
+    ]
+
+    if unknown:
+        print("Refusing to write:\n", file=sys.stderr)
+        for name in unknown:
+            print(f"  - {name}: not defined in any locale. Check the spelling.", file=sys.stderr)
+        return 1
+
+    for locale in locales:
+        path = strings_file(locale)
+        content, removed = strip_one_locale(names, locale)
+
+        path.write_text(content, encoding="utf-8")
+
+        try:
+            ElementTree.parse(path)
+        except ElementTree.ParseError as error:
+            print(f"{path} is no longer valid XML after writing: {error}", file=sys.stderr)
+            return 1
+
+        print(f"  {path.relative_to(REPO_ROOT)}: -{removed}")
+
+    print(f"\nDone. {len(names)} string(s) removed from {len(locales)} locale(s).")
+    print("Remember the references: aapt will fail the build if a layout or menu still "
+          "points at one of these.")
+    return 0
+
+
 def check(locales: list[str]) -> int:
     default_path = strings_file(DEFAULT_LOCALE)
     if not default_path.is_file():
@@ -489,6 +559,9 @@ def main(argv: list[str]) -> int:
 
     if len(argv) >= 2 and argv[0] == "--show":
         return show_strings(argv[1:], locales)
+
+    if len(argv) >= 2 and argv[0] == "--remove":
+        return remove_strings(argv[1:], locales)
 
     mode = argv[0] if len(argv) == 2 and argv[0] in ("--fill", "--replace") else None
     if mode:


### PR DESCRIPTION
Adding, back-filling and rewording strings all go through `scripts/add_strings.py`. Deleting was
still ten hand edits — and renaming a key needs both halves, so the missing half was the one that
came up.

```bash
python scripts/add_strings.py --remove export_tag
```

## Why it is worth a flag

The same argument the other modes rest on. A string missed in one locale is **still valid XML and
still passes `--check`**, so an orphan sits there indefinitely until somebody wonders what it was
for. Nothing fails; the file is just quietly wrong.

It refuses names that exist nowhere, so a typo fails loudly rather than reporting a successful
removal of nothing. It takes bare names rather than a JSON file, since there is nothing to
translate — which also keeps the no-non-ASCII-through-shell-quoting rule intact.

It deliberately does **not** update references. A layout still pointing at a removed string fails
at aapt, which is the right place to learn that.

## Verification

Round trip: adding a throwaway string and removing it again leaves every `strings.xml`
**byte-identical** — `git diff` reports no change — so no blank line or stray whitespace is left
behind. `--check` passes at 139/139 afterwards. The rejection path was exercised too.

## Docs

`AGENTS.md` and `.claude/skills/add-strings/SKILL.md` both gain the flag, the rename recipe, and
the note about references. The skill's command table was also missing `--show` and `--replace`,
which already existed — those are now listed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*This pull request description was written by Claude Code.*
