### PR TITLE
Add a skill for rendering and reading the app's UI

### DIFF
--- a/.claude/skills/device-screenshots/SKILL.md
+++ b/.claude/skills/device-screenshots/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: device-screenshots
+description: Render app UI on the Gradle managed device and look at the result without spending a fortune in vision tokens. Use whenever a change is visual - colours, themes, drawables, layout - or when a screenshot needs comparing before and after, light and dark.
+---
+
+# Looking at the app's UI
+
+Two halves: getting a screenshot off the device, and reading it cheaply. The second is the part
+that is easy to get wrong.
+
+## Never Read a raw screenshot
+
+A device screenshot is ~1080px wide and mostly whitespace. Reading one costs a lot of vision
+tokens for a picture whose informative part is a few hundred pixels, and reading a before/after
+pair separately doubles it for a comparison that wants to be side by side anyway.
+
+Run them through the sheet tool first:
+
+```bash
+python .claude/skills/device-screenshots/sheet.py \
+    app/build/outputs/managed_device_android_test_additional_output/debug/testEmulator \
+    <scratchpad>/shots
+```
+
+Then Read the sheets it prints. One subject, all its variants, one image, a few hundred pixels
+wide.
+
+Files are grouped on the part before the last hyphen; the part after is the variant label:
+
+```
+my_device_list_item-fixed.png       ->  subject my_device_list_item, variant "fixed"
+my_device_list_item-wallpaper.png                                    variant "wallpaper"
+```
+
+| Flag | Default | For |
+| --- | --- | --- |
+| `--width` | 420 | target width per panel |
+| `--max-height` | 420 | cap, so a tall image cannot produce a 2000px sheet |
+| `--dark` | `dark,wallpaper_dark,night` | variants composited over black rather than white |
+
+Needs Pillow (`python -m pip install pillow`).
+
+## Getting the screenshots
+
+`SystemColorsLayoutTest` is the working example. Inflate a layout — or load a drawable —
+against a themed context, draw it to a `Bitmap`, and write it to the directory AGP passes as the
+`additionalTestOutputDir` instrumentation argument. AGP copies that back to the host after the
+run:
+
+```
+app/build/outputs/managed_device_android_test_additional_output/debug/testEmulator/
+```
+
+Run it on the managed device, which provisions and tears down its own emulator:
+
+```bash
+JAVA_HOME='C:\Program Files\Android\Android Studio\jbr' ./gradlew :app:testEmulatorDebugAndroidTest
+```
+
+No activity is needed for most of this. Inflating the layout against a
+`ContextThemeWrapper(context, R.style.Theme_OpenTagViewer)` on the main thread is enough, and it
+avoids every problem that comes with launching one.
+
+## Two traps, both hit here already
+
+**Transparency.** Several layouts have no background of their own. Converting them straight to
+RGB renders every transparent pixel black, and the result looks like a catastrophic bug that is
+not there. The tool composites over a background; do the same anywhere else.
+
+**Images are not assertions.** A screenshot proves what one configuration looked like once.
+Whatever the change is, assert it as well — a resolved colour, a contrast ratio, a measured
+height. `SystemColorsLayoutTest` requires the timeline tiles to clear WCAG 3:1 against their
+background, which is what actually fails the build; the images are what explain why.
+
+And be careful what the assertion is *about*. That same test renders drawables through a themed
+context, so it kept passing while the history timeline was invisible in the app — the app was
+loading them with a null theme. The test proved the drawable could render, not that the app asked
+for it correctly. `ThemedDrawableLoadingTest` covers the call site instead.
+
+## Dark mode
+
+Rendering the day theme only is the usual mistake — the app has a full `values-night` palette. A
+themed context can be forced to night without changing the device:
+
+```java
+Configuration night = new Configuration(context.getResources().getConfiguration());
+night.uiMode = (night.uiMode & ~Configuration.UI_MODE_NIGHT_MASK)
+        | Configuration.UI_MODE_NIGHT_YES;
+Context darkContext = context.createConfigurationContext(night);
+// then wrap in ContextThemeWrapper(darkContext, R.style.Theme_OpenTagViewer)
+```
+
+Name those outputs `-dark` so the sheet tool composites them over black.
+
+## Related
+
+- `AGENTS.md` rule 2 — do not claim something works if you have not run it. A rendered sheet is
+  evidence; "it should look right" is not.
+- `CONTRIBUTING.md` for how the managed device is configured.

