### PR TITLE
Slide the sign-in steps in the direction the user is going

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,32 @@ Two more rules that came out of the same failures:
 - **A `GONE` view still matches `withId`.** "Not on screen" is `matches(not(isDisplayed()))`,
   never an expected `NoMatchingViewException`.
 
+#### `animationsDisabled` does not disable animations
+
+It reads like it settles the question. It does not: AGP passes `--no-window-animation` to
+`am instrument`, which zeroes the *window* and *transition* scales and leaves
+`animator_duration_scale` — the one `ViewPropertyAnimator` and `ObjectAnimator` obey — exactly
+as the device had it. Animators in the app can and do run at full speed under test.
+
+So **no view's final state may be set in an animation callback.** `StepTransition`, which
+animates the sign-in steps, is the worked example: every visibility, offset and alpha it
+touches is at its final value before the call returns, and the animation only decorates the
+journey there. A screen whose state is readable only once an animation has ended cannot be
+asserted on without sleeping, and `Eventually` is a retry loop, not a fix for that.
+
+Two things fall out of it that are easy to get wrong:
+
+- **Animating a step out is not free.** These containers are siblings in a vertical
+  `LinearLayout`, so one still fading occupies its height and the arriving one is laid out
+  *below* it, then jumps when the old one finally goes. It reads as a snapping bug, not as a
+  slow fade. Only the arriving step animates; cross-fading them needs a `FrameLayout`.
+- **Do not read the animator scale to decide what a test expects.** It is a global, and by the
+  time this suite reaches any one class something earlier has already turned animators off.
+  `StepTransitionTest` sets the scale it needs per test, through reflection, and puts it back.
+
+That test also pins down that Settings → Accessibility → **Remove animations** is honoured —
+the flow stops moving entirely rather than moving quickly, which is the point of the setting.
+
 ### Looking at the UI yourself
 
 A visual change should be looked at, not reasoned about. `SystemColorsLayoutTest` shows the

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/login/StepTransitionTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/login/StepTransitionTest.java
@@ -1,0 +1,273 @@
+package dev.wander.android.opentagviewer.ui.login;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.animation.ValueAnimator;
+import android.content.Context;
+import android.view.View;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Method;
+
+import dev.wander.android.opentagviewer.ui.login.StepTransition.Direction;
+
+/**
+ * What the sign-in flow's step transition guarantees, separately from how it looks.
+ *
+ * <p>The login flow tests drive these transitions for real, but they cannot tell an animation
+ * apart from a plain visibility swap - which is the whole question here. An animation that got
+ * the final state wrong, or left a view half-faded for the next time it was shown, would pass
+ * every one of them.
+ */
+@RunWith(AndroidJUnit4.class)
+public class StepTransitionTest {
+
+    private static Context context() {
+        return getInstrumentation().getTargetContext();
+    }
+
+    /** Animations touch view properties, so everything here runs where views live. */
+    private static void onMainThread(final Runnable what) {
+        getInstrumentation().runOnMainSync(what);
+    }
+
+    private static View shown() {
+        final View view = new View(context());
+        view.setVisibility(View.VISIBLE);
+        return view;
+    }
+
+    private static View hidden() {
+        final View view = new View(context());
+        view.setVisibility(View.GONE);
+        return view;
+    }
+
+    /**
+     * <b>"Remove animations" is honoured</b> - the flow stops animating rather than animating
+     * quickly.
+     *
+     * <p>Settings &gt; Accessibility &gt; Remove animations zeroes the global animation scales,
+     * which is what {@link ValueAnimator#areAnimatorsEnabled()} reports. Somebody who turns
+     * that on has usually done so because motion makes the screen hard to use or makes them
+     * unwell, so shortening the duration is not good enough: nothing may move at all.
+     *
+     * <p>Forced here through the same scale the setting writes, because a test cannot toggle an
+     * accessibility preference and a claim in a comment is not a guarantee.
+     */
+    @Test
+    public void removeAnimationsStopsTheStepsMovingAtAll() throws Exception {
+        final View outgoing = shown();
+        final View incoming = hidden();
+
+        withAnimatorsOff(() ->
+                onMainThread(() -> StepTransition.swap(outgoing, incoming, Direction.FORWARD)));
+
+        assertEquals("nothing should have been left animating out",
+                View.GONE, outgoing.getVisibility());
+        assertEquals(View.VISIBLE, incoming.getVisibility());
+        assertSettled(outgoing);
+        assertSettled(incoming);
+    }
+
+    /**
+     * <b>The step being left goes at once, animating or not.</b>
+     *
+     * <p>Not a detail - it is why the transition looks right. The step containers are siblings
+     * in a vertical {@code LinearLayout}, so one still fading out still occupies its height,
+     * and the arriving step gets laid out below it and then jumps into place when the old one
+     * finally goes. Leaving it visible for even one animation is visible as a snap.
+     *
+     * <p>It is also what keeps Espresso out of trouble here, and that is worth knowing because
+     * the obvious assumption is wrong: {@code testOptions.animationsDisabled} passes
+     * {@code --no-window-animation} to {@code am instrument}, which turns off window and
+     * transition animations and leaves {@code animator_duration_scale} - what
+     * {@link android.view.ViewPropertyAnimator} obeys - exactly as the device had it. So these
+     * animations do run under test, and only this leaves no window in which two steps are both
+     * on screen.
+     */
+    @Test
+    public void theStepBeingLeftIsGoneBeforeTheCallReturns() throws Exception {
+        final View outgoing = shown();
+
+        withAnimatorsOn(() ->
+                onMainThread(() -> StepTransition.swap(outgoing, hidden(), Direction.FORWARD)));
+
+        assertEquals(
+                "the step being left may not linger in the layout",
+                View.GONE,
+                outgoing.getVisibility());
+        assertSettled(outgoing);
+    }
+
+    /** Not navigation, so nothing moves at all. */
+    @Test
+    public void aSwapWithNoDirectionDoesNotAnimate() {
+        final View outgoing = shown();
+        final View incoming = hidden();
+
+        onMainThread(() -> StepTransition.swap(outgoing, incoming, Direction.NONE));
+
+        assertEquals(View.GONE, outgoing.getVisibility());
+        assertEquals(View.VISIBLE, incoming.getVisibility());
+        assertSettled(incoming);
+        assertSettled(outgoing);
+    }
+
+    /**
+     * True on every path, animated or not: the step being navigated to is on screen by the time
+     * the call returns, so nothing downstream has to wait for an animation to answer "which
+     * step am I on".
+     */
+    @Test
+    public void theArrivingStepIsVisibleBeforeTheCallReturns() throws Exception {
+        for (final Direction direction : Direction.values()) {
+            final View incoming = hidden();
+
+            withAnimatorsOn(() ->
+                    onMainThread(() -> StepTransition.swap(shown(), incoming, direction)));
+
+            assertEquals(
+                    "arriving step not visible for " + direction,
+                    View.VISIBLE,
+                    incoming.getVisibility());
+        }
+    }
+
+    @Test
+    public void forwardBringsTheNextStepInFromTheRight() throws Exception {
+        final View incoming = hidden();
+
+        withAnimatorsOn(() ->
+                onMainThread(() -> StepTransition.swap(shown(), incoming, Direction.FORWARD)));
+
+        assertTrue(
+                "going forwards, the next step should start off to the right",
+                incoming.getTranslationX() > 0f);
+    }
+
+    @Test
+    public void backBringsThePreviousStepInFromTheLeft() throws Exception {
+        final View incoming = hidden();
+
+        withAnimatorsOn(() ->
+                onMainThread(() -> StepTransition.swap(shown(), incoming, Direction.BACK)));
+
+        assertTrue(
+                "going back, the previous step should start off to the left",
+                incoming.getTranslationX() < 0f);
+    }
+
+    /**
+     * The heading names the step, so it travels with it rather than switching under it.
+     *
+     * <p>Its text is set by the caller before this runs and is never touched here, so what the
+     * screen says is readable the moment the step changes - only the movement is decorative.
+     */
+    @Test
+    public void theHeadingTravelsWithTheStepItNames() throws Exception {
+        final View heading = shown();
+
+        withAnimatorsOn(() -> onMainThread(() -> StepTransition.enter(heading, Direction.FORWARD)));
+
+        assertTrue("the heading should arrive from the same side as the step",
+                heading.getTranslationX() > 0f);
+        assertEquals("the heading never leaves the screen", View.VISIBLE, heading.getVisibility());
+    }
+
+    /**
+     * A step interrupted mid-animation has to come back whole.
+     *
+     * <p>These containers are reused rather than re-inflated, so a view abandoned at alpha 0
+     * would be shown again as nothing at all - which reads as a blank screen, not as a bug in
+     * an animation.
+     */
+    @Test
+    public void aStepInterruptedMidAnimationIsNotLeftHalfFaded() throws Exception {
+        final View page = hidden();
+
+        withAnimatorsOn(() -> onMainThread(() -> {
+            StepTransition.swap(shown(), page, Direction.FORWARD);
+            // Interrupted before it could finish, which is what a fast tap does.
+            StepTransition.swap(page, null, Direction.NONE);
+        }));
+
+        assertEquals(View.GONE, page.getVisibility());
+        assertSettled(page);
+    }
+
+    /** Leaving a step with nothing to replace it - the spinner taking over - is allowed. */
+    @Test
+    public void aStepCanBeLeftWithNothingArriving() {
+        final View outgoing = shown();
+
+        onMainThread(() -> StepTransition.swap(outgoing, null, Direction.FORWARD));
+
+        assertEquals(View.GONE, outgoing.getVisibility());
+    }
+
+    /** As "Remove animations" leaves the device. */
+    private static void withAnimatorsOff(final Runnable what) throws Exception {
+        withDurationScale(0f, () -> {
+            assertFalse("the scale did not take effect, so this proves nothing",
+                    ValueAnimator.areAnimatorsEnabled());
+            what.run();
+        });
+    }
+
+    /**
+     * As a device with animations on.
+     *
+     * <p>Needed explicitly rather than assumed: the scale is a global, and by the time this
+     * class runs inside the whole suite something earlier has already turned animators off. A
+     * test of what an animation does cannot be at the mercy of what ran before it.
+     */
+    private static void withAnimatorsOn(final Runnable what) throws Exception {
+        withDurationScale(1f, () -> {
+            assertTrue("the scale did not take effect, so this proves nothing",
+                    ValueAnimator.areAnimatorsEnabled());
+            what.run();
+        });
+    }
+
+    /**
+     * Run something at a given animator duration scale, and put the scale back afterwards
+     * however that turns out.
+     *
+     * <p>By reflection because there is no public setter, and there should not be: the scale is
+     * a global the user owns, and an app is expected to read it rather than write it - which is
+     * the right rule everywhere except in the tests proving the app reads it. If a future
+     * platform closes this off for good, the honest response is to delete these tests rather
+     * than to assert the behaviour without checking it.
+     */
+    private static void withDurationScale(final float scale, final Runnable what)
+            throws Exception {
+        final Method setDurationScale =
+                ValueAnimator.class.getDeclaredMethod("setDurationScale", float.class);
+        setDurationScale.setAccessible(true);
+
+        final Method getDurationScale =
+                ValueAnimator.class.getDeclaredMethod("getDurationScale");
+        getDurationScale.setAccessible(true);
+        final float previous = (float) getDurationScale.invoke(null);
+
+        setDurationScale.invoke(null, scale);
+        try {
+            what.run();
+        } finally {
+            setDurationScale.invoke(null, previous);
+        }
+    }
+
+    private static void assertSettled(final View view) {
+        assertEquals("left offset sideways", 0f, view.getTranslationX(), 0.001f);
+        assertEquals("left translucent", 1f, view.getAlpha(), 0.001f);
+    }
+}

