### PR TITLE
Stop Windows checkouts corrupting the byte-for-byte fixtures

### DIFF
--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -28,6 +28,21 @@ gh pr view "$PR" --json statusCheckRollup --jq \
   '.statusCheckRollup[] | select(.status == "COMPLETED") | "\(.name): \(.conclusion)"'
 ```
 
+## First check whether this PR gets checks at all
+
+An **empty** rollup is not "too early" — it may mean nothing will ever run. Every workflow here
+is path-filtered (`app/**`, `scripts/**`, `gradle/**`, `pyrightconfig.json`, `.flake8`), so a PR
+touching only docs, `.gitattributes`, `.claude/`, or `.github/` itself produces no checks and a
+monitor on it waits out its whole timeout for nothing.
+
+```bash
+gh pr view <n> --json statusCheckRollup --jq '.statusCheckRollup | length'
+```
+
+Zero, and the diff touches no filtered path? **Do not arm a monitor.** Say the change is not
+covered by CI and why, and let the human decide — that is more useful than a green tick would
+have been, because it names what is *not* being verified.
+
 ## Use `gh pr view`, not `gh pr checks`
 
 `gh pr checks` sets its exit code from the checks themselves, so the usual

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Line endings.
+#
+# Git for Windows defaults to core.autocrlf=true, which rewrites LF to CRLF on checkout. For
+# source that is harmless. For a fixture whose bytes are the thing under test it is fatal, and
+# fatal in the least helpful way: the file is correct in the repository, correct on Linux and
+# macOS, and wrong in the working tree of every Windows contributor. Four tests in
+# test_macos_fixture.py failed that way and could not be made to pass on Windows at all -
+# `assert b'\n' == b'\r'`, on a file nobody had touched.
+#
+# So the fixtures declare themselves binary. `-text` means: never translate, in either
+# direction. It is not a claim that they are unreadable - they are XML, YAML and JSON - only
+# that their bytes are load-bearing.
+
+# Committed exports, replayed byte for byte by opentagviewer_export's fixture tests to prove
+# the exporter still produces exactly what macOS wrote.
+app/src/test/resources/** -text
+
+# Sample key files as other tools emit them. The point of these is to be somebody else's
+# output, so rewriting their line endings on checkout defeats them.
+python/test/resources/** -text
+
+# The locked bundle the Android importer's tests open. A zip is binary regardless; declared
+# so no future setting can decide otherwise.
+*.zip binary


### PR DESCRIPTION
This repo had **no `.gitattributes`**, and Git for Windows defaults to `core.autocrlf=true` — so every LF in a checked-out file becomes CRLF.

Harmless for source. Fatal for a fixture whose bytes are the thing under test, and fatal in the least useful way: the file is right in the repository, right on Linux and macOS, and wrong in the working tree of every Windows contributor.

```
in git:   ... "UTF-8"?>  \n  <!DOCTYPE
on disk:  ... "UTF-8"?>  \r \n  <!DOCTYPE
```

Four tests in `test_macos_fixture.py` failed exactly that way — `assert b'\n' == b'\r'` on files nobody had touched — and could not be made to pass on Windows at all. **They pass now** (`4 failed` → `8 passed` in that file).

### Three declarations, each for a reason

| Pattern | Why |
| --- | --- |
| `app/src/test/resources/**` | committed exports, replayed byte for byte to prove the exporter still produces exactly what macOS wrote |
| `python/test/resources/**` | sample key files as *other tools* emit them — being somebody else's output is the whole point, so rewriting their line endings defeats them |
| `*.zip` | binary regardless; the locked-bundle fixture shouldn't depend on nobody deciding otherwise later |

Deliberately **not** a repo-wide `* text=auto`. The blobs are already LF, so it would buy nothing and renormalise a large diff to say so.

### Verified

- `test_macos_fixture.py`: 8 passed (was 4 failing).
- `python/opentagviewer_export/tests`: 173 passed.
- `python/test/test_keyfile_fixtures.py`: 19 passed — unchanged, confirming the `-text` on that tree breaks nothing.
- Working tree re-checked-out and confirmed clean afterwards, with the plists now landing as LF.

### Not fixed here

`test_hardware.py::TestWhatImportingItCosts::test_identifying_an_accessory_does_not_drag_in_the_bundle_writer` fails on clean `main` and in isolation, so it is pre-existing and unrelated to line endings. Left alone rather than swept into this.

---
*This PR description was written by Claude Code.*