### PR TITLE
Put the shared bundle package inside the APK

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -289,7 +289,34 @@ chaquopy {
         }
     }
     productFlavors {}
-    sourceSets {}
+    sourceSets {
+        getByName("main") {
+            // The shared bundle-format package, so `import opentagviewer_export` resolves in
+            // the APK as well as on desktop. It is the one implementation of the format and of
+            // the accessory-identification heuristic; main.py already calls into it.
+            //
+            // **Whitelisted, not just added.** `../python` also holds `exporter/` (the desktop
+            // wizard, which imports tkinter) and `test/` - and a top-level package named `test`
+            // on the Python path shadows the standard library's own `test` module. Pointing
+            // srcDir at the directory wholesale would put both in the APK.
+            //
+            // An include filter rather than a directory move, because the filter is verified
+            // rather than assumed - PythonPackagingTest imports each of these on a device and
+            // fails if `exporter` or a shadowing `test` came along too.
+            //
+            // **The filter applies to the whole source set, not to the srcDir it follows.**
+            // `include("opentagviewer_export/**")` alone therefore drops main.py - the bridge
+            // this app cannot run without - out of the APK, silently and with a green build.
+            // Hence the first pattern, which keeps app/src/main/python/main.py. `../python`
+            // has no top-level .py files for it to catch by accident, and the test is what
+            // notices if that stops being true.
+            srcDir("../python")
+            include("*.py", "opentagviewer_export/**")
+            // The package's own test suite is not part of the app. It imports pytest, which is
+            // not in the APK, so it is dead weight that would fail if anything ever touched it.
+            exclude("opentagviewer_export/tests/**")
+        }
+    }
 }
 
 dependencies {

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/python/PythonPackagingTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/python/PythonPackagingTest.java
@@ -1,0 +1,150 @@
+package dev.wander.android.opentagviewer.python;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.chaquo.python.PyObject;
+import com.chaquo.python.Python;
+import com.chaquo.python.android.AndroidPlatform;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * What Python actually ends up inside the APK.
+ *
+ * <p>The build packages two things and must package exactly two: {@code main.py}, the bridge the
+ * app cannot run without, and {@code opentagviewer_export}, the shared bundle-format package that
+ * {@code main.py} calls into. The directory the second comes from - {@code python/} - also holds
+ * the desktop wizard and its tests, neither of which belongs on a phone.
+ *
+ * <p><b>Both halves of that went wrong while this was being written, and neither failed a build.</b>
+ * Chaquopy's {@code include} filter applies to the whole source set rather than to the {@code
+ * srcDir} it follows, so filtering to the shared package dropped {@code main.py} out of the APK -
+ * green build, working unit tests, an app that cannot sign in. And a top-level package named
+ * {@code test} on the Python path shadows the standard library's own, which is the hazard that
+ * left this undone in the first place.
+ *
+ * <p>So these are imports on a real device, not an inspection of the zip. What matters is whether
+ * the interpreter can find these modules, and only the interpreter can answer that.
+ */
+@RunWith(AndroidJUnit4.class)
+public class PythonPackagingTest {
+
+    @BeforeClass
+    public static void startPython() {
+        if (!Python.isStarted()) {
+            Python.start(new AndroidPlatform(
+                    getInstrumentation().getTargetContext().getApplicationContext()));
+        }
+    }
+
+    /**
+     * The bridge is still there.
+     *
+     * <p>The regression guard for the filter above. Everything the app does against Apple goes
+     * through this module; without it the app starts, looks fine, and fails at sign-in.
+     */
+    @Test
+    public void theBridgeModuleIsPackaged() {
+        final PyObject main = Python.getInstance().getModule("main");
+
+        assertNotNull(main);
+        assertNotNull("main.py must still expose the hardware bridge",
+                main.get("identifyHardware"));
+    }
+
+    /** The point of the exercise: the shared package resolves inside the APK. */
+    @Test
+    public void theSharedPackageIsPackaged() {
+        assertNotNull(Python.getInstance().getModule("opentagviewer_export"));
+        assertNotNull(Python.getInstance().getModule("opentagviewer_export.hardware"));
+        assertNotNull(Python.getInstance().getModule("opentagviewer_export.passcode"));
+    }
+
+    /** An AirTag as the app stores one. Matches the fixture in {@code test_hardware_bridge.py}. */
+    private static final String AIRTAG_PLIST =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\""
+            + " \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+            + "<plist version=\"1.0\">\n"
+            + "<dict>\n"
+            + "    <key>identifier</key><string>725A989D-D871-49A7-B2FE-948C24F356AB</string>\n"
+            + "    <key>model</key><string></string>\n"
+            + "    <key>productId</key><integer>21760</integer>\n"
+            + "    <key>vendorId</key><integer>76</integer>\n"
+            + "    <key>stableIdentifier</key><array>"
+            + "<string>2001~#001234a12345aaac~#A02BCDEFG1AB</string></array>\n"
+            + "</dict>\n"
+            + "</plist>\n";
+
+    /**
+     * And it runs, rather than merely importing.
+     *
+     * <p>Asked through {@code main.py}'s own bridge, because that is how the app reaches it -
+     * importing the package directly would pass even if the bridge were wired to nothing.
+     *
+     * <p><b>This is the test that would catch the shared package going missing at runtime.</b>
+     * {@code identifyHardware} swallows every exception and returns null by design - an
+     * accessory is not worth losing over a label - so a failed import there is invisible unless
+     * something asks for an answer it knows the right shape of. On desktop CPython the same
+     * assertion is {@code test_hardware_bridge.py}; the point of repeating it here is that the
+     * APK is a different path with a different chance of not containing the package.
+     */
+    @Test
+    public void theHardwareHeuristicAnswersThroughTheBridge() {
+        final PyObject answer = Python.getInstance().getModule("main")
+                .callAttr("identifyHardware", AIRTAG_PLIST);
+
+        assertNotNull("null here means the shared package did not import inside the APK", answer);
+        assertEquals("AirTag", answer.toString());
+    }
+
+    /**
+     * The standard library's {@code test} module is not shadowed by the exporter's.
+     *
+     * <p>{@code python/test/} is the desktop wizard's test suite. On the Python path it would sit
+     * where the standard library's {@code test} package goes, which is the specific hazard that
+     * kept this change unmerged. Asserted by name: those modules must not be importable.
+     */
+    @Test
+    public void theExportersTestsAreNotOnThePath() {
+        assertThrows("python/test/ must not be packaged - it shadows the stdlib's test module",
+                Exception.class,
+                () -> Python.getInstance().getModule("test.test_airtag_decryptor"));
+    }
+
+    /**
+     * The desktop wizard is not packaged.
+     *
+     * <p>It imports tkinter, which does not exist here - so a build that shipped it would fail
+     * at import time on a phone rather than at build time on a desktop.
+     */
+    @Test
+    public void theDesktopWizardIsNotPackaged() {
+        assertThrows("python/exporter/ is the tkinter wizard and must not reach the APK",
+                Exception.class,
+                () -> Python.getInstance().getModule("exporter.asyncui"));
+    }
+
+    /**
+     * The shared package's own tests are not shipped either.
+     *
+     * <p>They came along at first, because the include pattern that picks up the package picks
+     * up everything under it. Harmless in the sense that nothing imports them - they would fail
+     * if anything did, since pytest is not in the APK - but they are a test suite inside a
+     * phone app, and the reason to keep them out is the same reason the wizard is kept out.
+     */
+    @Test
+    public void thePackagesOwnTestsAreNotShipped() {
+        assertThrows("opentagviewer_export/tests/ does not belong in the APK",
+                Exception.class,
+                () -> Python.getInstance().getModule("opentagviewer_export.tests.test_hardware"));
+    }
+}