--- a/app/src/main/java/dev/wander/android/opentagviewer/AppleLoginActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/AppleLoginActivity.java
@@ -60,6 +60,8 @@ import dev.wander.android.opentagviewer.service.web.CronetProvider;
 import dev.wander.android.opentagviewer.service.web.GitHubService;
 import dev.wander.android.opentagviewer.service.web.GithubRawUtilityFilesService;
 import dev.wander.android.opentagviewer.ui.login.Apple2FACodeInputManager;
+import dev.wander.android.opentagviewer.ui.login.StepTransition;
+import dev.wander.android.opentagviewer.ui.login.StepTransition.Direction;
 import dev.wander.android.opentagviewer.ui.settings.AmapApiKeyDialog;
 import dev.wander.android.opentagviewer.ui.settings.SharedMainSettingsManager;
 import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
@@ -74,13 +76,27 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * This entire thing should be refactored and made less convoluted and spaghetti-like
- * Also: prettier (i.e. add animations)
  */
 @Slf4j
 public class AppleLoginActivity extends AppCompatActivity {
     private static final String TAG = AppleLoginActivity.class.getSimpleName();
 
     private static final Pattern REGEX_2FA_CODE = Pattern.compile("^[0-9]{6}$");
+
+    /**
+     * The mutually exclusive steps of the flow, in the order the user walks through them.
+     *
+     * <p>Listed once so that showing a step is "show this one" rather than every caller
+     * remembering to hide each of the others - which was six separate {@code setVisibility}
+     * calls spread over the file, and is the kind of thing that leaves two steps stacked on
+     * top of each other when one of them is missed.
+     */
+    private static final int[] PAGES = {
+            R.id.login_anisette_container,
+            R.id.login_maininfo_container,
+            R.id.login_2fa_choice,
+            R.id.login_2fa_container,
+    };
 
     private static final int HINT_DIFFERENT_ANISETTE_SERVER_AFTER_FAILED_2FACODES = 3;
 
@@ -253,9 +269,63 @@ public class AppleLoginActivity extends AppCompatActivity {
         }
     }
 
