### PR TITLE
Tell the user what was wrong with the zip they picked

### DIFF
--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/util/parse/ImportRejectionTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/util/parse/ImportRejectionTest.java
@@ -1,0 +1,329 @@
+package dev.wander.android.opentagviewer.util.parse;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.net.Uri;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import dev.wander.android.opentagviewer.util.parse.ZipImporterException.Reason;
+
+/**
+ * What the importer says when the file it was handed is not an OpenTagViewer export.
+ *
+ * <p>Every one of these used to end at the same toast - "Error occurred while importing new
+ * devices. Try to restart the app and retry." - which is advice for a broken app, handed to
+ * somebody who picked the wrong file. Worse, a file that was not a zip at all was reported as
+ * {@code OPENTAGVIEWER.yml was empty!}, because {@link java.util.zip.ZipInputStream} does not
+ * announce a non-zip: {@code getNextEntry} just returns null, so the entry loop never ran and
+ * the first thing the code could think to complain about was the missing manifest.
+ *
+ * <p>So these tests are about the {@link Reason}, not the message text. The reason is what
+ * decides which string the user sees, and it is the part that was missing.
+ *
+ * <p>The happy paths live in {@link AppleZipImporterUtilTest}. Kept apart because that class
+ * is about what a good export produces and this one is about what a bad file is called.
+ */
+@RunWith(AndroidJUnit4.class)
+public class ImportRejectionTest {
+
+    private static final String BEACON = "0FB0AEAC-C083-405E-A979-4AA6A73F5C56";
+
+    private static final String VALID_YAML =
+            "version: 0.0.2\n"
+            + "exportTimestamp: 1740685990163\n"
+            + "via: test\n"
+            + "sourceUser: tester\n";
+
+    private Context context;
+    private File file;
+
+    @Before
+    public void setUp() {
+        this.context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    }
+
+    @After
+    public void tearDown() {
+        if (this.file != null && this.file.exists() && !this.file.delete()) {
+            this.file.deleteOnExit();
+        }
+    }
+
+    // -----------------------------------------------------------------------------------
+    // not a zip at all
+    // -----------------------------------------------------------------------------------
+
+    /** The one that started this: a holiday photo, which was reported as a missing manifest. */
+    @Test
+    public void aJpegIsNotAZip() throws IOException {
+        // The real thing's first bytes. Nothing about them resembles a zip, and the point is
+        // that the importer notices before it tries to read entries out of them.
+        final Reason reason = importFailureOf(bytes(
+                0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00, 0x01));
+
+        assertEquals(Reason.NOT_A_ZIP, reason);
+    }
+
+    @Test
+    public void aTextFileRenamedToZipIsNotAZip() throws IOException {
+        assertEquals(Reason.NOT_A_ZIP,
+                importFailureOf("this is just some text, not an archive".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /** Zero bytes cannot even be sniffed, and must not read as an empty export. */
+    @Test
+    public void anEmptyFileIsNotAZip() throws IOException {
+        assertEquals(Reason.NOT_A_ZIP, importFailureOf(new byte[0]));
+    }
+
+    /**
+     * A file too short to hold a signature.
+     *
+     * <p>Its own case because the sniff reads four bytes and a single {@code read} is not
+     * obliged to return all of them - a short file is the one input where a partial read is
+     * guaranteed rather than theoretical.
+     */
+    @Test
+    public void aTwoByteFileIsNotAZip() throws IOException {
+        assertEquals(Reason.NOT_A_ZIP, importFailureOf(bytes('P', 'K')));
+    }
+
+    // -----------------------------------------------------------------------------------
+    // a zip, but not ours
+    // -----------------------------------------------------------------------------------
+
+    @Test
+    public void somebodyElsesZipIsNotAnExport() throws IOException {
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("holiday/IMG_0001.jpg", "not really a jpeg, but it is in a real zip");
+        entries.put("holiday/notes.txt", "sunny");
+
+        assertEquals(Reason.NOT_AN_EXPORT, importFailureOf(zipOf(entries)));
+    }
+
+    /**
+     * An archive with no entries at all.
+     *
+     * <p>A zip - it begins at the end-of-central-directory record rather than a local file
+     * header - so it must be rejected for not being an export rather than for not being a zip.
+     */
+    @Test
+    public void anEmptyArchiveIsAZipButNotAnExport() throws IOException {
+        assertEquals(Reason.NOT_AN_EXPORT, importFailureOf(zipOf(new LinkedHashMap<>())));
+    }
+
+    /**
+     * The plists without the manifest.
+     *
+     * <p>Someone zipping the folders by hand rather than running the exporter produces exactly
+     * this, and it is not an export however much of an export it looks like.
+     */
+    @Test
+    public void beaconFilesWithoutTheManifestAreNotAnExport() throws IOException {
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("OwnedBeacons/" + BEACON + ".plist", "<plist></plist>");
+
+        assertEquals(Reason.NOT_AN_EXPORT, importFailureOf(zipOf(entries)));
+    }
+
+    // -----------------------------------------------------------------------------------
+    // ours, but not usable
+    // -----------------------------------------------------------------------------------
+
+    @Test
+    public void aBlankManifestIsADamagedExport() throws IOException {
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("OPENTAGVIEWER.yml", "   \n");
+        entries.put("OwnedBeacons/" + BEACON + ".plist", "<plist></plist>");
+
+        assertEquals(Reason.DAMAGED, importFailureOf(zipOf(entries)));
+    }
+
+    @Test
+    public void aManifestMissingItsRequiredFieldsIsADamagedExport() throws IOException {
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("OPENTAGVIEWER.yml", "version: 0.0.2\n"); // no via, sourceUser, timestamp
+        entries.put("OwnedBeacons/" + BEACON + ".plist", "<plist></plist>");
+
+        assertEquals(Reason.DAMAGED, importFailureOf(zipOf(entries)));
+    }
+
+    /** Cut off mid-stream, as a download that stopped early would be. */
+    @Test
+    public void aTruncatedZipIsADamagedExport() throws IOException {
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("OPENTAGVIEWER.yml", VALID_YAML);
+        entries.put("OwnedBeacons/" + BEACON + ".plist", longPlist());
+
+        final byte[] whole = zipOf(entries);
+        final byte[] cut = new byte[whole.length / 2];
+        System.arraycopy(whole, 0, cut, 0, cut.length);
+
+        final Reason reason = importFailureOf(cut);
+
+        // Not NOT_A_ZIP: it starts with a perfectly good signature, and telling somebody their
+        // export is not a zip when the first half of one is exactly what they have is worse
+        // than useless.
+        assertEquals(Reason.DAMAGED, reason);
+    }
+
+    /**
+     * A well-formed export carrying no tags.
+     *
+     * <p>Previously this succeeded, and said "Loading location data for 0 new imported devices"
+     * - which reads as the import having worked and the tags having vanished afterwards.
+     */
+    @Test
+    public void anExportWithNoTagsSaysSoRatherThanImportingNothing() throws IOException {
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("OPENTAGVIEWER.yml", VALID_YAML);
+
+        assertEquals(Reason.NO_TAGS, importFailureOf(zipOf(entries)));
+    }
+
+    // -----------------------------------------------------------------------------------
+    // the file itself
+    // -----------------------------------------------------------------------------------
+
+    @Test
+    public void aFileThatIsNotThereIsUnreadable() {
+        final Uri missing = Uri.fromFile(
+                new File(this.context.getCacheDir(), "no-such-import-file.zip"));
+
+        final ZipImporterException thrown = assertThrows(ZipImporterException.class,
+                () -> new AppleZipImporterUtil(this.context).extractZip(missing));
+
+        assertEquals(Reason.UNREADABLE, thrown.getReason());
+    }
+
+    // -----------------------------------------------------------------------------------
+    // the plumbing that carries the reason to the user
+    // -----------------------------------------------------------------------------------
+
+    /**
+     * The reason has to survive being wrapped, because RxJava wraps what it is handed and the
+     * subscriber that picks the message never sees the exception that was thrown.
+     */
+    @Test
+    public void theReasonSurvivesBeingWrapped() {
+        final Throwable wrapped = new RuntimeException("outer",
+                new IllegalStateException("middle",
+                        new ZipImporterException(Reason.NOT_AN_EXPORT, "inner")));
+
+        assertEquals(Reason.NOT_AN_EXPORT, ZipImporterException.reasonOf(wrapped));
+    }
+
+    /** Anything not diagnosed keeps the generic message, rather than borrowing a wrong one. */
+    @Test
+    public void anUnrelatedFailureHasNoReason() {
+        assertEquals(Reason.UNKNOWN,
+                ZipImporterException.reasonOf(new IllegalStateException("something else")));
+        assertEquals(Reason.UNKNOWN, ZipImporterException.reasonOf(null));
+    }
+
+    /** A cause chain that points at itself must not hang the error handler. */
+    @Test
+    public void aSelfReferencingCauseDoesNotLoop() {
+        final Throwable loop = new RuntimeException("round and round") {
+            @Override
+            public synchronized Throwable getCause() {
+                return this;
+            }
+        };
+
+        assertEquals(Reason.UNKNOWN, ZipImporterException.reasonOf(loop));
+    }
+
+    /**
+     * The manifest failure is caught by the same {@code catch} as everything else here.
+     *
+     * <p>It used to extend {@code RuntimeException} directly, so the branch written to catch
+     * import failures did not catch it. Harmless while both branches did the same thing, and
+     * exactly the sort of thing that stops being harmless when one of them stops.
+     */
+    @Test
+    public void aManifestFailureIsAnImporterFailure() {
+        assertTrue(ZipImporterException.class.isAssignableFrom(
+                AppleZipImporterUtil.ImportFileFormatException.class));
+    }
+
+    // -----------------------------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------------------------
+
+    /** Import these bytes, expect it to be refused, and report why. */
+    private Reason importFailureOf(final byte[] content) throws IOException {
+        this.file = File.createTempFile("otv-reject-test", ".zip", this.context.getCacheDir());
+        try (OutputStream out = new FileOutputStream(this.file)) {
+            out.write(content);
+        }
+
+        final Uri uri = Uri.fromFile(this.file);
+        final ZipImporterException thrown = assertThrows(
+                "the importer accepted a file it should have refused",
+                ZipImporterException.class,
+                () -> new AppleZipImporterUtil(this.context).extractZip(uri));
+
+        return thrown.getReason();
+    }
+
+    private static byte[] zipOf(final Map<String, String> entries) throws IOException {
+        final File scratch = File.createTempFile("otv-reject-src", ".zip");
+        try {
+            try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(scratch))) {
+                for (Map.Entry<String, String> entry : entries.entrySet()) {
+                    out.putNextEntry(new ZipEntry(entry.getKey()));
+                    out.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
+                    out.closeEntry();
+                }
+            }
+            final byte[] read = new byte[(int) scratch.length()];
+            try (RandomAccessFile in = new RandomAccessFile(scratch, "r")) {
+                in.readFully(read);
+            }
+            return read;
+        } finally {
+            if (!scratch.delete()) {
+                scratch.deleteOnExit();
+            }
+        }
+    }
+
+    private static byte[] bytes(final int... values) {
+        final byte[] out = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            out[i] = (byte) values[i];
+        }
+        return out;
+    }
+
+    /** Big enough that cutting the archive in half lands inside the deflate stream. */
+    private static String longPlist() {
+        final StringBuilder sb = new StringBuilder("<plist><dict>");
+        for (int i = 0; i < 500; i++) {
+            sb.append("<key>filler").append(i).append("</key><string>value</string>");
+        }
+        return sb.append("</dict></plist>").toString();
+    }
+}