--- a/docs/android-import-handover.md
+++ b/docs/android-import-handover.md
@@ -11,7 +11,7 @@ things it emits are ahead of what the app can read, and one thing it shares need
 
 ---
 
-## 1. Wire the shared package into Chaquopy
+## 1. Wire the shared package into Chaquopy — **done**
 
 `python/opentagviewer_export/` is the one implementation of the bundle format and of the
 accessory-identification heuristic. The app's Python layer already calls into it -
@@ -30,23 +30,30 @@ chaquopy {
 }
 ```
 
+**Filtering won, and the open question is answered: Chaquopy does honour `include` and
+`exclude`.** So the package stays where it is, nothing moves, and `pyproject.toml`, the
+PyInstaller spec and `conftest.py` are all untouched. What shipped:
+
+```kotlin
+srcDir("../python")
+include("*.py", "opentagviewer_export/**")
+exclude("opentagviewer_export/tests/**")
+```
+
 > [!WARNING]
-> **Do not merge that line as written.** `../python` also contains `exporter/` (the desktop wizard,
-> which imports tkinter) and `test/` - and a top-level package called `test` on the Python path
-> **shadows the standard library's `test` module**. That is a real hazard in a phone app and the
-> reason this was left undone rather than committed unverified.
->
-> Two ways out, either fine:
->
-> - **Move the shared package under a directory of its own** - `python/shared/opentagviewer_export/`
->   - and point `srcDir` at `python/shared`, which then contains exactly one thing. The exporter
->   reaches it by adding `shared` to its path; `python/pyproject.toml` and the PyInstaller spec both
->   need to know.
-> - **Filter the source set**, if Chaquopy's `srcDir` honours AGP's `exclude` patterns. Cheaper if
->   it works; unverified here, which is the whole problem.
->
-> Whichever, `app/src/test/python/conftest.py` puts `python/` on `sys.path` today and must be
-> changed to match, or the tests will exercise a layout the app does not have.
+> **The filter applies to the whole source set, not to the `srcDir` it follows.** So
+> `include("opentagviewer_export/**")` on its own also filters `app/src/main/python/`, and
+> **drops `main.py` out of the APK** — with a green build, passing unit tests, and an app that
+> cannot sign in. That is what the first pattern is for. `../python` has no top-level `.py`
+> files for it to catch by accident today.
+
+Both hazards — that one, and `test/` shadowing the standard library — are now asserted rather
+than reasoned about. `PythonPackagingTest` imports each module on a device: `main` and
+`opentagviewer_export` must resolve, `test.test_airtag_decryptor` and `exporter.asyncui` must
+not. It also asks the heuristic for an answer it knows the shape of, because `identifyHardware`
+swallows every exception by design and a failed import there is otherwise invisible.
+
+The APK now contains exactly `main.pyc` and six `opentagviewer_export` modules.
 
 `main.py`'s two bridge functions never raise: an accessory is not worth losing over a label, so a
 failed import there costs the label and logs.


### PR DESCRIPTION
Handover [§1](../blob/main/docs/android-import-handover.md). `main.py` has been calling into `opentagviewer_export` since the exporter shipped — and it worked on desktop CPython and nowhere else, because the package was never on the Chaquopy source path. The line that fixes it was written down but deliberately left unmerged, since `../python` also holds the tkinter wizard and a top-level package called `test` that shadows the standard library's.

### The open question, answered

**Chaquopy does honour source-set `include`/`exclude`.** So nothing moves: `pyproject.toml`, the PyInstaller spec and `conftest.py` are all untouched.

```kotlin
srcDir("../python")
include("*.py", "opentagviewer_export/**")
exclude("opentagviewer_export/tests/**")
```

### The trap that first pattern is for

**The filter applies to the whole source set, not to the `srcDir` it follows.** So `include("opentagviewer_export/**")` on its own *also* filters `app/src/main/python/` — and drops **`main.py` out of the APK**. Green build, green unit tests, an app that cannot sign in.

I only found it by unzipping the APK instead of trusting the build. That is the entire reason it is not in this commit.

### So the hazards are asserted, not reasoned about

`PythonPackagingTest` imports each module **on a device**:

- `main` and `opentagviewer_export.{hardware,passcode}` must resolve
- `test.test_airtag_decryptor` and `exporter.asyncui` must **not**
- the heuristic must return `"AirTag"` for a known plist — necessary because `identifyHardware` swallows every exception by design (an accessory is not worth losing over a label), so a failed import there is otherwise completely invisible

It also caught the shared package's **own test suite** being packaged into the app. Now excluded.

The APK ends up with exactly `main.pyc` and six `opentagviewer_export` modules.

### Verified

- 145 instrumented tests pass, including the 6 new ones.
- 54 desktop bridge tests pass (`app/src/test/python`).
- APK contents inspected directly, before and after.

### Unrelated, but found on the way

There is **no `.gitattributes` in this repo**, so Git for Windows checks out `python/opentagviewer_export/tests/` fixtures with CRLF. `test_macos_fixture.py` compares them byte for byte, so 4 of its tests can never pass on Windows (`assert b'\n' != b'\r'`). Pre-existing and untouched here — happy to fix separately.

---
*This PR description was written by Claude Code.*