-    private void setCurrentStepText(final int stringResId) {
+    /**
+     * Move to one step of the flow, animating away whichever one is currently up.
+     *
+     * @param pageId    one of {@link #PAGES}, or {@link View#NO_ID} to leave the flow showing
+     *                  nothing - which is what happens while the spinner is up
+     * @param direction the way the user is travelling, which decides which way things slide.
+     *                  {@link Direction#NONE} for a render that is not navigation, such as
+     *                  the first draw or a restore after rotation
+     */
+    private void showPage(final int pageId, final Direction direction) {
+        View outgoing = null;
+        for (final int candidate : PAGES) {
+            if (candidate == pageId) {
+                continue;
+            }
+            final View page = this.findViewById(candidate);
+            if (outgoing == null && page.getVisibility() == VISIBLE) {
+                outgoing = page;
+                continue;
+            }
+            // Either already off screen or a second visible step, which should not happen.
+            // Hidden without ceremony either way: only one thing can animate out, and a view
+            // left half-faded by an earlier swap would come back that way next time.
+            StepTransition.swap(page, null, Direction.NONE);
+        }
+
+        StepTransition.swap(
+                outgoing,
+                pageId == View.NO_ID ? null : this.findViewById(pageId),
+                direction);
+    }
+
+    /** Leave the current step with nothing to replace it, because the spinner is taking over. */
+    private void hideCurrentPage(final Direction direction) {
+        this.showPage(View.NO_ID, direction);
+    }
+
+    /**
+     * Name the step the user is on, travelling with it when it changes.
+     *
+     * <p>Set before it is animated, so what it says is readable straight away and only the
+     * movement is decorative.
+     *
+     * <p>Unchanged text is left alone rather than re-animated. Choosing a 2FA method and then
+     * typing the code are two steps under one heading, so animating on every call would make
+     * the heading twitch for a change that did not happen.
+     */
+    private void setCurrentStepText(final int stringResId, final Direction direction) {
         TextView textView = this.findViewById(R.id.login_current_input_indicator);
-        textView.setText(stringResId);
+
+        final String next = this.getString(stringResId);
+        if (next.contentEquals(textView.getText())) {
+            return;
+        }
+
+        textView.setText(next);
+        StepTransition.enter(textView, direction);
     }
 
     private void showLoading(final Integer stringResId) {
@@ -287,7 +357,7 @@ public class AppleLoginActivity extends AppCompatActivity {
     }
 
     private void handleAuth(LoginActivityState state) {
-        this.setCurrentStepText(R.string.welcome);
+        this.setCurrentStepText(R.string.welcome, Direction.NONE);
         this.showLoading(null);
 
         var sub = this.getAnisetteSetupStatus()
@@ -295,18 +365,20 @@ public class AppleLoginActivity extends AppCompatActivity {
             .subscribe(status -> {
                 this.hideLoading();
 
+                // Nothing here is navigation - it is the screen being drawn, or restored after
+                // a rotation. Animating it would replay steps the user did not just take.
                 if (status == SETUP_STATUS.OK && (!state.hasSpecifiedCurrentPage() || state.getCurrentPage() == PAGE.LOGIN)) {
                     this.binding.setAllowServerConfNext(true);
                     this.sharedMainSettingsManager.showAnisetteTestStatus(OK);
                     this.sharedMainSettingsManager.setAnisetteTextFieldError(null);
-                    this.showAccountLoginAuthOptions();
+                    this.showAccountLoginAuthOptions(Direction.NONE);
                 } else if (state.getCurrentPage() == PAGE.CHOOSE_2FA) {
-                    this.showNextAuthPage(state.getAuthResponse().getLoginState());
+                    this.showNextAuthPage(state.getAuthResponse().getLoginState(), Direction.NONE);
                 } else if (state.currentPageIs2faEntry()) {
-                    this.show2FACodeEntryTextbox();
+                    this.show2FACodeEntryTextbox(Direction.NONE);
                 } else {
                     // show welcome step/server setup step
-                    this.showInitialWelcomeConfOptions(status);
+                    this.showInitialWelcomeConfOptions(status, Direction.NONE);
                 }
             });
     }
@@ -318,7 +390,7 @@ public class AppleLoginActivity extends AppCompatActivity {
         // there is nothing to validate and nothing that could stop somebody getting past here.
         if (this.localAnisetteStatus.state() == AnisetteStatus.State.READY) {
             this.getUiState().setCurrentPage(PAGE.LOGIN);
-            this.showAccountLoginAuthOptions();
+            this.showAccountLoginAuthOptions(Direction.FORWARD);
             return;
         }
 
@@ -335,13 +407,13 @@ public class AppleLoginActivity extends AppCompatActivity {
 
         this.testAndSaveAnisetteUrl(currentInput, () -> {
             this.getUiState().setCurrentPage(PAGE.LOGIN);
-            this.showAccountLoginAuthOptions();
+            this.showAccountLoginAuthOptions(Direction.FORWARD);
         });
     }
 
     public void onClickBackToAnisetteSettings(View view) {
         Log.d(TAG, "Clicked backwards to language + anisette settings");
-        this.showInitialWelcomeConfOptions(SETUP_STATUS.NO_SERVER_CONFIGURED);
+        this.showInitialWelcomeConfOptions(SETUP_STATUS.NO_SERVER_CONFIGURED, Direction.BACK);
     }
 
     public void onClickLoginButton(View view) {
@@ -359,8 +431,7 @@ public class AppleLoginActivity extends AppCompatActivity {
         // show spinner in button
         // TODO: don't take away the entire UI like this.
         // for now this is good enough...
-        final LinearLayout accountLoginContainer = this.findViewById(R.id.login_maininfo_container);
-        accountLoginContainer.setVisibility(GONE);
+        this.hideCurrentPage(Direction.FORWARD);
 
         final String emailOrPhone = Objects.requireNonNull(emailOrPhoneInput.getText()).toString();
         final String password = Objects.requireNonNull(passwordInput.getText()).toString();
@@ -385,9 +456,10 @@ public class AppleLoginActivity extends AppCompatActivity {
                 this.getUiState().setAuthResponse(null);
                 Log.e(TAG, "Error while trying to log in via python", error);
 
-                // undo loading and allow user to try again, basically.
+                // undo loading and allow user to try again, basically. Backwards, because
+                // that is what it is: the step the user just left, handed back to them.
                 this.hideLoading();
-                accountLoginContainer.setVisibility(VISIBLE);
+                this.showPage(R.id.login_maininfo_container, Direction.BACK);
                 emailOrPhoneInput.setEnabled(true);
                 passwordInput.setEnabled(true);
                 loginButton.setClickable(true);
@@ -405,10 +477,10 @@ public class AppleLoginActivity extends AppCompatActivity {
         Log.d(TAG, "Login state was " + loginState);
         this.getUiState().setAuthResponse(authResponse);
 
-        this.showNextAuthPage(loginState);
+        this.showNextAuthPage(loginState, Direction.FORWARD);
     }
 
-    private void showNextAuthPage(PythonAuthService.LOGIN_STATE loginState) {
+    private void showNextAuthPage(PythonAuthService.LOGIN_STATE loginState, Direction direction) {
         switch (loginState) {
             case LOGGED_OUT:
                 // TODO: invalid password?
@@ -421,23 +493,20 @@ public class AppleLoginActivity extends AppCompatActivity {
                 break;
             case REQUIRE_2FA:
                 // require 2FA!
-                this.show2FAChoiceScreen();
+                this.show2FAChoiceScreen(direction);
                 break;
         }
     }
 
-    private void show2FAChoiceScreen() {
+    private void show2FAChoiceScreen(Direction direction) {
         var state = this.getUiState();
         state.setCurrentPage(PAGE.CHOOSE_2FA);
 
         PythonAuthResponse authResponse = state.getAuthResponse();
-        // TODO: make this all nice and animated...
         // determine which options should be shown:
         this.hideLoading();
-        LinearLayout twoFACodeEntryContainer = this.findViewById(R.id.login_2fa_container);
-        twoFACodeEntryContainer.setVisibility(GONE);
 
-        this.setCurrentStepText(R.string.two_factor_authentication);
+        this.setCurrentStepText(R.string.two_factor_authentication, direction);
         Button trustedDeviceButton = this.findViewById(R.id.twofactorauth_choice_trusted_device);
         final boolean hasTrustedDevice = authResponse.getAuthMethods().stream().anyMatch(authMethod -> authMethod.getType() == TRUSTED_DEVICE);
         trustedDeviceButton.setVisibility(hasTrustedDevice ? VISIBLE : GONE);
@@ -466,8 +535,9 @@ public class AppleLoginActivity extends AppCompatActivity {
                     this.getUiState().getSms2FAButtonToAuthMethod().put(v, authMethodPhone);
                 });
 
-        LinearLayout accountLoginContainer = this.findViewById(R.id.login_2fa_choice);
-        accountLoginContainer.setVisibility(VISIBLE);
+        // Shown last, so the options above are in place before it slides in rather than
+        // appearing one by one on a view the user is already looking at.
+        this.showPage(R.id.login_2fa_choice, direction);
     }
 
     public void onClick2FAWithTrustedDevice(View view) {
@@ -478,13 +548,12 @@ public class AppleLoginActivity extends AppCompatActivity {
 
         this.getUiState().setChosenAuthMethod(chosenAuthMethod);
 
-        LinearLayout accountLoginContainer = this.findViewById(R.id.login_2fa_choice);
-        accountLoginContainer.setVisibility(GONE);
+        this.hideCurrentPage(Direction.FORWARD);
         this.showLoading(R.string.requesting_code);
 
         var async = this.authService.requestCode(chosenAuthMethod)
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(this::show2FACodeEntryTextbox,
+                .subscribe(() -> this.show2FACodeEntryTextbox(Direction.FORWARD),
                 error -> {
                     Log.e(TAG, "Error occurred when trying to request 2FA code from Trusted Devices", error);
                     this.hideLoading();
@@ -499,13 +568,12 @@ public class AppleLoginActivity extends AppCompatActivity {
         this.getUiState().setChosenAuthMethod(phoneAuthMethod);
 
         // TODO: try to do the auth
-        LinearLayout accountLoginContainer = this.findViewById(R.id.login_2fa_choice);
-        accountLoginContainer.setVisibility(GONE);
+        this.hideCurrentPage(Direction.FORWARD);
         this.showLoading(R.string.requesting_code);
 
         var async = this.authService.requestCode(phoneAuthMethod)
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(this::show2FACodeEntryTextbox,
+                .subscribe(() -> this.show2FACodeEntryTextbox(Direction.FORWARD),
                 error -> {
                     Log.e(TAG, "Error occurred when trying to request 2FA code to SMS for phone number " + phoneAuthMethod.getPhoneNumber(), error);
                     this.hideLoading();
@@ -514,17 +582,13 @@ public class AppleLoginActivity extends AppCompatActivity {
                 });
     }
 
-    private void showInitialWelcomeConfOptions(SETUP_STATUS setupStatus) {
+    private void showInitialWelcomeConfOptions(SETUP_STATUS setupStatus, Direction direction) {
         var state = this.getUiState();
         state.setCurrentPage(PAGE.SETUP);
-        LinearLayout accountLoginContainer = this.findViewById(R.id.login_maininfo_container);
-        accountLoginContainer.setVisibility(GONE);
 
-        // TODO: make this all nice and animated...
         final UserSettings userSettings = this.getUserSettings();
 
-        LinearLayout anisetteSetupContainer = this.findViewById(R.id.login_anisette_container);
-        anisetteSetupContainer.setVisibility(VISIBLE);
+        this.showPage(R.id.login_anisette_container, direction);
 
         MaterialAutoCompleteTextView urlTextInput = findViewById(R.id.anisetteServerUrl);
 
@@ -543,7 +607,7 @@ public class AppleLoginActivity extends AppCompatActivity {
         if (this.localAnisetteStatus.state() == AnisetteStatus.State.READY) {
             // Nothing is going to ask a server for anything, so testing one would be a network
             // request whose only possible effect is to block the button below it.
-            this.setCurrentStepText(R.string.welcome);
+            this.setCurrentStepText(R.string.welcome, direction);
             this.binding.setAllowServerConfNext(true);
             return;
         }
@@ -551,9 +615,9 @@ public class AppleLoginActivity extends AppCompatActivity {
         this.testAndSaveAnisetteUrl(currentAnisetteServerSelection);
 
         if (setupStatus == SETUP_STATUS.NO_SERVER_CONFIGURED) {
-            this.setCurrentStepText(R.string.welcome);
+            this.setCurrentStepText(R.string.welcome, direction);
         } else {
-            this.setCurrentStepText(R.string.choose_your_server);
+            this.setCurrentStepText(R.string.choose_your_server, direction);
 
             this.sharedMainSettingsManager.showAnisetteTestStatus(ERROR);
             this.sharedMainSettingsManager.setAnisetteTextFieldError(
@@ -563,19 +627,10 @@ public class AppleLoginActivity extends AppCompatActivity {
         }
     }
 
-    private void showAccountLoginAuthOptions() {
-        // TODO: make this all nice and animated...
-        LinearLayout anisetteSetupContainer = this.findViewById(R.id.login_anisette_container);
-        anisetteSetupContainer.setVisibility(GONE);
+    private void showAccountLoginAuthOptions(Direction direction) {
+        this.showPage(R.id.login_maininfo_container, direction);
 
-        LinearLayout login2FAChoice = this.findViewById(R.id.login_2fa_choice);
-        login2FAChoice.setVisibility(GONE);
-
-        // main:
-        LinearLayout accountLoginContainer = this.findViewById(R.id.login_maininfo_container);
-        accountLoginContainer.setVisibility(VISIBLE);
-
-        this.setCurrentStepText(R.string.apple_account);
+        this.setCurrentStepText(R.string.apple_account, direction);
 
         TextInputEditText emailOrPhoneInput = this.findViewById(R.id.email_or_phone_input_field);
         TextInputEditText passwordInput = this.findViewById(R.id.password_input_field);
@@ -593,14 +648,13 @@ public class AppleLoginActivity extends AppCompatActivity {
         }));
     }
 
-    private void show2FACodeEntryTextbox() {
+    private void show2FACodeEntryTextbox(Direction direction) {
         this.getUiState().setCurrentPage(PAGE.ENTER_2FA_CODE);
 
         this.hideLoading();
-        this.setCurrentStepText(R.string.two_factor_authentication);
+        this.setCurrentStepText(R.string.two_factor_authentication, direction);
 
-        LinearLayout twoFACodeEntryContainer = this.findViewById(R.id.login_2fa_container);
-        twoFACodeEntryContainer.setVisibility(VISIBLE);
+        this.showPage(R.id.login_2fa_container, direction);
 
         TextView infoText = this.findViewById(R.id.twofa_sent_info_text);
         var chosenAuthMethod = this.getUiState().getChosenAuthMethod();
@@ -633,7 +687,7 @@ public class AppleLoginActivity extends AppCompatActivity {
         passwordInput.setEnabled(true);
         loginButton.setClickable(true);
 
-        this.showAccountLoginAuthOptions();
+        this.showAccountLoginAuthOptions(Direction.BACK);
     }
 
     public void onClickBackTo2FAMethodChoice(View view) {
@@ -646,7 +700,7 @@ public class AppleLoginActivity extends AppCompatActivity {
         this.twoFactorEntryManager.clear();
         final FrameLayout twoFactorErrorMessage = this.findViewById(R.id.verification_code_error_msg_container);
         twoFactorErrorMessage.setVisibility(GONE); // re-show it later if relevant...
-        this.show2FAChoiceScreen();
+        this.show2FAChoiceScreen(Direction.BACK);
     }
 
     private void on2FAAuthCodeFilled(final String authCode) {
@@ -656,8 +710,7 @@ public class AppleLoginActivity extends AppCompatActivity {
         }
 
         this.showLoading(R.string.logging_in);
-        final LinearLayout twoFACodeEntryContainer = this.findViewById(R.id.login_2fa_container);
-        twoFACodeEntryContainer.setVisibility(GONE); // for now: on error unhide
+        this.hideCurrentPage(Direction.FORWARD); // for now: on error unhide
 
         final FrameLayout twoFactorErrorMessage = this.findViewById(R.id.verification_code_error_msg_container);
         final TextView errorMessageText = this.findViewById(R.id.verification_code_error_message);
@@ -680,7 +733,7 @@ public class AppleLoginActivity extends AppCompatActivity {
 
                     Log.e(TAG, "Error during auth data retrieval and storage after 2FA success", error);
                     this.hideLoading();
-                    twoFACodeEntryContainer.setVisibility(VISIBLE);
+                    this.showPage(R.id.login_2fa_container, Direction.BACK);
                     this.twoFactorEntryManager.clear();
                     this.twoFactorAuthChoiceBackButton.setEnabled(true);
 
@@ -697,7 +750,7 @@ public class AppleLoginActivity extends AppCompatActivity {
             state.setFailed2FAAttemptCount(failedLoginAttemptCount);
 
             this.hideLoading();
-            twoFACodeEntryContainer.setVisibility(VISIBLE);
+            this.showPage(R.id.login_2fa_container, Direction.BACK);
             this.twoFactorEntryManager.clear();
             this.twoFactorAuthChoiceBackButton.setEnabled(true);
 

--- a/app/src/main/java/dev/wander/android/opentagviewer/ui/login/StepTransition.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/ui/login/StepTransition.java
@@ -1,0 +1,144 @@
+package dev.wander.android.opentagviewer.ui.login;
+
+import static android.view.View.GONE;
+import static android.view.View.VISIBLE;
+
+import android.animation.ValueAnimator;
+import android.os.Build;
+import android.util.TypedValue;
+import android.view.View;
+
+import androidx.annotation.Nullable;
+import androidx.interpolator.view.animation.LinearOutSlowInInterpolator;
+
+/**
+ * Sliding the next step of the sign-in flow in, in the direction the user is travelling.
+ *
+ * <p>The whole flow is one activity swapping visibility on sibling containers, so there is no
+ * activity or fragment transition to hang an animation off. This does it directly: the step
+ * arriving slides in from the edge it would have come from and fades up.
+ *
+ * <p><b>Only the arriving step is animated, and the one being left is hidden outright.</b> That
+ * is not a shortcut - those containers are siblings in a vertical {@code LinearLayout}, so a
+ * step still fading out still occupies its height, and the arriving one gets laid out
+ * underneath it and then jumps up the moment the old one is finally gone. Cross-fading them
+ * properly needs them stacked in a {@code FrameLayout} instead; until somebody wants that badly
+ * enough to restructure the layout, the old step going at once is the honest version.
+ *
+ * <p>It buys two other things. The flow's state is readable the instant a call returns, so no
+ * test has to wait for an animation, and there is no window in which two steps are both on
+ * screen for Espresso to catch.
+ *
+ * <p>The slide is deliberately short. These containers sit inside a {@code ScrollView} whose
+ * children are {@code match_parent}, so anything translated sideways is clipped at the parent's
+ * edge; 30dp keeps the clipped sliver under the part of the fade where it is not visible
+ * anyway. A full-width slide would look like the view was being cut in half.
+ */
+public final class StepTransition {
+
+    /**
+     * Which way the user is travelling, which is the only thing the caller has to decide.
+     *
+     * <p>{@link #NONE} is not "no preference" - it means the screen is being drawn rather than
+     * navigated, such as the first render or a restore after rotation. Animating those makes
+     * the app look like it is replaying steps the user did not take.
+     */
+    public enum Direction {
+        FORWARD,
+        BACK,
+        NONE
+    }
+
+    /** Long enough to read as movement, short enough not to sit between the user and the form. */
+    private static final long DURATION_MS = 220L;
+
+    private static final float SLIDE_DP = 30f;
+
+    private StepTransition() {}
+
+    /**
+     * Hide {@code outgoing} and show {@code incoming}, sliding the latter in.
+     *
+     * <p>Either may be null - leaving a step to show a spinner has no incoming view, and the
+     * first step of the flow has no outgoing one.
+     *
+     * <p><b>Both views are in their final state by the time this returns</b>, animation or no
+     * animation. Nothing about the flow is allowed to depend on an animation having run.
+     */
+    public static void swap(
+            @Nullable final View outgoing,
+            @Nullable final View incoming,
+            final Direction direction) {
+        if (outgoing == incoming) {
+            return;
+        }
+
+        if (outgoing != null) {
+            // At once, and not animated: see the class comment. It has to leave the layout in
+            // the same frame the next step enters it, or the next step is positioned below it.
+            outgoing.animate().cancel();
+            settle(outgoing, GONE);
+        }
+
+        if (incoming == null) {
+            return;
+        }
+
+        incoming.animate().cancel();
+        settle(incoming, VISIBLE);
+
+        if (direction != Direction.NONE && animatorsEnabled()) {
+            enter(incoming, direction);
+        }
+    }
+
+    /**
+     * Slide a view in from the edge it would have travelled from, fading up as it arrives.
+     *
+     * <p>Public because the step is not the only thing that moves: the heading above it names
+     * the step, so it travels with it. It is already on screen and stays that way - only its
+     * offset and opacity are touched - so the caller can set whatever it says beforehand and
+     * nothing has to wait for the animation to read it.
+     */
+    public static void enter(@Nullable final View view, final Direction direction) {
+        if (view == null || direction == Direction.NONE || !animatorsEnabled()) {
+            return;
+        }
+
+        final float slide = dpToPx(view, SLIDE_DP);
+
+        view.animate().cancel();
+        view.setTranslationX(direction == Direction.FORWARD ? slide : -slide);
+        view.setAlpha(0f);
+        view.animate()
+                .translationX(0f)
+                .alpha(1f)
+                .setDuration(DURATION_MS)
+                .setInterpolator(new LinearOutSlowInInterpolator())
+                .withEndAction(() -> settle(view, view.getVisibility()));
+    }
+
+    /** Put a view back where the layout expects it, at the given visibility. */
+    private static void settle(final View view, final int visibility) {
+        view.setTranslationX(0f);
+        view.setAlpha(1f);
+        view.setVisibility(visibility);
+    }
+
+    /**
+     * Whether animating is worth doing at all.
+     *
+     * <p>False when the user has turned animations off in developer or accessibility settings,
+     * and when instrumented tests run - AGP's {@code animationsDisabled} sets the same scale.
+     * The check needs API 26; below that the setting existed but was not readable, so the
+     * animation runs, which is what those versions did before this class existed.
+     */
+    private static boolean animatorsEnabled() {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.O || ValueAnimator.areAnimatorsEnabled();
+    }
+
+    private static float dpToPx(final View view, final float dp) {
+        return TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP, dp, view.getResources().getDisplayMetrics());
+    }
+}


### PR DESCRIPTION
The sign-in flow's four steps swapped visibility on sibling containers, so moving between them was a hard cut — nothing said whether you had gone forwards or back. Each step now slides in from the edge it would have travelled from and fades up, and the heading that names the step travels with it rather than switching underneath.

### Only the arriving step animates

Not a shortcut. The step containers are siblings in a vertical `LinearLayout`, so a step still fading out still occupies its height — the arriving one gets laid out *below* it and then jumps into place when the old one finally goes. That reads as a snapping bug, not as a fade. Cross-fading them properly needs them stacked in a `FrameLayout`, which is a bigger change than this is worth; the step leaving at once is the honest version.

It buys determinism too: there is no window in which two steps are both on screen for a test to catch.

### Also in here

Showing a step is now `showPage(id, direction)` rather than six `setVisibility` calls spread over the file, each of which had to remember to hide all the others.

### Two things asserted rather than assumed

**Settings → Accessibility → Remove animations is honoured** — the flow stops moving entirely rather than moving quickly, which is the point of that setting. Forced through the same global scale the setting writes, because a claim in a comment is not a guarantee.

**`testOptions.animationsDisabled` does not disable animators.** It passes `--no-window-animation` to `am instrument`, which zeroes the window and transition scales and leaves `animator_duration_scale` — the one `ViewPropertyAnimator` obeys — exactly as the device had it. So these animations run for real under Espresso. Nothing depends on that: every visibility, offset and alpha is at its final value before the call returns. `AGENTS.md` now records it, along with the related trap that the scale is a global no test may *read* to decide what it expects — by the time this suite reaches any one class, something earlier has already turned animators off.

### Verified

- `:app:testEmulatorDebugAndroidTest` — 123 tests, all passing (5 skipped, the usual network-dependent Anisette ones). That includes the login flow tests, which drive every one of these transitions.
- 8 new tests in `StepTransitionTest` covering direction, the accessibility setting, and the final-state guarantee.
- Looked at on a device by @parawanderer, which is how the snap was found.

---
*This PR description was written by Claude Code.*