### PR TITLE
Skip a keychain item that cannot be read, instead of ending the export

### DIFF
--- a/docs/findmy-py-servicekey-der-report.md
+++ b/docs/findmy-py-servicekey-der-report.md
@@ -1,0 +1,113 @@
+# Report to FindMy.py: a raw `DerError` escapes `service_keys_from_der` and kills the run
+
+> **A bug report from a consumer**, addressed to whoever works on FindMy.py. Delete it from this
+> repository once the library has an answer.
+>
+> Traced from a real user's run — [OpenTagViewer#89](https://github.com/parawanderer/OpenTagViewer/issues/89).
+> Their account is ordinary: five Apple AirTags, all owned by the signed-in Apple ID, all visible
+> under *Items*. Nothing exotic about it, which is the point — this is reachable by anybody.
+
+## One sentence
+
+`service_keys_from_der` converts a `DerError` to `ServiceKeyError` for the *outer* parse and not
+for the descent, so an item whose first element parses but whose contents are not DER escapes as a
+raw `DerError` and aborts the export — where the two items immediately before it, failing for the
+same underlying reason, were skipped correctly.
+
+## The evidence, from one run
+
+The last three lines of the user's log, in order:
+
+```
+DEBUG findmy.keychain.session: Item for acct 504353426f756e64 holds no key: An item's v_Data is
+      not DER at all: Truncated DER: element claims 42 bytes, 30 remain
+DEBUG findmy.keychain.session: Item for acct 64656661756c74 holds no key: An item's v_Data is
+      not DER at all: Truncated DER: element claims 67 bytes, 19 remain
+
+DerError: Truncated DER: element claims 109 bytes, 61 remain      <- fatal
+```
+
+The first two are hex for `PCSBound` and `default`. Both were **handled**: caught, logged, skipped,
+run continues. The third is the same class of malformed payload and it takes down the whole export.
+
+The view held 61 items and 59 were read, so this is one item in sixty-one.
+
+## Why the difference
+
+`servicekey.py`:
+
+```python
+try:
+    element, _ = der.parse_one(payload)          # guarded
+except der.DerError as e:
+    msg = f"An item's v_Data is not DER at all: {e}"
+    raise ServiceKeyError(msg) from None
+
+if element.tag_class == der.CLASS_APPLICATION and element.tag_number == PRIVATE_KEY_V2_TAG:
+    return _from_v2(element)
+
+return _from_v1(element)                          # not guarded
+```
+
+`_from_v1` opens with `children = element.children()` (line 398), which calls `parse_all` on the
+element's *content*. If the outer TLV is well-formed but its content is not DER — which is exactly
+what a non-key item looks like — that raises `DerError`, and `DerError` is not a `ServiceKeyError`.
+
+The caller only catches the latter:
+
+```python
+# session.py:603
+try:
+    found = service_keys_from_der(payload_of(item))
+except (ItemError, ServiceKeyError) as e:
+    logger.debug("Item for acct %s holds no key: %s", account[:8].hex(), e)
+    continue
+```
+
+So the skip-and-continue that exists for precisely this situation is bypassed on a technicality of
+which exception type came out.
+
+## Suggested fix
+
+Make the whole of `service_keys_from_der` answer in its own vocabulary, rather than only its first
+statement:
+
+```python
+try:
+    element, _ = der.parse_one(payload)
+    if element.tag_class == der.CLASS_APPLICATION and element.tag_number == PRIVATE_KEY_V2_TAG:
+        return _from_v2(element)
+    return _from_v1(element)
+except der.DerError as e:
+    msg = f"An item's v_Data is not DER at all: {e}"
+    raise ServiceKeyError(msg) from None
+```
+
+`_from_v1` and `_from_v2` both descend, so both can raise it; wrapping at this level covers the
+two arms and anything added later. The docstring already promises `:raises ServiceKeyError: If the
+payload is neither form` — this makes that true.
+
+Worth considering whether `session.py:603` should also catch `DerError` defensively. Belt and
+braces, but the failure mode is a user's whole export dying on one unreadable item out of sixty-one,
+which is a bad trade against one extra exception type in a tuple.
+
+## What this is not
+
+- **Not the user's account.** Owned tags, on the right account, visible under *Items*.
+- **Not Advanced Data Protection**, which they initially suspected. Keychain material is end-to-end
+  encrypted under trusted-device custody either way.
+- **Not the two `carries no signing key` warnings** in the same log; those peers are skipped by
+  design.
+
+## Reproducing without an account
+
+The failing shape is an outer TLV whose length is honest and whose content is not DER:
+
+```python
+from findmy.keychain.servicekey import service_keys_from_der
+
+# SEQUENCE, length 3, content that is not parseable as DER elements
+service_keys_from_der(bytes([0x30, 0x03, 0x02, 0x7F, 0x41]))
+```
+
+Expected: `ServiceKeyError`. Actual: `DerError`.

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 [[package]]
 name = "findmy"
 version = "0.10.1"
