### PR TITLE
Stop the client-info comment claiming a goal it no longer has

### DIFF
--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/AdiDeviceIdentity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/AdiDeviceIdentity.java
@@ -25,9 +25,20 @@ import java.util.UUID;
 public final class AdiDeviceIdentity {
 
     /**
-     * What we claim to be. Matching anisette-v3-server exactly is deliberate: this string is
-     * already the most common one Apple sees from Anisette traffic, so it is the least
-     * remarkable thing we could send.
+     * What we claim to be.
+     *
+     * <p>The value matches anisette-v3-server, which was originally chosen because it is the most
+     * common string Apple sees and therefore the least remarkable thing to send. <b>That reasoning
+     * no longer applies.</b> Rule 11 has this app registering under a name and a serial that exist
+     * to be recognised - a user looking at their Apple device list is meant to know which entry is
+     * this - so blending in stopped being achievable the moment being identifiable became the
+     * point. The string stays because it works, not because it hides.
+     *
+     * <p><b>The parts describe one real release and have to move together.</b> Model, OS version,
+     * build, CFNetwork and Darwin are a set; claiming a Mac here and an iPhone elsewhere is a
+     * contradiction Apple's own clients never produce. See rule 11 and
+     * {@code docs/findmy-export/01-authentication.md} section 2.2, which carries a worked iPhone
+     * set if this ever changes to one.
      */
     public static final String CLIENT_INFO =
             "<MacBookPro13,2> <macOS;13.1;22C65> <com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>";

--- a/docs/android-import-handover.md
+++ b/docs/android-import-handover.md
@@ -175,3 +175,34 @@ now takes `serial=` on the Anisette provider and defaults CloudKit to it, so thi
 fix at the point the provider is built, plus a decision that `0PENTAGVIEWR` is the app's. The
 exporter presents `0PENTAGXPORT`, deliberately different: two installs, two entries, each
 removable without breaking the other.
+
+**And the entry has no name, which is the field a person reads first.** Nothing calls the
+`postdata` announce of
+[Stage 2 §7](./findmy-export/02-mobileme-delegate.md#7-naming-the-registered-device), so Apple
+names the row after whatever model the client claims - `MacBookPro18,3` shows up as a bare
+**"MacBookPro"**, sitting in a list of the user's real hardware with nothing to tell it apart.
+FindMy.py cannot do this at all today; the ask is written up in
+[findmy-py-device-name-request.md](./findmy-py-device-name-request.md). Target is
+**`OpenTagViewer App`**, with the exporter as `OpenTagViewer Exporter`.
+
+**Once name and serial are set, the model is only choosing an icon** - so the app should claim an
+iPhone and the desktop tool a Mac, which makes a device list readable at a glance. Two conditions
+on that:
+
+- **Do not switch the model on its own.** Today the app sends serial `"0"` and no name, so an
+  iPhone claim would produce an entry called "iPhone" with no serial, among the user's real
+  iPhones. Strictly worse than the Mac claim it has now. Model, name and serial land together or
+  not at all.
+- **All five strings move together.** Model, OS version, build, CFNetwork and Darwin describe one
+  real release - see [rule 11](../AGENTS.md) and
+  [Stage 1 §2.2](./findmy-export/01-authentication.md), which carries a worked set:
+  `iPhone15,2`, iOS `17.4`, build `21E219`, CFNetwork `1494.0.7`, Darwin `23.4.0`.
+
+> **[observed] Claiming to be a phone does not make it a second factor.** A registered entry
+> presenting as an iPhone still reports *"This device cannot be used to receive Apple Account
+> verification codes"*. What decides that is omitting `ptkn`, exactly as
+> [Stage 1 §13](./findmy-export/01-authentication.md) argued - so the icon change carries no risk
+> of turning this app into a second factor for someone's Apple ID.
+
+`AdiDeviceIdentity.CLIENT_INFO`'s comment used to justify its value as the least remarkable string
+Apple sees. That reasoning is gone: an entry built to be recognised is not blending in.

--- a/docs/android-import-handover.md
+++ b/docs/android-import-handover.md
@@ -206,3 +206,11 @@ on that:
 
 `AdiDeviceIdentity.CLIENT_INFO`'s comment used to justify its value as the least remarkable string
 Apple sees. That reasoning is gone: an entry built to be recognised is not blending in.
+
+**Build the disclosure text from the account, not from constants.** §7.1 of Stage 2 requires that
+the identifiers shown to the user are the ones actually sent - the whole point being that somebody
+reading their Apple device list can match it to what the app told them. FindMy.py now exposes
+`account.device_name` and `account.serial`, so the screen that announces what will be registered
+should read them rather than restating string literals that can drift out of step with what goes
+on the wire. A disclosure that is merely *usually* right is worse than none, because it teaches the
+user to trust a name that might not be theirs.


### PR DESCRIPTION
`CLIENT_INFO`'s comment said matching anisette-v3-server was deliberate because it is "the least remarkable thing we could send". That stopped being true once rule 11 had the app registering under a name and serial designed to be recognised in the user's Apple device list — blending in is not achievable and is no longer the goal.

Value unchanged. The comment now says the string stays because it works, and records the constraint that matters if it is ever switched: model, OS version, build, CFNetwork and Darwin describe one real release and move together.

Comment only, no behaviour change.

---

*Summary written by Claude Code.*