--- a/.claude/skills/device-screenshots/sheet.py
+++ b/.claude/skills/device-screenshots/sheet.py
@@ -1,0 +1,170 @@
+"""Turn a directory of device screenshots into a few small, labelled sheets.
+
+Screenshots off an Android device are ~1080px wide and mostly whitespace. Reading them at full
+size spends a large number of vision tokens on a picture whose informative part is a few hundred
+pixels, and reading a before/after pair separately doubles that for a comparison the eye wants
+side by side anyway.
+
+This groups files by subject, puts each subject's variants in one sheet, and scales them down.
+
+Naming
+------
+Files are grouped on the part before the last hyphen, and the part after it is the variant:
+
+    my_device_list_item-fixed.png      -> subject "my_device_list_item", variant "fixed"
+    my_device_list_item-wallpaper.png                                    variant "wallpaper"
+
+Anything with no hyphen becomes its own single-panel sheet.
+
+Usage
+-----
+    python .claude/skills/device-screenshots/sheet.py <input-dir> <output-dir>
+    python .claude/skills/device-screenshots/sheet.py <in> <out> --width 420 --max-height 400
+    python .claude/skills/device-screenshots/sheet.py <in> <out> --dark wallpaper_dark,dark
+
+Two behaviours worth knowing, both learned the hard way:
+
+* Transparent pixels are composited over a background rather than dropped. Several layouts here
+  have no background of their own, and converting them straight to RGB renders them solid black.
+* Tall narrow images (the timeline tiles are 13x48) are laid out side by side and capped by
+  height. Scaling those to a fixed width produced a 300x2252 sheet.
+
+Needs Pillow. If it is missing:  python -m pip install pillow
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+try:
+    from PIL import Image, ImageDraw
+except ImportError:  # pragma: no cover - the message is the whole point
+    sys.exit("Pillow is required: python -m pip install pillow")
+
+LABEL_HEIGHT = 15
+PADDING = 10
+
+# Panels for a dark variant are composited over near-black instead of white, or a dark-mode
+# screenshot with transparency comes out as dark-on-white and looks broken rather than dark.
+LIGHT_BACKGROUND = (255, 255, 255)
+DARK_BACKGROUND = (18, 18, 18)
+
+# Above this ratio an image is treated as a tall sliver and laid out horizontally, capped by
+# height rather than width.
+TALL_RATIO = 2.0
+
+
+def load(path: Path, background: tuple[int, int, int]) -> Image.Image:
+    raw = Image.open(path).convert("RGBA")
+    canvas = Image.new("RGBA", raw.size, background + (255,))
+    return Image.alpha_composite(canvas, raw).convert("RGB")
+
+
+def group_by_subject(source: Path) -> "OrderedDict[str, list[tuple[str, Path]]]":
+    groups: "OrderedDict[str, list[tuple[str, Path]]]" = OrderedDict()
+
+    for path in sorted(source.glob("*.png")):
+        stem = path.stem
+        subject, _, variant = stem.rpartition("-")
+
+        if not subject:
+            subject, variant = stem, ""
+
+        groups.setdefault(subject, []).append((variant, path))
+
+    return groups
+
+
+def build_sheet(
+        panels: list[tuple[str, Image.Image]],
+        horizontal: bool) -> Image.Image:
+    """Lay the panels out with a label above each."""
+    if horizontal:
+        width = sum(p.width for _, p in panels) + PADDING * (len(panels) + 1)
+        height = max(p.height for _, p in panels) + LABEL_HEIGHT + PADDING
+    else:
+        width = max(p.width for _, p in panels)
+        height = sum(p.height + LABEL_HEIGHT for _, p in panels)
+
+    sheet = Image.new("RGB", (width, height), LIGHT_BACKGROUND)
+    draw = ImageDraw.Draw(sheet)
+
+    if horizontal:
+        x = PADDING
+        for label, panel in panels:
+            draw.text((x, 2), label, fill=(0, 0, 0))
+            sheet.paste(panel, (x, LABEL_HEIGHT))
+            x += panel.width + PADDING
+    else:
+        y = 0
+        for label, panel in panels:
+            draw.text((4, y + 2), label, fill=(0, 0, 0))
+            y += LABEL_HEIGHT
+            sheet.paste(panel, (0, y))
+            y += panel.height
+
+    return sheet
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("source", type=Path, help="directory of .png screenshots")
+    parser.add_argument("destination", type=Path, help="where to write the sheets")
+    parser.add_argument("--width", type=int, default=420,
+                        help="target width per panel for ordinary images (default 420)")
+    parser.add_argument("--max-height", type=int, default=420,
+                        help="cap on panel height (default 420)")
+    parser.add_argument("--dark", default="dark,wallpaper_dark,night",
+                        help="comma-separated variant names to composite over black")
+
+    args = parser.parse_args(argv)
+
+    if not args.source.is_dir():
+        print(f"No such directory: {args.source}", file=sys.stderr)
+        return 2
+
+    dark_variants = {v.strip() for v in args.dark.split(",") if v.strip()}
+    args.destination.mkdir(parents=True, exist_ok=True)
+
+    groups = group_by_subject(args.source)
+    if not groups:
+        print(f"No .png files in {args.source}", file=sys.stderr)
+        return 1
+
+    for subject, entries in groups.items():
+        panels: list[tuple[str, Image.Image]] = []
+        horizontal = False
+
+        for variant, path in entries:
+            background = DARK_BACKGROUND if variant in dark_variants else LIGHT_BACKGROUND
+            image = load(path, background)
+
+            # A tall sliver is capped by height and the sheet runs sideways; anything else is
+            # scaled to the target width.
+            if image.height > image.width * TALL_RATIO:
+                horizontal = True
+                scale = min(args.max_height / image.height, 1.0)
+            else:
+                scale = min(args.width / image.width, args.max_height / image.height, 1.0)
+
+            image = image.resize(
+                (max(1, int(image.width * scale)), max(1, int(image.height * scale))),
+                Image.LANCZOS)
+
+            panels.append((variant or subject, image))
+
+        sheet = build_sheet(panels, horizontal)
+        target = args.destination / f"{subject}.png"
+        sheet.save(target, optimize=True)
+
+        print(f"{target}  {sheet.width}x{sheet.height}  ({len(panels)} panel(s))")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,15 @@ If you add or change one of these, update its index in the same commit:
 | A workflow in `.github/workflows/` | the CI table in [CONTRIBUTING.md](./CONTRIBUTING.md#continuous-integration) |
 | A test suite, or one that needs opting into | the test table and its section in `CONTRIBUTING.md` |
 | A script in `scripts/` that people run by hand | the section of `CONTRIBUTING.md` covering that workflow |
+| A skill in `.claude/skills/` | the skills table below |
 | A constraint that would take someone an afternoon to rediscover | a rule here |
+
+Skills carry the longer version of a workflow, so this file can stay short:
+
+| Skill | For |
+| --- | --- |
+| `.claude/skills/add-strings/` | any user-facing string — adding, rewording, removing, checking |
+| `.claude/skills/device-screenshots/` | rendering the UI on the managed device and reading it cheaply |
 
 The test for whether it belongs here rather than in a comment: would somebody hit it *before*
 reading the code that explains it? Anisette's machine-identity binding is the example — it
@@ -258,6 +266,27 @@ Two more rules that came out of the same failures:
   first one completed the sign-in and there is no activity left to close a keyboard on.
 - **A `GONE` view still matches `withId`.** "Not on screen" is `matches(not(isDisplayed()))`,
   never an expected `NoMatchingViewException`.
+
+### Looking at the UI yourself
+
+A visual change should be looked at, not reasoned about. `SystemColorsLayoutTest` shows the
+pattern: inflate a layout, or load a drawable, against a themed context, draw it to a bitmap,
+and write it to the directory AGP passes as `additionalTestOutputDir`. It comes back to the
+host in `app/build/outputs/managed_device_android_test_additional_output/`, and the managed
+device runs headless, so no window and no emulator of your own is needed.
+
+Then compact them before reading — a raw 1080px screenshot is mostly whitespace:
+
+```bash
+python .claude/skills/device-screenshots/sheet.py <output-dir> <somewhere-temporary>
+```
+
+**A screenshot is not an assertion.** It shows what one configuration looked like once. Assert
+the thing that matters as well — a resolved colour, a contrast ratio, a measured height — and
+be careful what the assertion is about: the screenshot test kept passing while the history
+timeline was invisible, because it loaded the drawables with a theme and the app did not.
+
+Full details, including forcing dark mode without touching the device: `.claude/skills/device-screenshots/`.
 
 ### Showing a UI test to a person
 


### PR DESCRIPTION
Every visual change this session went through an ad-hoc script in a scratch directory, rewritten
each time and thrown away. It should be a skill — because the useful part is not the resizing, it
is the handful of things that were got wrong first.

## `sheet.py`

Groups screenshots by subject, puts each subject's variants into one labelled image, and scales
them down. A raw device screenshot is ~1080px wide and mostly whitespace; reading a before/after
pair separately doubles the cost of a comparison that wants to be side by side anyway.

```bash
python .claude/skills/device-screenshots/sheet.py <device-output-dir> <somewhere-temporary>
```

Two behaviours exist because of specific failures:

- **Transparency is composited, not dropped.** Several layouts have no background of their own,
  and converting straight to RGB renders every transparent pixel black — which looks like a
  catastrophic bug that is not there.
- **Tall slivers go sideways, capped by height.** The timeline tiles are 13×48. Scaling them to a
  fixed width produced a 300×2252 sheet, worse than the originals. They now come out 158×262.

## What the skill records beyond the tool

That a screenshot **is not an assertion** — it shows one configuration once, and the assertion is
what fails a build.

And that it matters what the assertion is *about*: `SystemColorsLayoutTest` renders the timeline
tiles and requires them to clear WCAG 3:1, and it kept passing throughout the outage in #85,
because it loads those drawables through a themed context and the app did not. The test proved
the drawable could render, not that the app asked for it correctly.

It also covers forcing dark mode via `createConfigurationContext` without touching the device,
which is the gap in everything rendered so far.

## AGENTS.md

Gains a skills table. It had none, so `add-strings` has been sitting unindexed — exactly what
rule 10 exists to prevent.

## Verified

Run against the real managed-device output: six sheets, correct grouping, the tall-tile case
handled.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*This pull request description was written by Claude Code.*