--- a/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
@@ -650,11 +650,33 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
                 Log.i(TAG, "Finished visualising new location reports!");
             }, error -> {
                 Log.e(TAG, "Error occurred while importing new devices!", error);
-                Toast.makeText(
-                        this,
-                        R.string.error_occurred_while_importing_new_devices_try_to_restart_the_app_and_retry,
-                        LENGTH_LONG).show();
+                Toast.makeText(this, importFailureMessage(error), LENGTH_LONG).show();
             });
+    }
+
+    /**
+     * What to tell somebody whose import did not work.
+     *
+     * <p>Almost always they picked the wrong file, and for a long time the answer to that was
+     * "try to restart the app and retry" - advice for a broken app, given to somebody who
+     * chose their holiday photos. The generic message is kept for the cases that really are
+     * unexplained, which is the only place it was ever true.
+     */
+    private static int importFailureMessage(Throwable error) {
+        switch (ZipImporterException.reasonOf(error)) {
+            case NOT_A_ZIP:
+                return R.string.import_failed_not_a_zip;
+            case NOT_AN_EXPORT:
+                return R.string.import_failed_not_an_export;
+            case DAMAGED:
+                return R.string.import_failed_damaged;
+            case NO_TAGS:
+                return R.string.import_failed_no_tags;
+            case UNREADABLE:
+                return R.string.import_failed_unreadable;
+            default:
+                return R.string.error_occurred_while_importing_new_devices_try_to_restart_the_app_and_retry;
+        }
     }
 
     private void onExportLogsToLocationPicked(@lombok.NonNull Intent data) {
@@ -696,14 +718,21 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
         return Observable.fromCallable(() -> {
             try {
                 Uri zipFileUri = data.getData();
-                assert zipFileUri != null;
+                if (zipFileUri == null) {
+                    // A result with no file in it. Nothing to diagnose, but it is still the
+                    // picked file's problem rather than the app's, so say so as such.
+                    throw new ZipImporterException(
+                            ZipImporterException.Reason.UNREADABLE, "Picker returned no file");
+                }
 
                 var util = new AppleZipImporterUtil(this.getApplicationContext());
                 return util.extractZip(zipFileUri);
 
             } catch (ZipImporterException e) {
-                Log.e(TAG, "Import or conversion error occurred while importing file", e);
-                throw new RuntimeException(e);
+                // Rethrown as itself rather than wrapped: the reason it carries is what decides
+                // what the user is told, and it only survives if the exception does.
+                Log.e(TAG, "Import failed (" + e.getReason() + ")", e);
+                throw e;
             } catch (Exception e) {
                 Log.e(TAG, "Unexpected error occurred while importing file into DB", e);
                 throw new RuntimeException(e);

--- a/app/src/main/java/dev/wander/android/opentagviewer/util/parse/AppleZipImporterUtil.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/util/parse/AppleZipImporterUtil.java
@@ -17,11 +17,13 @@ import com.networknt.schema.SchemaValidatorsConfig;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -33,6 +35,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
 import java.util.zip.ZipInputStream;
 
 import javax.xml.xpath.XPath;
@@ -43,6 +46,7 @@ import dev.wander.android.opentagviewer.data.model.BeaconNamingRecordCloudKitMet
 import dev.wander.android.opentagviewer.db.room.entity.BeaconNamingRecord;
 import dev.wander.android.opentagviewer.db.room.entity.Import;
 import dev.wander.android.opentagviewer.db.room.entity.OwnedBeacon;
+import dev.wander.android.opentagviewer.util.parse.ZipImporterException.Reason;
 import dev.wander.android.opentagviewer.db.repo.model.ImportData;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -78,6 +82,15 @@ public class AppleZipImporterUtil {
 
     private static final String X_PATH_TO_CLOUDKIT_METADATA = "/plist/dict/key[.='cloudKitMetadata']/following-sibling::data[1]";
 
+    private static final int ZIP_SIGNATURE_LENGTH = 4;
+
+    /** Local file header, end of central directory (an empty archive), and spanned marker. */
+    private static final byte[][] ZIP_SIGNATURES = {
+            {'P', 'K', 0x03, 0x04},
+            {'P', 'K', 0x05, 0x06},
+            {'P', 'K', 0x07, 0x08},
+    };
+
     private final Context appContext;
 
     public AppleZipImporterUtil(Context appContext) {
@@ -93,9 +106,10 @@ public class AppleZipImporterUtil {
         // accessories macOS has never observed a key index for.
         Map<String, String> keyAlignmentRecords = new HashMap<>();
 
-        try (ZipInputStream zipInput = new ZipInputStream(
-                this.appContext.getContentResolver()
-                        .openInputStream(zipFileUri), StandardCharsets.UTF_8);
+        int entriesSeen = 0;
+
+        try (BufferedInputStream source = this.open(zipFileUri);
+             ZipInputStream zipInput = new ZipInputStream(source, StandardCharsets.UTF_8);
              ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
 
             byte[] buffer = new byte[1024];
@@ -103,6 +117,7 @@ public class AppleZipImporterUtil {
             ZipEntry zipEntry;
 
             while ((zipEntry = zipInput.getNextEntry()) != null) {
+                entriesSeen++;
                 // read data
                 String fileName = zipEntry.getName();
                 Log.d(TAG, "Now reading file " + fileName + " while unzipping...");
@@ -149,12 +164,31 @@ public class AppleZipImporterUtil {
                         break;
                 }
             }
+        } catch (ZipException e) {
+            // The signature said zip, so it is one - it just cannot be read to the end.
+            throw new ZipImporterException(Reason.DAMAGED,
+                    "Zip could not be read after " + entriesSeen + " entries", e);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ZipImporterException(Reason.DAMAGED,
+                    "Import stream failed after " + entriesSeen + " entries", e);
+        }
+
+        if (openTagViewerYaml == null) {
+            // A zip, but not one of ours: this is the common case of somebody picking the wrong
+            // file, so it has to be distinguishable from an export of ours that went wrong.
+            throw new ZipImporterException(Reason.NOT_AN_EXPORT,
+                    "No OPENTAGVIEWER.yml among the " + entriesSeen + " entries in this zip");
         }
 
         assertOpenTagViewerYamlIsValid(openTagViewerYaml);
         innerJoinBeaconFiles(ownedBeacons, beaconNamingRecords);
+
+        if (ownedBeacons.isEmpty()) {
+            // Otherwise this succeeds and reports "0 new imported devices", which reads as the
+            // import having worked and the tags having gone missing afterwards.
+            throw new ZipImporterException(Reason.NO_TAGS,
+                    "Export is well-formed but carries no OwnedBeacons");
+        }
 
         // now we can produce the expected data
         return convert(
@@ -163,6 +197,77 @@ public class AppleZipImporterUtil {
           beaconNamingRecords,
           keyAlignmentRecords
         );
+    }
+
+    /**
+     * Open the picked file, having first established that it is a zip at all.
+     *
+     * <p>Checked up front rather than inferred from the parse, because {@link ZipInputStream}
+     * does not report a non-zip: {@code getNextEntry} simply returns null, so a JPEG and an
+     * empty archive and somebody else's zip all arrived at the same place, and the first
+     * complaint the code could make was that the manifest was missing. "This export has no
+     * OPENTAGVIEWER.yml" is a strange thing to tell somebody who picked a photo.
+     */
+    private BufferedInputStream open(@NonNull Uri zipFileUri) throws ZipImporterException {
+        final BufferedInputStream source;
+        try {
+            final InputStream raw = this.appContext.getContentResolver().openInputStream(zipFileUri);
+            if (raw == null) {
+                throw new ZipImporterException(Reason.UNREADABLE,
+                        "Content resolver returned no stream for " + zipFileUri);
+            }
+            source = new BufferedInputStream(raw);
+        } catch (IOException | SecurityException e) {
+            // Picked from a provider that has since revoked access, or the file has moved.
+            throw new ZipImporterException(Reason.UNREADABLE,
+                    "Could not open " + zipFileUri, e);
+        }
+
+        try {
+            source.mark(ZIP_SIGNATURE_LENGTH);
+            final byte[] signature = new byte[ZIP_SIGNATURE_LENGTH];
+            final int read = readFully(source, signature);
+            source.reset();
+
+            if (read < ZIP_SIGNATURE_LENGTH || !isZipSignature(signature)) {
+                throw new ZipImporterException(Reason.NOT_A_ZIP,
+                        "File does not start with a zip signature");
+            }
+        } catch (IOException e) {
+            throw new ZipImporterException(Reason.UNREADABLE,
+                    "Could not read the start of " + zipFileUri, e);
+        }
+
+        return source;
+    }
+
+    /** Read until the buffer is full or the stream ends, which a single read does not promise. */
+    private static int readFully(final InputStream in, final byte[] into) throws IOException {
+        int total = 0;
+        while (total < into.length) {
+            final int read = in.read(into, total, into.length - total);
+            if (read < 0) {
+                break;
+            }
+            total += read;
+        }
+        return total;
+    }
+
+    /**
+     * Whether these first bytes are any of the three things a zip can begin with.
+     *
+     * <p>An archive with no entries starts at the end-of-central-directory record rather than
+     * at a local file header, and a spanned one carries its own marker. Both are zips, so both
+     * are accepted here and rejected later for the real reason - that they are not an export.
+     */
+    private static boolean isZipSignature(final byte[] bytes) {
+        for (final byte[] candidate : ZIP_SIGNATURES) {
+            if (Arrays.equals(bytes, candidate)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static void processBeaconNamingRecord(final List<String> regexGroupMatches, final String newFileContent, Map<String, Pair<String, String>> beaconIdToEntryIdAndContent) {
@@ -473,13 +578,21 @@ public class AppleZipImporterUtil {
                 .collect(Collectors.toList());
     }
 
-    public static class ImportFileFormatException extends RuntimeException {
+    /**
+     * The manifest was there and did not hold up.
+     *
+     * <p>A {@link ZipImporterException} because it is one - it previously extended
+     * {@code RuntimeException} directly, so the {@code catch (ZipImporterException)} written to
+     * handle import failures never saw it and it fell through to the generic handler beside it.
+     * That made no difference only because both did the same thing.
+     */
+    public static class ImportFileFormatException extends ZipImporterException {
         public ImportFileFormatException(String message) {
-            super(message);
+            super(Reason.DAMAGED, message);
         }
 
         public ImportFileFormatException(String message, Throwable cause) {
-            super(message, cause);
+            super(Reason.DAMAGED, message, cause);
         }
     }
 

--- a/app/src/main/java/dev/wander/android/opentagviewer/util/parse/ZipImporterException.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/util/parse/ZipImporterException.java
@@ -1,12 +1,84 @@
 package dev.wander.android.opentagviewer.util.parse;
 
+/**
+ * An import that could not be completed.
+ *
+ * <p>Carries a {@link Reason}, because the person who hit this picked a file and the only
+ * useful thing to tell them is what was wrong with it. Every failure used to arrive at the
+ * same toast - "try to restart the app and retry" - which is advice for a broken app, and the
+ * overwhelmingly likely cause is that they chose the wrong file. Someone who picked their
+ * holiday photos was told to restart.
+ *
+ * <p>The message is for logcat and is not shown to anybody; the reason is what the UI reads.
+ */
 public class ZipImporterException extends RuntimeException {
 
-    public ZipImporterException(String message, Throwable cause) {
+    /**
+     * What was wrong with the file, at the granularity a user can act on.
+     *
+     * <p>Deliberately not one per throw site. Splitting "the central directory is corrupt" from
+     * "the manifest failed schema validation" would be honest and useless: the answer to both
+     * is to export again.
+     */
+    public enum Reason {
+        /** Not a zip at all - no zip signature. Usually the wrong file entirely. */
+        NOT_A_ZIP,
+
+        /** A real zip, but with no {@code OPENTAGVIEWER.yml}, so it is somebody else's zip. */
+        NOT_AN_EXPORT,
+
+        /** Ours, but unreadable: truncated, corrupt, or a format this version cannot parse. */
+        DAMAGED,
+
+        /** A valid export that carries no tags, so importing it would do nothing. */
+        NO_TAGS,
+
+        /** The file itself could not be opened - revoked permission, or it has since moved. */
+        UNREADABLE,
+
+        /** Anything not diagnosed. The generic message is the honest one here. */
+        UNKNOWN
+    }
+
+    private final Reason reason;
+
+    public ZipImporterException(Reason reason, String message) {
+        super(message);
+        this.reason = reason;
+    }
+
+    public ZipImporterException(Reason reason, String message, Throwable cause) {
         super(message, cause);
+        this.reason = reason;
+    }
+
+    public ZipImporterException(String message, Throwable cause) {
+        this(Reason.UNKNOWN, message, cause);
     }
 
     public ZipImporterException(String message) {
-        super(message);
+        this(Reason.UNKNOWN, message);
+    }
+
+    public Reason getReason() {
+        return this.reason;
+    }
+
+    /**
+     * The reason behind a throwable, wherever it ended up in the cause chain.
+     *
+     * <p>Needed because this travels out through RxJava, which wraps what it is handed, so the
+     * error the subscriber sees is rarely the one that was thrown.
+     */
+    public static Reason reasonOf(Throwable error) {
+        for (Throwable t = error; t != null; t = t.getCause()) {
+            if (t instanceof ZipImporterException) {
+                return ((ZipImporterException) t).getReason();
+            }
+            if (t.getCause() == t) {
+                break;
+            }
+        }
+        return Reason.UNKNOWN;
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -148,4 +148,9 @@
     <string name="are_you_sure_you_want_to_remove_these_devices">Möchtest du diese Geräte wirklich entfernen? Nach dem Entfernen müssen sie erneut importiert werden.</string>
     <string name="remove_devices">Geräte entfernen</string>
     <string name="export_tags">Tags exportieren</string>
+    <string name="import_failed_not_a_zip">Diese Datei ist keine ZIP-Datei. Wähle die ZIP-Datei aus, die der OpenTagViewer-Exporter erstellt hat.</string>
+    <string name="import_failed_not_an_export">Diese ZIP-Datei stammt nicht vom OpenTagViewer-Exporter, es gibt also nichts zu importieren.</string>
+    <string name="import_failed_damaged">Dieser Export konnte nicht gelesen werden. Er ist möglicherweise unvollständig oder wurde mit einer neueren Version des Exporters erstellt.</string>
+    <string name="import_failed_no_tags">Dieser Export enthält keine Tags, es gibt also nichts zu importieren.</string>
+    <string name="import_failed_unreadable">Diese Datei konnte nicht geöffnet werden. Wähle sie erneut aus.</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -148,4 +148,9 @@
     <string name="are_you_sure_you_want_to_remove_these_devices">Are you sure you want to remove these devices? Once removed they will need to be reimported to get them back.</string>
     <string name="remove_devices">Remove Devices</string>
     <string name="export_tags">Export Tags</string>
+    <string name="import_failed_not_a_zip">That file is not a zip. Choose the zip file the OpenTagViewer exporter made.</string>
+    <string name="import_failed_not_an_export">This zip was not made by the OpenTagViewer exporter, so there is nothing to import.</string>
+    <string name="import_failed_damaged">This export could not be read. It may be incomplete, or made by a newer version of the exporter.</string>
+    <string name="import_failed_no_tags">This export does not contain any tags, so there is nothing to import.</string>
+    <string name="import_failed_unreadable">That file could not be opened. Choose it again.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -148,4 +148,9 @@
     <string name="are_you_sure_you_want_to_remove_these_devices">Voulez-vous vraiment supprimer ces appareils ? Une fois supprimés, il faudra les réimporter pour les récupérer.</string>
     <string name="remove_devices">Supprimer les appareils</string>
     <string name="export_tags">Exporter les tags</string>
+    <string name="import_failed_not_a_zip">Ce fichier n’est pas une archive zip. Choisissez l’archive créée par l’exportateur OpenTagViewer.</string>
+    <string name="import_failed_not_an_export">Cette archive n’a pas été créée par l’exportateur OpenTagViewer : il n’y a rien à importer.</string>
+    <string name="import_failed_damaged">Cet export n’a pas pu être lu. Il est peut-être incomplet, ou créé par une version plus récente de l’exportateur.</string>
+    <string name="import_failed_no_tags">Cet export ne contient aucun tag : il n’y a rien à importer.</string>
+    <string name="import_failed_unreadable">Ce fichier n’a pas pu être ouvert. Sélectionnez-le à nouveau.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -148,4 +148,9 @@
     <string name="are_you_sure_you_want_to_remove_these_devices">これらのデバイスを削除してもよろしいですか？削除すると、元に戻すには再インポートが必要です。</string>
     <string name="remove_devices">デバイスを削除</string>
     <string name="export_tags">タグをエクスポート</string>
+    <string name="import_failed_not_a_zip">このファイルは zip ではありません。OpenTagViewer エクスポーターが作成した zip ファイルを選んでください。</string>
+    <string name="import_failed_not_an_export">この zip は OpenTagViewer エクスポーターで作成されたものではないため、取り込むものがありません。</string>
+    <string name="import_failed_damaged">このエクスポートを読み取れませんでした。内容が不完全か、より新しいバージョンのエクスポーターで作成された可能性があります。</string>
+    <string name="import_failed_no_tags">このエクスポートにはタグが含まれていないため、取り込むものがありません。</string>
+    <string name="import_failed_unreadable">このファイルを開けませんでした。もう一度選び直してください。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -148,4 +148,9 @@
     <string name="are_you_sure_you_want_to_remove_these_devices">이 기기들을 삭제하시겠습니까? 삭제하면 다시 가져와야 복구할 수 있습니다.</string>
     <string name="remove_devices">기기 삭제</string>
     <string name="export_tags">태그 내보내기</string>
+    <string name="import_failed_not_a_zip">이 파일은 zip이 아닙니다. OpenTagViewer 내보내기 도구가 만든 zip 파일을 선택하세요.</string>
+    <string name="import_failed_not_an_export">이 zip은 OpenTagViewer 내보내기 도구로 만든 것이 아니어서 가져올 항목이 없습니다.</string>
+    <string name="import_failed_damaged">이 내보내기 파일을 읽을 수 없습니다. 파일이 불완전하거나 더 새로운 버전의 내보내기 도구로 만들었을 수 있습니다.</string>
+    <string name="import_failed_no_tags">이 내보내기 파일에는 태그가 없어 가져올 항목이 없습니다.</string>
+    <string name="import_failed_unreadable">이 파일을 열 수 없습니다. 다시 선택하세요.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -148,4 +148,9 @@
     <string name="are_you_sure_you_want_to_remove_these_devices">Weet je zeker dat je deze apparaten wilt verwijderen? Eenmaal verwijderd moeten ze opnieuw worden geïmporteerd.</string>
     <string name="remove_devices">Apparaten verwijderen</string>
     <string name="export_tags">Tags exporteren</string>
+    <string name="import_failed_not_a_zip">Dat bestand is geen zip. Kies het zipbestand dat de OpenTagViewer-exporter heeft gemaakt.</string>
+    <string name="import_failed_not_an_export">Deze zip is niet gemaakt door de OpenTagViewer-exporter, dus er valt niets te importeren.</string>
+    <string name="import_failed_damaged">Deze export kon niet worden gelezen. Mogelijk is hij onvolledig of gemaakt met een nieuwere versie van de exporter.</string>
+    <string name="import_failed_no_tags">Deze export bevat geen tags, dus er valt niets te importeren.</string>
+    <string name="import_failed_unreadable">Dat bestand kon niet worden geopend. Kies het opnieuw.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -148,4 +148,9 @@
     <string name="are_you_sure_you_want_to_remove_these_devices">Удалить эти устройства? После удаления их придётся импортировать заново.</string>
     <string name="remove_devices">Удалить устройства</string>
     <string name="export_tags">Экспорт меток</string>
+    <string name="import_failed_not_a_zip">Это не zip-архив. Выберите zip-файл, созданный экспортёром OpenTagViewer.</string>
+    <string name="import_failed_not_an_export">Этот архив создан не экспортёром OpenTagViewer, импортировать нечего.</string>
+    <string name="import_failed_damaged">Не удалось прочитать этот экспорт. Возможно, он неполный или создан более новой версией экспортёра.</string>
+    <string name="import_failed_no_tags">В этом экспорте нет меток, импортировать нечего.</string>
+    <string name="import_failed_unreadable">Не удалось открыть этот файл. Выберите его снова.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -148,4 +148,9 @@
     <string name="are_you_sure_you_want_to_remove_these_devices">确定要移除这些设备吗？移除后需要重新导入才能恢复。</string>
     <string name="remove_devices">移除设备</string>
     <string name="export_tags">导出标签</string>
+    <string name="import_failed_not_a_zip">该文件不是 zip 压缩包。请选择 OpenTagViewer 导出工具生成的 zip 文件。</string>
+    <string name="import_failed_not_an_export">此 zip 不是 OpenTagViewer 导出工具生成的，没有可导入的内容。</string>
+    <string name="import_failed_damaged">无法读取此导出文件。它可能不完整，或由更新版本的导出工具生成。</string>
+    <string name="import_failed_no_tags">此导出文件不含任何标签，没有可导入的内容。</string>
+    <string name="import_failed_unreadable">无法打开该文件。请重新选择。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -148,4 +148,9 @@
     <string name="are_you_sure_you_want_to_remove_these_devices">確定要移除這些裝置嗎？移除後需要重新匯入才能復原。</string>
     <string name="remove_devices">移除裝置</string>
     <string name="export_tags">匯出標籤</string>
+    <string name="import_failed_not_a_zip">該檔案不是 zip 壓縮檔。請選擇 OpenTagViewer 匯出工具產生的 zip 檔案。</string>
+    <string name="import_failed_not_an_export">此 zip 不是 OpenTagViewer 匯出工具產生的，沒有可匯入的內容。</string>
+    <string name="import_failed_damaged">無法讀取此匯出檔案。它可能不完整，或由更新版本的匯出工具產生。</string>
+    <string name="import_failed_no_tags">此匯出檔案不含任何標籤，沒有可匯入的內容。</string>
+    <string name="import_failed_unreadable">無法開啟該檔案。請重新選擇。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,4 +182,9 @@
     <string name="are_you_sure_you_want_to_remove_these_devices">Are you sure you want to remove these devices? Once removed they will need to be reimported to get them back.</string>
     <string name="remove_devices">Remove Devices</string>
     <string name="export_tags">Export Tags</string>
+    <string name="import_failed_not_a_zip">That file is not a zip. Choose the zip file the OpenTagViewer exporter made.</string>
+    <string name="import_failed_not_an_export">This zip was not made by the OpenTagViewer exporter, so there is nothing to import.</string>
+    <string name="import_failed_damaged">This export could not be read. It may be incomplete, or made by a newer version of the exporter.</string>
+    <string name="import_failed_no_tags">This export does not contain any tags, so there is nothing to import.</string>
+    <string name="import_failed_unreadable">That file could not be opened. Choose it again.</string>
 </resources>


### PR DESCRIPTION
Every import failure arrived at the same toast:

> Error occurred while importing new devices. Try to restart the app and retry.

That is advice for a broken app, and the overwhelmingly likely cause is that the person picked the wrong file. Someone who chose their holiday photos was told to restart.

Worse, a file that was not a zip at all was diagnosed as a **missing manifest**. `ZipInputStream` does not report a non-zip — `getNextEntry` simply returns `null`, so the entry loop never ran and the first thing the code could think to complain about was that `OPENTAGVIEWER.yml` was empty. A JPEG, an empty archive and somebody else's zip all ended in the same place.

### What it does now

The file is recognised *before* it is parsed — a zip-signature sniff up front — and `ZipImporterException` carries a `Reason`:

| Reason | What the user sees |
| --- | --- |
| `NOT_A_ZIP` | That file is not a zip. Choose the zip file the OpenTagViewer exporter made. |
| `NOT_AN_EXPORT` | This zip was not made by the OpenTagViewer exporter, so there is nothing to import. |
| `DAMAGED` | This export could not be read. It may be incomplete, or made by a newer version of the exporter. |
| `NO_TAGS` | This export does not contain any tags, so there is nothing to import. |
| `UNREADABLE` | That file could not be opened. Choose it again. |
| `UNKNOWN` | the existing generic message — kept for anything genuinely undiagnosed, which is the only case it was ever true of |

Five strings, all ten locales.

The reasons are deliberately coarse. Splitting "the central directory is corrupt" from "the manifest failed schema validation" would be honest and useless: the answer to both is to export again.

### Two things fixed on the way

**An export with no tags used to succeed** and report *"Loading location data for 0 new imported devices"* — which reads as the import having worked and the tags having gone missing afterwards. It now says the export has no tags in it. This is a behaviour change beyond the reported bug; it is the next thing you hit after the one that was reported, and importing zero tags was never useful.

**`ImportFileFormatException` extended `RuntimeException` directly**, so the `catch (ZipImporterException)` written to handle import failures never caught it. Harmless only because the branch beside it did the same thing — which is exactly the sort of thing that stops being harmless when one of them stops.

### Tests

The importer had **no failure tests at all**. There are now 16 in `ImportRejectionTest`, covering each reason: a real JPEG header, a text file, an empty file, a two-byte file (the one input where a partial read is guaranteed rather than theoretical), a foreign zip, an empty archive, beacon plists without the manifest, a blank manifest, a manifest missing required fields, a zip truncated mid-deflate, and an export carrying no tags.

Plus the plumbing that carries the reason out through RxJava to the subscriber that picks the message — including a self-referencing cause chain, which must not hang the error handler.

### Verified

`:app:testEmulatorDebugAndroidTest` — 130 tests, all passing. Not exercised against a real export on hardware; the happy paths in `AppleZipImporterUtilTest` are unchanged and still pass.

---
*This PR description was written by Claude Code.*