### PR TITLE
Settle the app's connection model, and the screens for it

### DIFF
--- a/docs/android-import-handover.md
+++ b/docs/android-import-handover.md
@@ -159,6 +159,95 @@ Worth knowing while building it: the app must present `0PENTAGVIEWR` and not the
 exporter never does — it may enrol as a peer rather than only recovering. That is the one place
 this stops being read-only, and it deserves its own decision rather than arriving as a side effect.
 
+## 7. The connection model, and the screens that express it
+
+Refinement to everything above, settled after the exporter shipped. **The app has two states and
+no third.**
+
+| | What it means |
+| --- | --- |
+| **Not connected** | Signed in to Apple, because fetching location reports needs an Apple ID whatever the tags are. Tags come from files the user imports. Nothing is read from their iCloud account and nothing is written to it. |
+| **Connected** | Also reads the tags in the user's own Apple account, which means it has joined the keychain trust circle. |
+
+**There is no export-only mode in the app.** A one-off export that touches nothing is what the
+desktop tool is for. In the app, "read my tags from my Apple account" and "join" are the same act
+— joining is what stops it quietly ceasing to work — so they are not two questions.
+
+The app can still *write* a bundle for someone else, but that is a thing a connected app can do,
+not a mode it runs in.
+
+### First run: two buttons, not four
+
+- **Fetch my tags from my Apple account**
+- **Import tags from a file**
+
+The obvious four collapse. **A bundle and a key file are the same button**: the app can tell them
+apart by looking, and `opentagviewer_export/keyfiles.py` already parses `.keys`, bare key lists,
+`findmy-custom-accessory.json` and `macless-haystack-devices.json`. A user with one AirTag and one
+self-generated tag is both cases at once anyway, so neither is a mode to be in.
+
+**Say what was found, not just that it worked.** "Imported 3 AirTags" against "imported 2
+self-generated tags" is how somebody who picked the wrong file finds out, and it is the natural
+place to say that a bundle is a snapshot rather than a live link.
+
+**Every path signs in.** Copy that implies importing a file avoids needing an Apple account will
+produce a fresh crop of issues shaped exactly like #19.
+
+### "Shared with me in Find My" is not a fourth option — it is the first one failing
+
+A tag can only be registered by an iPhone or iPad, so an account with no device on it owns no
+tags. Somebody choosing *fetch my tags* and finding nothing is almost always a person whose friend
+shared tags with them in Apple's own Find My. That sharing does not carry key material — see
+[export-modes.md](./export-modes.md) — so there is nothing to fetch and never will be.
+
+Catch it where it happens rather than asking users to classify themselves up front:
+
+> **No tags owned by this account**
+>
+> Tags are registered by an iPhone or iPad, and only that account can unlock them. This account
+> has no device that can.
+>
+> **If a friend shared their tags with you in Find My**, that sharing does not include the keys
+> this app needs. Ask them to export a bundle for you, and import it here.
+
+Then drop them into the import path. The sold-or-wiped-device case reaches the same screen and
+needs no branch of its own — that user still has Apple's own routes to restore keychain access.
+
+### Settings: one switch
+
+**Read my tags from my Apple account — on or off.** On joins. There is no separate "stay
+connected" question, because users do not distinguish it from being connected at all, and no
+third state on the screen.
+
+Turning it off should say what it does not undo: it stops reading the tag list, and it does not
+remove the entry from the user's Apple device list. That removal is theirs to do, in Apple's
+interface.
+
+### The one prompt that interrupts a connected app
+
+Once joined, key rotation is handled — a member is given the new keys. So the only thing that
+breaks a working connection is the user changing something in Apple's own interface: **removing
+OpenTagViewer from their device list**, or **resetting iCloud Keychain**. Section 6.7.1 of
+[the Stage 3 spec](./findmy-export/03-keychain-trust.md) says the same.
+
+Both are deliberate acts elsewhere, so the copy can be specific:
+
+> **Your Apple account no longer recognises OpenTagViewer.** This usually means it was removed
+> from your device list. Enter the passcode of one of your Apple devices to reconnect.
+
+Which is the argument for naming the entry — `0PENTAGVIEWR` — on the connect screen in the first
+place. It gets removed because the row looked unfamiliar next to *"If you do not recognise this
+device"*.
+
+### Two passcodes, and only one of them is new
+
+The **device passcode** is an existing iPhone PIN or Mac login password, used to recover the
+keychain. The passcode the user **chooses** seals this client's own recovery record, and exists
+only on the connected path. Neither is the Apple ID password, and saying so on the screen saves a
+support thread.
+
+---
+
 ## 6. Two smaller things
 
 **The FindMy pin is out of step with itself.** `app/build.gradle.kts` installs the

--- a/docs/export-modes.md
+++ b/docs/export-modes.md
@@ -126,8 +126,13 @@ write anything.
 
 | Flow | Joins |
 | --- | --- |
-| One-off export, in the app or the wizard | **no** — recover keys, decrypt, write the zip, leave nothing |
-| Live tracking of your own account's tags | yes, and say so before doing it |
+| One-off export, in the **desktop tool** | **no** — recover keys, decrypt, write the zip, leave nothing |
+| Reading your own account's tags **in the app** | yes, and say so before doing it |
+
+**The app has no export-only mode**, and should not grow one. Reading the user's tags and
+joining are the same act there — joining is what stops it quietly ceasing to work — so they are
+not two questions to ask. A one-off export that writes nothing to the account is exactly what
+the desktop tool exists for.
 
 Bundling the join into sign-in would give every user who wanted a single export a peer in their
 keychain trust circle and an escrow record that **no Apple interface displays**, acquired without


### PR DESCRIPTION
Refinement to `docs/android-import-handover.md`, plus a correction to `docs/export-modes.md`.

**The app has two states and no third**: not connected (signed in, tags come from files) and connected (also reads the tags in the user's own Apple account, which means it has joined).

**No export-only mode in the app.** Reading your own tags and joining are the same act there — joining is what stops it quietly ceasing to work — so they are not two questions to ask a user. A one-off export that writes nothing to the account is what the desktop tool is for. `export-modes.md` said otherwise and is corrected.

Also settled:

- **First run is two buttons, not four.** A bundle and a key file are one button — `keyfiles.py` already tells them apart — and a user with one AirTag and one self-generated tag is both at once.
- **"Shared with me in Find My" is the first option failing, not a fourth option.** A tag can only be registered by an iPhone or iPad, so an account with no device owns no tags. Caught where it happens, with copy, rather than asked up front.
- **Settings is one switch.** On joins. No separate "stay connected", because users do not distinguish it from being connected.
- **The one prompt that interrupts a connected app**, and why it can be specific: once joined, rotation is handled, so what breaks a connection is the user removing the app from their device list — which is why that entry should be named on the connect screen.
- Every path signs in. Copy implying otherwise produces issues shaped like #19.

---

*Summary written by Claude Code.*