-source = { git = "https://github.com/parawanderer/FindMy.py?branch=feat%2Ficloud-keychain-export#acd17c507b63e8bd0e56d8b4c5a92c096050bfa3" }
+source = { git = "https://github.com/parawanderer/FindMy.py?branch=feat%2Ficloud-keychain-export#47c4f898e4664420d203569a94bae435af73a252" }
 dependencies = [
     { name = "aiohttp" },
     { name = "anisette" },


### PR DESCRIPTION
Takes the FindMy.py fix for the crash reported in #89, and keeps the diagnosis that found it.

## What was wrong

`service_keys_from_der` converted a `DerError` into `ServiceKeyError` for the **outer** `parse_one`
and not for the descent that follows. `_from_v1` opens with `element.children()`, so a payload
whose first element parses but whose contents are not DER raised a raw `DerError` — and the caller
in `session.py` only caught `(ItemError, ServiceKeyError)`.

So the skip-and-continue written for exactly this case was bypassed on which exception type came
out. The proof is three consecutive lines of the reporter's log:

```
DEBUG  Item for acct 504353426f756e64 holds no key: … Truncated DER: claims 42, 30 remain
DEBUG  Item for acct 64656661756c74   holds no key: … Truncated DER: claims 67, 19 remain

DerError: Truncated DER: element claims 109 bytes, 61 remain      <- fatal
```

Those hex accounts are `PCSBound` and `default`. Two items failed the same way and were skipped
correctly; the third ended the export. One item in sixty-one.

## What it actually cost

More than one item. `unlock` reads `Manatee` and then `ProtectedCloudStorage`, accumulating keys
across both, and the reporter's log shows Manatee completing with **141 elliptic-curve keys**
before the crash. The exception unwound the whole call, so those were found and then discarded.

## The fix

Upstream, `acd17c5` → `47c4f89`: the whole body of `service_keys_from_der` inside the guard rather
than only `parse_one` — both arms descend, so both could raise it — plus `der.DerError` alongside
`ServiceKeyError` in the caller that skips unreadable items. That second half is a consistency fix
rather than defensiveness: `pcs.py`'s key walk already caught both, and `_pcs_keys_in` had not
carried it across.

Only `python/uv.lock` changes here.

## Verified against the new pin

| | |
| --- | --- |
| The #89 payload shape | `DerError` → **`ServiceKeyError`**, item skipped, run survives |
| A payload that already worked | still `ServiceKeyError`, no regression |
| Caller catches `DerError` | confirmed present in `_pcs_keys_in` |
| Exporter suite | 441 pass, 2 skipped |
| flake8 | clean |

Reproduction, no account needed:

```python
service_keys_from_der(bytes([0x30, 0x03, 0x02, 0x7F, 0x41]))
# before: DerError   after: ServiceKeyError
```

## What is not claimed

**This is not confirmed to fix the reported export**, which is why it links #89 rather than closing
it. Whether the one fatal item was itself a key is not visible from the log — only the reporter's
next run answers that. What is certain is that the 61-item view now survives it, and the 141 keys
already recovered from Manatee are no longer thrown away.

If it still comes up short, the line to read is the `holds no key` DEBUG for the item that used to
be fatal.

Reported by @paula-coder-646 in #89, with a traceback that pinned the failure to the line.

---

*PR description summarised by Claude Code.*
