### PR TITLE
Give this install one identity, and say so when Apple stops accepting it

### DIFF
--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -30,18 +30,32 @@ gh pr view "$PR" --json statusCheckRollup --jq \
 
 ## First check whether this PR gets checks at all
 
-An **empty** rollup is not "too early" — it may mean nothing will ever run. Every workflow here
-is path-filtered (`app/**`, `scripts/**`, `gradle/**`, `pyrightconfig.json`, `.flake8`), so a PR
-touching only docs, `.gitattributes`, `.claude/`, or `.github/` itself produces no checks and a
-monitor on it waits out its whole timeout for nothing.
+An **empty** rollup is not "too early" — it may mean nothing will ever run.
 
 ```bash
-gh pr view <n> --json statusCheckRollup --jq '.statusCheckRollup | length'
+gh pr view <n> --json statusCheckRollup,baseRefName \
+  --jq '{base: .baseRefName, checks: (.statusCheckRollup | length)}'
 ```
 
-Zero, and the diff touches no filtered path? **Do not arm a monitor.** Say the change is not
-covered by CI and why, and let the human decide — that is more useful than a green tick would
-have been, because it names what is *not* being verified.
+Two independent reasons it comes back zero, and **the second one is invisible in the diff**:
+
+- **Path filters.** Every workflow here is filtered (`app/**`, `scripts/**`, `gradle/**`,
+  `pyrightconfig.json`, `.flake8`), so a PR touching only docs, `.gitattributes`, `.claude/`, or
+  `.github/` itself produces nothing.
+- **A base that is not `main`.** Every workflow is `pull_request: branches: [ "main" ]`, so a
+  **stacked PR gets no checks whatsoever**, however much application code it touches. This is
+  the one that catches you out: the obvious test — "does the diff touch a filtered path?" —
+  says yes, and still nothing runs. Seen on #105, which changed `app/**` heavily and had a
+  rollup of zero because it was based on the branch of #104.
+
+Zero either way? **Do not arm a monitor.** Say the change is not covered by CI and why, and let
+the human decide — that is more useful than a green tick would have been, because it names what
+is *not* being verified. For a stack, the choice is theirs: merge the base so GitHub retargets
+the child onto `main`, or retarget it now and accept the parent's commits showing in the diff.
+
+**Whichever they pick, local runs are the only evidence until then.** Say what you ran, in
+numbers — `./gradlew :app:testEmulatorDebugAndroidTest` and the pytest suites — rather than
+letting "no checks" read as "nothing to check".
 
 ## Use `gh pr view`, not `gh pr checks`
 
@@ -68,14 +82,23 @@ while true; do
         '.statusCheckRollup[] | select(.status == "COMPLETED") | "\(.name): \(.conclusion)"' 2>/dev/null | sort)
   comm -13 <(printf '%s\n' "$seen") <(printf '%s\n' "$now")
   seen="$now"
+  total=$(gh pr view "$PR" --json statusCheckRollup --jq '.statusCheckRollup | length' 2>/dev/null)
+  if [ "$total" = "0" ]; then
+    echo "PR #$PR: NO CHECKS EXIST - nothing is verifying this. See the section above."
+    break
+  fi
   if [ "$(gh pr view "$PR" --json statusCheckRollup --jq \
           '[.statusCheckRollup[].status] | all(. == "COMPLETED")' 2>/dev/null)" = "true" ]; then
-    echo "PR #$PR: all checks finished"
+    echo "PR #$PR: all $total checks finished"
     break
   fi
   sleep 30
 done
 ```
+
+**The zero case is checked separately, and that is not belt-and-braces.** `[] | all(...)` is
+`true` in jq, so without it an empty rollup exits immediately announcing "all checks finished" —
+a monitor reporting success over a PR that ran nothing at all. That happened on #105.
 
 `timeout_ms`: the emulator suite here takes several minutes and the whole run rarely exceeds 20,
 so 2700000 (45 min) is comfortable. `persistent: false` — it ends itself.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,7 +254,7 @@ See **[CONTRIBUTING.md](./CONTRIBUTING.md)** for setup and every test suite. Sho
 Gradle provisions the emulator, runs the tests, and destroys it:
 
 ```bash
-./gradlew :app:testEmulatorDebugAndroidTest    # 72 tests, about 20 seconds
+./gradlew :app:testEmulatorDebugAndroidTest    # 190 tests, about a minute
 ```
 
 Use this rather than `connectedDebugAndroidTest`. The Android Gradle Plugin holds its ADB

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -287,7 +287,7 @@ chaquopy {
             // wheel for desktop platforms and a pure-Python `py3-none-any` one as well.
             // There is no Android wheel, so pip falls back to the pure-Python build - which
             // is correct but markedly slower. The messages here are small enough not to care.
-            install("git+https://github.com/parawanderer/FindMy.py@acd17c507b63e8bd0e56d8b4c5a92c096050bfa3")
+            install("git+https://github.com/parawanderer/FindMy.py@7bb292dc469cf087db942cda24d77b2e3ff511ff")
 
             install("NSKeyedUnArchiver==1.5")
         }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -287,7 +287,7 @@ chaquopy {
             // wheel for desktop platforms and a pure-Python `py3-none-any` one as well.
             // There is no Android wheel, so pip falls back to the pure-Python build - which
             // is correct but markedly slower. The messages here are small enough not to care.
-            install("git+https://github.com/parawanderer/FindMy.py@7bb292dc469cf087db942cda24d77b2e3ff511ff")
+            install("git+https://github.com/parawanderer/FindMy.py@2ea738aafbf86b2f9455704b81fc731c732c863b")
 
             install("NSKeyedUnArchiver==1.5")
         }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -287,7 +287,7 @@ chaquopy {
             // wheel for desktop platforms and a pure-Python `py3-none-any` one as well.
             // There is no Android wheel, so pip falls back to the pure-Python build - which
             // is correct but markedly slower. The messages here are small enough not to care.
-            install("git+https://github.com/parawanderer/FindMy.py@2ea738aafbf86b2f9455704b81fc731c732c863b")
+            install("git+https://github.com/parawanderer/FindMy.py@102dd8ea14767d2a2aa745186ac23276f32689f1")
 
             install("NSKeyedUnArchiver==1.5")
         }

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/SessionExpiredLoginTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/SessionExpiredLoginTest.java
@@ -1,0 +1,288 @@
+package dev.wander.android.opentagviewer;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertFalse;
+import static org.hamcrest.Matchers.not;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.SystemClock;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import dev.wander.android.opentagviewer.anisette.FakeAnisetteSource;
+import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
+import dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStore;
+import dev.wander.android.opentagviewer.db.repo.UserAuthRepository;
+import dev.wander.android.opentagviewer.db.repo.UserSettingsRepository;
+import dev.wander.android.opentagviewer.db.repo.model.UserSettings;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.python.FakeAppleAuthService;
+import dev.wander.android.opentagviewer.service.web.FakeAnisetteServerTester;
+import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Being signed out by Apple rather than by choice.
+ *
+ * <p>A session can stop working for reasons the user did nothing to cause: Apple invalidating
+ * it, a password change, or the machine identity moving because local Anisette fell back to a
+ * server. Before this, all of them arrived as a toast asserting that the FindMy library had
+ * been updated - true of one migration and wrong every other time - or, in the case that
+ * actually matters, as nothing at all.
+ *
+ * <p><b>The reason this is worth a screen and not a log line.</b> Somebody dropped on a login
+ * form with no explanation reasonably concludes the app has lost everything, and a reasonable
+ * next step is to go and tidy up whatever unfamiliar entry is sitting in their Apple device
+ * list - which is the single action that makes it worse, because that entry is this app.
+ *
+ * <p>The activity is driven directly with the extras rather than through a failing restore.
+ * Producing the real thing needs Apple to reject a session, which cannot be arranged; what can
+ * be asserted is that the screen honours what it is sent, and {@code MapsActivityTest} covers
+ * nothing here, so the contract between them is stated in {@code MapsActivity} and in
+ * {@code AppleLoginActivity}'s constants.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class SessionExpiredLoginTest {
+
+    private static final String EMAIL = "someone@example.com";
+
+    private ActivityScenario<AppleLoginActivity> scenario;
+    private DeviceStateGuard deviceState;
+
+    @Before
+    public void startSignedOut() {
+        this.deviceState = DeviceStateGuard.capture(getInstrumentation().getTargetContext());
+
+        signEverybodyOut();
+        forgetAnyChosenServer();
+
+        // Ready, so the screen goes straight to the account form and the dialog is the only
+        // thing in front of it. An unavailable source would add the welcome step and make
+        // "is the email field filled in" a question about a different page.
+        AppDependencies.replaceAuthService(FakeAppleAuthService.signsInImmediately());
+        AppDependencies.replaceServerTester(FakeAnisetteServerTester.thatIsUp());
+        AppDependencies.replaceAnisette(settings -> FakeAnisetteSource.ready());
+    }
+
+    @After
+    public void putTheRealOnesBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        AppDependencies.reset();
+
+        getInstrumentation().waitForIdleSync();
+        signEverybodyOut();
+        this.deviceState.restore();
+    }
+
+    /**
+     * The explanation appears, and says the thing that stops somebody making it worse.
+     *
+     * <p>Asserted on the words, not on "a dialog is up". What matters is that it says the tags
+     * are still here - a dialog that only said "sign in again" would leave the same fear.
+     */
+    @Test
+    public void somebodySignedOutByAppleIsToldWhatHappened() {
+        launchAfterExpiry(EMAIL);
+
+        final Context context = getInstrumentation().getTargetContext();
+        Eventually.check(() -> onView(withText(context.getString(R.string.session_expired_title)))
+                .check(matches(isDisplayed())));
+        onView(withText(context.getString(R.string.session_expired_message)))
+                .check(matches(isDisplayed()));
+    }
+
+    /**
+     * And once they dismiss it, their address is already in the field.
+     *
+     * <p>Read from the account being discarded, which is why {@code MapsActivity} reads it
+     * before clearing rather than after.
+     *
+     * <p>Dismissed first because a dialog owns the focused window, so Espresso resolves views
+     * against the dialog's hierarchy and not the activity's - looking for the field while it is
+     * up fails with {@code NoMatchingViewException} even though the field is there. It is also
+     * the order a person meets it in.
+     */
+    @Test
+    public void theirAddressIsAlreadyFilledIn() {
+        launchAfterExpiry(EMAIL);
+        dismissTheExplanation();
+
+        Eventually.check(() -> onView(withId(R.id.email_or_phone_input_field))
+                .perform(scrollTo()).check(matches(withText(EMAIL))));
+    }
+
+    /**
+     * Dismissing it leaves them on the sign-in form, not somewhere else.
+     *
+     * <p>The dialog is an explanation, not a decision - there is nothing to accept or decline,
+     * and no other screen to go to.
+     */
+    @Test
+    public void dismissingItLeavesThemOnTheSignInForm() {
+        launchAfterExpiry(EMAIL);
+        dismissTheExplanation();
+
+        onView(withId(R.id.email_or_phone_input_field))
+                .perform(scrollTo()).check(matches(isDisplayed()));
+        onView(withId(R.id.password_input_field)).perform(scrollTo()).check(matches(isDisplayed()));
+    }
+
+    /**
+     * An ordinary first run says none of this.
+     *
+     * <p>The half that makes the other three mean something. A dialog shown unconditionally
+     * would pass every test above and tell every new user their session had expired.
+     */
+    @Test
+    public void anordinaryFirstRunIsNotToldAnything() {
+        this.scenario = ActivityScenario.launch(AppleLoginActivity.class);
+        TestPace.afterAStep();
+
+        Eventually.check(() -> onView(withId(R.id.email_or_phone_input_field))
+                .perform(scrollTo()).check(matches(isDisplayed())));
+
+        final Context context = getInstrumentation().getTargetContext();
+        onView(withId(R.id.email_or_phone_input_field))
+                .perform(scrollTo()).check(matches(not(withText(EMAIL))));
+        assertFalse("a first run has no expired session to explain",
+                isShowing(context.getString(R.string.session_expired_title)));
+    }
+
+    /**
+     * An address alone prefills without announcing anything.
+     *
+     * <p>The two extras are independent on purpose: an address can be known when nothing has
+     * expired, and something can expire when the address cannot be read.
+     */
+    @Test
+    public void anaddressWithoutAnExpiryPrefillsQuietly() {
+        final Intent intent = new Intent(
+                getInstrumentation().getTargetContext(), AppleLoginActivity.class);
+        intent.putExtra(AppleLoginActivity.EXTRA_PREFILL_EMAIL, EMAIL);
+        this.scenario = ActivityScenario.launch(intent);
+        TestPace.afterAStep();
+
+        final Context context = getInstrumentation().getTargetContext();
+        Eventually.check(() -> onView(withId(R.id.email_or_phone_input_field))
+                .perform(scrollTo()).check(matches(withText(EMAIL))));
+        assertFalse("nothing expired, so nothing to explain",
+                isShowing(context.getString(R.string.session_expired_title)));
+    }
+
+    /**
+     * An expiry with no address still explains itself.
+     *
+     * <p>{@code MapsActivity} reads the address defensively - it is recovering from an account
+     * that has already failed to restore - so "expired, and we could not read who you are" is
+     * a state that can genuinely arrive, and it must not silently show nothing.
+     */
+    @Test
+    public void anexpiryWithoutAnAddressStillExplainsItself() {
+        launchAfterExpiry(null);
+
+        final Context context = getInstrumentation().getTargetContext();
+        Eventually.check(() -> onView(withText(context.getString(R.string.session_expired_title)))
+                .check(matches(isDisplayed())));
+    }
+
+    // ------------------------------------------------------------------------------------
+
+    /**
+     * Wait for the explanation, then dismiss it.
+     *
+     * <p>{@code perform} rather than a bare click: the dialog animates in, so a tap can land
+     * before it is touchable and needs retrying - but a tap that works removes the very view
+     * being clicked, which Espresso reports from the same call. "Has the title gone" separates
+     * the two; the exception cannot.
+     */
+    private void dismissTheExplanation() {
+        final Context context = getInstrumentation().getTargetContext();
+
+        Eventually.check(() -> onView(withText(context.getString(R.string.session_expired_title)))
+                .check(matches(isDisplayed())));
+        Eventually.perform("the dismiss button",
+                () -> !isShowing(context.getString(R.string.session_expired_title)),
+                () -> onView(withText(context.getString(R.string.ok))).perform(click()));
+        TestPace.afterAStep();
+    }
+
+    private void launchAfterExpiry(final String email) {
+        final Intent intent = new Intent(
+                getInstrumentation().getTargetContext(), AppleLoginActivity.class);
+        intent.putExtra(AppleLoginActivity.EXTRA_SESSION_EXPIRED, true);
+        if (email != null) {
+            intent.putExtra(AppleLoginActivity.EXTRA_PREFILL_EMAIL, email);
+        }
+
+        this.scenario = ActivityScenario.launch(intent);
+        TestPace.afterAStep();
+    }
+
+    /**
+     * Whether some text is on screen, as a question rather than an assertion.
+     *
+     * <p>Needed because two of these assert an absence, and an absence cannot be an expected
+     * exception: {@code NoMatchingViewException} is also what a mistyped matcher throws.
+     */
+    private static boolean isShowing(final String text) {
+        try {
+            onView(withText(text)).check(matches(isDisplayed()));
+            return true;
+        } catch (final NoMatchingViewException | AssertionError e) {
+            return false;
+        }
+    }
+
+    private static void forgetAnyChosenServer() {
+        new UserSettingsRepository(
+                UserSettingsDataStore.getInstance(getInstrumentation().getTargetContext()))
+                .storeUserSettings(UserSettings.builder()
+                        .anisetteMode(UserSettings.ANISETTE_LOCAL)
+                        .build())
+                .blockingAwait();
+    }
+
+    /**
+     * A stored session would send this screen straight to the map in {@code onCreate}, so every
+     * test here depends on there being none.
+     */
+    private static void signEverybodyOut() {
+        final UserAuthRepository auth = new UserAuthRepository(
+                UserAuthDataStore.getInstance(getInstrumentation().getTargetContext()),
+                new AppCryptographyUtil());
+
+        int consecutivelyEmpty = 0;
+
+        for (int attempt = 0; attempt < 40 && consecutivelyEmpty < 3; attempt++) {
+            if (auth.getUserAuth().blockingFirst().isEmpty()) {
+                consecutivelyEmpty++;
+            } else {
+                consecutivelyEmpty = 0;
+                auth.clearUser().blockingAwait();
+            }
+            SystemClock.sleep(50);
+        }
+
+        if (consecutivelyEmpty < 3) {
+            throw new IllegalStateException("a stored session kept coming back");
+        }
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/anisette/AdiDeviceIdentityTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/anisette/AdiDeviceIdentityTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import android.util.Base64;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import dev.wander.android.opentagviewer.anisette.AdiDeviceIdentity.Hardware;
@@ -12,6 +14,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -161,6 +164,54 @@ public class AdiDeviceIdentityTest {
         assertEquals(36, fresh.uniqueDeviceIdentifier().length());
         assertEquals(fresh.uniqueDeviceIdentifier().toUpperCase(java.util.Locale.ROOT),
                 fresh.uniqueDeviceIdentifier());
+    }
+
+    /**
+     * A fresh install's local user id is a UUID, because FindMy.py's is.
+     *
+     * <p>Not cosmetic. The value Java provisions ADI with is handed to FindMy.py verbatim and
+     * encoded there, so it has to be a string both sides can carry and that Apple has seen in
+     * this shape before - which is the UUID every FindMy.py client already sends.
+     */
+    @Test
+    public void afreshInstallsLocalUserIdIsAUuid() {
+        final String id = AdiDeviceIdentity.generate().localUserUuid();
+
+        assertEquals(36, id.length());
+        assertEquals(id.toUpperCase(java.util.Locale.ROOT), id);
+        java.util.UUID.fromString(id);
+    }
+
+    /**
+     * And provisioning sends the encoded form, which is what FindMy.py will send at login.
+     *
+     * <p>This equality <i>is</i> the alignment. Java's ADI provisioning is one exchange, made
+     * once, before FindMy.py exists; the login happens later and FindMy.py composes the header
+     * itself as {@code base64(uid)}. If these two ever differ, one installation is introducing
+     * itself to Apple as two.
+     */
+    @Test
+    public void afreshInstallProvisionsUnderWhatFindMyWillSend() {
+        final AdiDeviceIdentity fresh = AdiDeviceIdentity.generate();
+        final String whatJavaSends =
+                fresh.hardware().localUserHeader(fresh.localUserUuid());
+        final String whatFindMyWillSend = Base64.encodeToString(
+                fresh.localUserUuid().getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP);
+
+        assertEquals(whatFindMyWillSend, whatJavaSends);
+    }
+
+    /**
+     * A legacy install sends it raw, and keeps doing so.
+     *
+     * <p>Changing this would only matter if such an install ever re-provisioned - which happens
+     * when somebody resets Anisette - and it should then send what it sent the first time.
+     */
+    @Test
+    public void alegacyInstallSendsItsLocalUserIdUnencoded() {
+        final String stored = "3F2A1B0C9D8E7F6A5B4C3D2E1F0A9B8C7D6E5F4A3B2C1D0E9F8A7B6C5D4E3F2A";
+
+        assertEquals(stored, Hardware.LEGACY_MAC.localUserHeader(stored));
     }
 
     /** Two installs must not be the same machine. */

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/anisette/AdiDeviceIdentityTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/anisette/AdiDeviceIdentityTest.java
@@ -1,0 +1,174 @@
+package dev.wander.android.opentagviewer.anisette;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import dev.wander.android.opentagviewer.anisette.AdiDeviceIdentity.Hardware;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The exact strings this app tells Apple it is.
+ *
+ * <p>These are <b>literals on purpose</b>, which is unusual and worth defending. Composing the
+ * expected value from the same enum that produces it would assert only that
+ * {@link String#format} works. What needs pinning down is that the bytes have not moved,
+ * because a session is bound to them: an install whose client info changes is a different
+ * machine, which costs its user a sign-in and leaves an entry in their Apple device list that
+ * they are invited to remove.
+ *
+ * <p>So a failure here is not "update the expected value". It is "somebody has re-identified
+ * every install that has this profile, and should have meant to".
+ */
+@RunWith(AndroidJUnit4.class)
+public class AdiDeviceIdentityTest {
+
+    /**
+     * What every install before profiles existed sent, preserved exactly.
+     *
+     * <p>Reproduced from the constant this replaced. The whole point of {@code LEGACY_MAC} is
+     * that it did not change, so this string is the specification and the enum is the thing
+     * being checked.
+     */
+    @Test
+    public void theLegacyMacsClientInfoHasNotMoved() {
+        assertEquals("<MacBookPro13,2> <macOS;13.1;22C65> <com.apple.AuthKit/1 "
+                        + "(com.apple.dt.Xcode/3594.4.19)>",
+                Hardware.LEGACY_MAC.clientInfo());
+    }
+
+    /**
+     * Including the part of it that is wrong.
+     *
+     * <p>macOS 13.1 is Darwin 22.2.0, and this says 22.3.0 - so the user agent and the client
+     * info name different releases. Kept, because correcting it would re-identify every install
+     * that has this profile to fix a contradiction Apple has evidently never minded.
+     */
+    @Test
+    public void theLegacyMacsUserAgentHasNotMovedEither() {
+        assertEquals("akd/1.0 CFNetwork/1404.0.5 Darwin/22.3.0", Hardware.LEGACY_MAC.userAgent());
+    }
+
+    /** And the six parts Python is handed have to describe the same machine as those two. */
+    @Test
+    public void theLegacyMacsProfileSaysTheSameThingAsItsHeaders() throws Exception {
+        final JSONObject json = new JSONObject(Hardware.LEGACY_MAC.toJson());
+
+        assertTrue(Hardware.LEGACY_MAC.clientInfo().startsWith(
+                "<" + json.getString("model") + "> <" + json.getString("os_name") + ";"
+                        + json.getString("os_version") + ";" + json.getString("os_build") + ">"));
+        assertTrue(Hardware.LEGACY_MAC.userAgent().endsWith(
+                "CFNetwork/" + json.getString("cfnetwork")
+                        + " Darwin/" + json.getString("darwin")));
+    }
+
+    /**
+     * The new profile, whose values are observed rather than invented.
+     *
+     * <p>From {@code docs/findmy-export/01-authentication.md} section 2.2. Apple synthesises the
+     * device-list row from the claimed model, so {@code iPhone15,2} renders as "iPhone 14 Pro"
+     * with a phone icon - which is the entire reason for it.
+     */
+    @Test
+    public void theIphoneProfileClaimsOneRealRelease() {
+        assertEquals("<iPhone15,2> <iPhone OS;17.4;21E219> <com.apple.AuthKit/1 "
+                        + "(com.apple.akd/1.0)>",
+                Hardware.IPHONE.clientInfo());
+        assertEquals("akd/1.0 CFNetwork/1494.0.7 Darwin/23.4.0", Hardware.IPHONE.userAgent());
+    }
+
+    /**
+     * Nothing may quietly claim to be a phone and a Mac at once.
+     *
+     * <p>The failure this guards is a profile added later that copies one of these and edits
+     * half of it - a new model beside the old CFNetwork. It is the contradiction
+     * {@code DeviceIdentity} requires all six fields to prevent, and Apple's own clients never
+     * produce it.
+     */
+    @Test
+    public void everyProfileIsInternallyConsistent() throws Exception {
+        for (final Hardware hardware : Hardware.values()) {
+            final JSONObject json = new JSONObject(hardware.toJson());
+            final boolean phone = json.getString("model").startsWith("iPhone");
+
+            assertEquals(hardware + " names a phone in one field and a Mac in another",
+                    phone, "iPhone OS".equals(json.getString("os_name")));
+            assertEquals(hardware + "'s user agent describes a different release",
+                    hardware.userAgent(),
+                    "akd/1.0 CFNetwork/" + hardware.cfnetwork()
+                            + " Darwin/" + hardware.darwin());
+        }
+    }
+
+    /** Two profiles that were the same machine would make the distinction meaningless. */
+    @Test
+    public void theProfilesAreActuallyDifferentMachines() {
+        assertNotEquals(Hardware.LEGACY_MAC.toJson(), Hardware.IPHONE.toJson());
+        assertNotEquals(Hardware.LEGACY_MAC.clientInfo(), Hardware.IPHONE.clientInfo());
+    }
+
+    /**
+     * The keys are FindMy.py's, and every profile supplies all six.
+     *
+     * <p>{@code DeviceIdentity.from_json} back-fills a missing key from the library's own
+     * identity instead of failing, so a field dropped here would not throw anywhere - it would
+     * ship a machine that is part this app and part FindMy.py. Python refuses that too; this is
+     * the same fence on the side that can actually name the fields.
+     */
+    @Test
+    public void everyProfileSuppliesTheSixFieldsFindMyExpects() throws Exception {
+        final Set<String> expected = new HashSet<>(java.util.Arrays.asList(
+                "model", "os_name", "os_version", "os_build", "cfnetwork", "darwin"));
+
+        for (final Hardware hardware : Hardware.values()) {
+            final JSONObject json = new JSONObject(hardware.toJson());
+            final Set<String> actual = new HashSet<>();
+            for (final java.util.Iterator<String> keys = json.keys(); keys.hasNext(); ) {
+                actual.add(keys.next());
+            }
+
+            assertEquals(hardware + " does not describe one whole machine", expected, actual);
+        }
+    }
+
+    /** A fresh install is the new profile. The old one is only ever recovered, never chosen. */
+    @Test
+    public void afreshIdentityIsAnIphone() {
+        assertEquals(Hardware.IPHONE, AdiDeviceIdentity.generate().hardware());
+    }
+
+    /**
+     * The generated parts keep the lengths ADI rejects other values for.
+     *
+     * <p>{@code ADISetAndroidID} answers -45001 to an identifier of the wrong size, and that
+     * arrives as a login that fails with nothing visibly wrong.
+     */
+    @Test
+    public void afreshIdentityHasTheShapesAdiAccepts() {
+        final AdiDeviceIdentity fresh = AdiDeviceIdentity.generate();
+
+        assertEquals(16, fresh.adiIdentifier().length());
+        assertEquals(fresh.adiIdentifier().toLowerCase(java.util.Locale.ROOT),
+                fresh.adiIdentifier());
+        assertEquals(36, fresh.uniqueDeviceIdentifier().length());
+        assertEquals(fresh.uniqueDeviceIdentifier().toUpperCase(java.util.Locale.ROOT),
+                fresh.uniqueDeviceIdentifier());
+    }
+
+    /** Two installs must not be the same machine. */
+    @Test
+    public void twoFreshIdentitiesAreDifferent() {
+        assertNotEquals(AdiDeviceIdentity.generate().uniqueDeviceIdentifier(),
+                AdiDeviceIdentity.generate().uniqueDeviceIdentifier());
+        assertNotEquals(AdiDeviceIdentity.generate().adiIdentifier(),
+                AdiDeviceIdentity.generate().adiIdentifier());
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/anisette/FakeAnisetteSource.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/anisette/FakeAnisetteSource.java
@@ -117,6 +117,20 @@ public final class FakeAnisetteSource implements AnisetteSource {
         return this.hardware.toJson();
     }
 
+    /**
+     * Fixed values, so a test can assert that these exact strings reached Apple.
+     *
+     * <p>A UUID for the device id because FindMy.py parses it as one - CloudKit does
+     * {@code uuid.UUID(device_uuid)} - and a real installation's is a UUID too.
+     */
+    public static final String UID = "9E1D0C4B-77A2-4E3F-8D51-2B6A0F9C3D74";
+    public static final String DEVID = "1A2B3C4D-5E6F-4071-8293-A4B5C6D7E8F9";
+
+    @Override
+    public String deviceIdsJson() {
+        return "{\"uid\":\"" + UID + "\",\"devid\":\"" + DEVID + "\"}";
+    }
+
     @Override
     public String describe() {
         return this.ready ? "fake, ready" : "fake, unavailable: " + this.unavailableReason;

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/anisette/FakeAnisetteSource.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/anisette/FakeAnisetteSource.java
@@ -93,6 +93,30 @@ public final class FakeAnisetteSource implements AnisetteSource {
         this.recordedProvenance = establishedLocally;
     }
 
+    private AdiDeviceIdentity.Hardware hardware = AdiDeviceIdentity.Hardware.IPHONE;
+
+    /**
+     * Claim a different machine. Not a named constructor because it is orthogonal to the
+     * states above - every one of them can be either profile, and the interesting case is an
+     * install that is {@link AdiDeviceIdentity.Hardware#LEGACY_MAC} <i>and</i> unavailable.
+     */
+    public FakeAnisetteSource claiming(AdiDeviceIdentity.Hardware hardware) {
+        this.hardware = hardware;
+        return this;
+    }
+
+    /**
+     * The real profile's own JSON, not a hand-written copy.
+     *
+     * <p>A literal here would keep passing after the real thing changed shape, which is the
+     * failure this fake would otherwise introduce - it is substituted into the sign-in path
+     * that feeds Python.
+     */
+    @Override
+    public String hardwareProfileJson() {
+        return this.hardware.toJson();
+    }
+
     @Override
     public String describe() {
         return this.ready ? "fake, ready" : "fake, unavailable: " + this.unavailableReason;

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/anisette/LocalAnisetteIdentityTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/anisette/LocalAnisetteIdentityTest.java
@@ -1,0 +1,208 @@
+package dev.wander.android.opentagviewer.anisette;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import dev.wander.android.opentagviewer.db.repo.model.UserSettings;
+
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * What an upgrade does to an identity that already exists.
+ *
+ * <p><b>This is the half nobody can test by hand.</b> Reaching the interesting case for real
+ * means having installed a build from before hardware profiles existed, signed in to a real
+ * Apple account on it, and then upgrading - and the way it fails is that Apple stops
+ * recognising the machine hours later, on somebody else's phone, with nothing in a log to say
+ * why. So the older shapes are written into {@link LocalAnisette#PREFERENCES} directly and read
+ * back through the same door the app uses.
+ *
+ * <p>The rule being tested is one sentence: <b>an install that already has an identity keeps
+ * the machine it has always claimed.</b> Everything below is a way of getting that wrong.
+ */
+@RunWith(AndroidJUnit4.class)
+public class LocalAnisetteIdentityTest {
+
+    /** What every install shipped before profiles existed - three keys and no fourth. */
+    private static final String OLD_DEVICE_ID = "8C6C1F0B-6C46-4B39-B4E5-3E5A0C8B2E11";
+    private static final String OLD_ADI_ID = "a1b2c3d4e5f60718";
+    private static final String OLD_LOCAL_USER =
+            "3F2A1B0C9D8E7F6A5B4C3D2E1F0A9B8C7D6E5F4A3B2C1D0E9F8A7B6C5D4E3F2A";
+
+    private Context context;
+    private SharedPreferences preferences;
+
+    @Before
+    public void clearAnyRealIdentity() {
+        this.context = getInstrumentation().getTargetContext().getApplicationContext();
+        this.preferences =
+                this.context.getSharedPreferences(LocalAnisette.PREFERENCES, Context.MODE_PRIVATE);
+        this.preferences.edit().clear().commit();
+    }
+
+    /**
+     * The device is shared with every other test in the suite, and an identity left behind here
+     * would be adopted as real by whatever ran next.
+     */
+    @After
+    public void leaveNothingBehind() {
+        this.preferences.edit().clear().commit();
+    }
+
+    private LocalAnisette subject() {
+        // Remote deliberately: it proves the answer does not depend on ADI. This settings object
+        // makes ensureReady() decline before it downloads anything, and the profile still has to
+        // come back - a sign-in relayed through a server claims a machine too.
+        return new LocalAnisette(
+                this.context,
+                UserSettings.builder().anisetteMode(UserSettings.ANISETTE_REMOTE).build(),
+                true);
+    }
+
+    private void writeTheOldShape() {
+        assertTrue(this.preferences.edit()
+                .putString(LocalAnisette.KEY_DEVICE_ID, OLD_DEVICE_ID)
+                .putString(LocalAnisette.KEY_ADI_ID, OLD_ADI_ID)
+                .putString(LocalAnisette.KEY_LOCAL_USER, OLD_LOCAL_USER)
+                .commit());
+    }
+
+    private static String modelOf(String json) throws Exception {
+        return new JSONObject(json).getString("model");
+    }
+
+    /**
+     * The one that matters.
+     *
+     * <p>Three keys and no hardware key can only mean an install from before there was a
+     * choice, and the only thing this app ever claimed then was the Mac. Defaulting it to the
+     * new profile instead would present Apple with a different machine on an existing session:
+     * a sign-in the user did not ask for, and a second device-list entry beside a *Remove from
+     * Account* button.
+     */
+    @Test
+    public void anIdentityWrittenBeforeProfilesExistedIsStillTheMac() throws Exception {
+        writeTheOldShape();
+
+        assertEquals(AdiDeviceIdentity.Hardware.LEGACY_MAC.toJson(),
+                subject().hardwareProfileJson());
+        assertEquals("MacBookPro13,2", modelOf(subject().hardwareProfileJson()));
+    }
+
+    /** Nothing stored at all is a genuinely new install, and gets the profile worth having. */
+    @Test
+    public void afreshInstallIsAnIphone() throws Exception {
+        assertEquals(AdiDeviceIdentity.Hardware.IPHONE.toJson(), subject().hardwareProfileJson());
+        assertEquals("iPhone15,2", modelOf(subject().hardwareProfileJson()));
+    }
+
+    /**
+     * Reading the profile must not quietly rewrite an existing install's identity.
+     *
+     * <p>Persisting {@code LEGACY_MAC} on read would be harmless today and a trap tomorrow: the
+     * derivation is what encodes "this predates the choice", and writing it down converts a
+     * fact that can be re-derived into stored state that can be wrong.
+     */
+    @Test
+    public void readingALegacyProfileDoesNotWriteOneOverTheTopOfIt() {
+        writeTheOldShape();
+
+        subject().hardwareProfileJson();
+
+        assertFalse("the absence of this key is what marks a legacy install",
+                this.preferences.contains(LocalAnisette.KEY_HARDWARE));
+        assertEquals(OLD_DEVICE_ID, this.preferences.getString(LocalAnisette.KEY_DEVICE_ID, null));
+        assertEquals(OLD_ADI_ID, this.preferences.getString(LocalAnisette.KEY_ADI_ID, null));
+        assertEquals(OLD_LOCAL_USER,
+                this.preferences.getString(LocalAnisette.KEY_LOCAL_USER, null));
+    }
+
+    /**
+     * A fresh install's profile is written down, and written down <i>with</i> the identity.
+     *
+     * <p>If the three keys were persisted and the fourth were not, the very next read would see
+     * the legacy shape and decide this brand-new install was a Mac.
+     */
+    @Test
+    public void afreshInstallRecordsWhatItDecided() {
+        subject().hardwareProfileJson();
+
+        assertEquals(AdiDeviceIdentity.Hardware.IPHONE.name(),
+                this.preferences.getString(LocalAnisette.KEY_HARDWARE, null));
+        assertNotNull(this.preferences.getString(LocalAnisette.KEY_DEVICE_ID, null));
+        assertNotNull(this.preferences.getString(LocalAnisette.KEY_ADI_ID, null));
+        assertNotNull(this.preferences.getString(LocalAnisette.KEY_LOCAL_USER, null));
+    }
+
+    /**
+     * Asking twice gives the same answer, including across instances.
+     *
+     * <p>Regenerating per call would make every login look like a new machine, which is
+     * precisely what two-factor authentication exists to notice.
+     */
+    @Test
+    public void theIdentityIsGeneratedOnceAndThenKept() {
+        final String first = subject().hardwareProfileJson();
+        final String storedDeviceId = this.preferences.getString(LocalAnisette.KEY_DEVICE_ID, null);
+
+        assertEquals(first, subject().hardwareProfileJson());
+        assertEquals(storedDeviceId,
+                this.preferences.getString(LocalAnisette.KEY_DEVICE_ID, null));
+    }
+
+    /**
+     * A stored profile this version has never heard of falls back rather than throwing.
+     *
+     * <p>The bad outcome is re-identifying that install; the worse one is an app that cannot
+     * start at all, which is what a {@code valueOf} straight off stored text would give after a
+     * profile was renamed or removed. It falls back to the Mac because the keys beside it say
+     * this install is not new.
+     */
+    @Test
+    public void anUnrecognisedStoredProfileFallsBackInsteadOfCrashing() {
+        writeTheOldShape();
+        this.preferences.edit().putString(LocalAnisette.KEY_HARDWARE, "VISION_PRO").commit();
+
+        assertEquals(AdiDeviceIdentity.Hardware.LEGACY_MAC.toJson(),
+                subject().hardwareProfileJson());
+    }
+
+    /** A profile stored explicitly is honoured, which is the whole point of storing it. */
+    @Test
+    public void astoredProfileIsUsedAsWritten() {
+        writeTheOldShape();
+        this.preferences.edit()
+                .putString(LocalAnisette.KEY_HARDWARE, AdiDeviceIdentity.Hardware.IPHONE.name())
+                .commit();
+
+        assertEquals(AdiDeviceIdentity.Hardware.IPHONE.toJson(), subject().hardwareProfileJson());
+    }
+
+    /**
+     * A partly written identity is not a legacy install.
+     *
+     * <p>SharedPreferences applies asynchronously, so a process killed mid-write can leave one
+     * key and not the others. Treating that as "from before profiles existed" would hand a
+     * brand-new install the Mac, permanently.
+     */
+    @Test
+    public void ahalfWrittenIdentityIsTreatedAsAbsent() {
+        assertTrue(this.preferences.edit()
+                .putString(LocalAnisette.KEY_DEVICE_ID, OLD_DEVICE_ID)
+                .commit());
+
+        assertEquals(AdiDeviceIdentity.Hardware.IPHONE.toJson(), subject().hardwareProfileJson());
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/anisette/LocalAnisetteIdentityTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/anisette/LocalAnisetteIdentityTest.java
@@ -3,6 +3,7 @@ package dev.wander.android.opentagviewer.anisette;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -188,6 +189,69 @@ public class LocalAnisetteIdentityTest {
                 .commit();
 
         assertEquals(AdiDeviceIdentity.Hardware.IPHONE.toJson(), subject().hardwareProfileJson());
+    }
+
+    /**
+     * The ids handed to FindMy.py are the ones stored, not new ones.
+     *
+     * <p>This is the whole alignment in one assertion: what a legacy install already told Apple
+     * during provisioning is what its next sign-in claims to be. Minting a pair here instead
+     * would put it back to talking to Apple as two devices, silently.
+     */
+    @Test
+    public void thestoredIdsAreTheOnesHandedOver() throws Exception {
+        writeTheOldShape();
+
+        final JSONObject ids = new JSONObject(subject().deviceIdsJson());
+
+        assertEquals(OLD_DEVICE_ID, ids.getString("devid"));
+        assertEquals(OLD_LOCAL_USER, ids.getString("uid"));
+    }
+
+    /**
+     * And the local user id is handed over as stored, never as the header renders it.
+     *
+     * <p>FindMy.py encodes it on the way out. Handing it the encoded form would encode it twice.
+     */
+    @Test
+    public void theuidIsHandedOverUnencoded() throws Exception {
+        writeTheOldShape();
+        final AdiDeviceIdentity.Hardware profile = AdiDeviceIdentity.Hardware.LEGACY_MAC;
+
+        final String handedOver = new JSONObject(subject().deviceIdsJson()).getString("uid");
+
+        assertEquals(OLD_LOCAL_USER, handedOver);
+        assertEquals("this install's header convention is raw, so these coincide here",
+                profile.localUserHeader(OLD_LOCAL_USER), handedOver);
+    }
+
+    /** A fresh install's ids are stable too - asking twice must not mint a second device. */
+    @Test
+    public void afreshInstallsIdsAreStableAcrossCalls() {
+        final String first = subject().deviceIdsJson();
+
+        assertEquals(first, subject().deviceIdsJson());
+    }
+
+    /**
+     * A fresh install hands over exactly what it stored, which is where a double-encode hides.
+     *
+     * <p>The legacy tests above cannot see this one: that profile sends its local user id raw,
+     * so the stored value and the header value coincide and a bug that returned the header form
+     * would pass. On a fresh install they differ - base64 against the UUID - and only the UUID
+     * is correct, because FindMy.py encodes it again on the way out.
+     */
+    @Test
+    public void afreshInstallHandsOverTheStoredIdsAndNotTheHeaderForms() throws Exception {
+        final JSONObject ids = new JSONObject(subject().deviceIdsJson());
+
+        assertEquals(this.preferences.getString(LocalAnisette.KEY_LOCAL_USER, null),
+                ids.getString("uid"));
+        assertEquals(this.preferences.getString(LocalAnisette.KEY_DEVICE_ID, null),
+                ids.getString("devid"));
+        assertNotEquals("this is the header form, and handing it over would encode it twice",
+                AdiDeviceIdentity.Hardware.IPHONE.localUserHeader(ids.getString("uid")),
+                ids.getString("uid"));
     }
 
     /**

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/python/IdentityBridgeTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/python/IdentityBridgeTest.java
@@ -1,0 +1,180 @@
+package dev.wander.android.opentagviewer.python;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.chaquo.python.PyObject;
+import com.chaquo.python.Python;
+import com.chaquo.python.android.AndroidPlatform;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import dev.wander.android.opentagviewer.anisette.AdiDeviceIdentity.Hardware;
+import dev.wander.android.opentagviewer.anisette.FakeAnisetteSource;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Java and Python agreeing about which machine this is.
+ *
+ * <p>Each side is tested on its own elsewhere - {@code AdiDeviceIdentityTest} pins the strings,
+ * {@code test_identity.py} pins the parsing - and <b>neither of those can catch the failure
+ * that matters</b>, because it lives in the gap between them. The field names crossing the
+ * bridge are FindMy.py's, and {@code DeviceIdentity.from_json} back-fills a name it does not
+ * recognise from the library's own identity rather than failing. So a rename on either side
+ * produces no exception and no log line: it produces a login that claims a MacBookPro13,2 on
+ * macOS 13.1 with FindMy.py's CFNetwork, a release that has never existed, sent to Apple as
+ * though it had.
+ *
+ * <p>Only a test with both halves present can see that, which means on a device, through
+ * Chaquopy, with the library the app actually ships. That is what this is.
+ */
+@RunWith(AndroidJUnit4.class)
+public class IdentityBridgeTest {
+
+    @BeforeClass
+    public static void startPython() {
+        if (!Python.isStarted()) {
+            Python.start(new AndroidPlatform(
+                    getInstrumentation().getTargetContext().getApplicationContext()));
+        }
+    }
+
+    private static PyObject identity() {
+        return Python.getInstance().getModule("identity");
+    }
+
+    /** What Python makes of a source claiming the given profile. */
+    private static PyObject profileFor(Hardware hardware) {
+        return identity().callAttr(
+                "hardwareProfile", FakeAnisetteSource.ready().claiming(hardware));
+    }
+
+    /**
+     * The assertion the whole bridge exists for.
+     *
+     * <p>Java's six values arrive in Python as the same six values, on a {@code DeviceIdentity}
+     * built by the real library. Every field is checked individually rather than in bulk,
+     * because back-filling means a wrong one looks exactly like a right one from a distance.
+     */
+    @Test
+    public void everyFieldSurvivesTheCrossing() {
+        for (final Hardware hardware : Hardware.values()) {
+            final PyObject identity = profileFor(hardware);
+
+            assertNotNull(hardware + " did not survive the crossing at all", identity);
+            assertEquals(hardware.model(), identity.get("model").toString());
+            assertEquals(hardware.osName(), identity.get("os_name").toString());
+            assertEquals(hardware.osVersion(), identity.get("os_version").toString());
+            assertEquals(hardware.osBuild(), identity.get("os_build").toString());
+            assertEquals(hardware.cfnetwork(), identity.get("cfnetwork").toString());
+            assertEquals(hardware.darwin(), identity.get("darwin").toString());
+        }
+    }
+
+    /**
+     * And the client info FindMy.py composes is the one Java provisions ADI under.
+     *
+     * <p>This is rule 11 stated as an equality. The two strings are built by different code in
+     * different languages from what is now one source, and if they ever differ the app is two
+     * devices as far as Apple is concerned - the exact thing that made {@code DeviceIdentity}
+     * necessary upstream.
+     */
+    @Test
+    public void bothSidesComposeTheSameClientInfo() {
+        for (final Hardware hardware : Hardware.values()) {
+            final String fromPython = profileFor(hardware).get("platform").toString();
+
+            assertTrue(hardware + ": Java sends " + hardware.clientInfo()
+                            + ", Python composes " + fromPython,
+                    hardware.clientInfo().startsWith(fromPython));
+        }
+    }
+
+    /** And the user agent, whose CFNetwork and Darwin have to describe that same release. */
+    @Test
+    public void bothSidesComposeTheSameUserAgent() {
+        for (final Hardware hardware : Hardware.values()) {
+            assertEquals(hardware.userAgent(),
+                    profileFor(hardware).callAttr("user_agent", "akd/1.0").toString());
+        }
+    }
+
+    /**
+     * A new sign-in gets the app's serial and Java's machine.
+     *
+     * <p>The end-to-end shape, as {@code loginSync} builds it - so a keyword renamed upstream
+     * fails here rather than at somebody's sign-in.
+     */
+    @Test
+    public void anewSignInIsGivenBothHalves() {
+        final PyObject kwargs = identity().callAttr(
+                "identityForNewSession",
+                FakeAnisetteSource.ready().claiming(Hardware.IPHONE));
+
+        assertEquals("0PENTAGVIEWR", kwargs.callAttr("get", "serial").toString());
+        assertEquals("iPhone15,2",
+                kwargs.callAttr("get", "identity").get("model").toString());
+    }
+
+    /**
+     * Including when local Anisette is unusable, which is the case that is easy to get wrong.
+     *
+     * <p>The fallback to a remote server is automatic and invisible. If the machine went with
+     * the transport, a user whose libraries failed to download would silently become a second
+     * device without having done anything.
+     */
+    @Test
+    public void asignInThatFallsBackToAServerClaimsTheSameMachine() {
+        final PyObject local = identity().callAttr(
+                "hardwareProfile", FakeAnisetteSource.ready().claiming(Hardware.IPHONE));
+        final PyObject fellBack = identity().callAttr(
+                "hardwareProfile",
+                FakeAnisetteSource.unavailable("no network").claiming(Hardware.IPHONE));
+
+        assertNotNull(fellBack);
+        assertEquals(local.toString(), fellBack.toString());
+    }
+
+    /**
+     * An install that predates profiles presents the Mac, even signing in today.
+     *
+     * <p>Their ADI is provisioned as a MacBookPro13,2 and is not provisioned again, so this is
+     * not a preference - it is the only answer that matches what Apple was already told.
+     */
+    @Test
+    public void alegacyInstallSigningInAgainStillClaimsTheMac() {
+        final PyObject kwargs = identity().callAttr(
+                "identityForNewSession",
+                FakeAnisetteSource.ready().claiming(Hardware.LEGACY_MAC));
+
+        assertEquals("MacBookPro13,2",
+                kwargs.callAttr("get", "identity").get("model").toString());
+        assertEquals("the serial is a label, and a new sign-in is a new entry either way",
+                "0PENTAGVIEWR", kwargs.callAttr("get", "serial").toString());
+    }
+
+    /**
+     * Nothing to ask means nothing imposed, rather than a guess.
+     *
+     * <p>FindMy.py's own identity is wrong for this app, but it is wrong in a way that costs a
+     * misleading device-list entry. Guessing a profile could contradict what ADI already sent,
+     * which is worse, and refusing to sign in would be worse still.
+     */
+    @Test
+    public void withNoBridgeThereIsNoMachineToClaim() {
+        assertNull(identity().callAttr("hardwareProfile", (Object) null));
+
+        final PyObject kwargs = identity().callAttr("identityForNewSession", (Object) null);
+
+        assertEquals("0PENTAGVIEWR", kwargs.callAttr("get", "serial").toString());
+        assertFalse("with no machine to claim, none should be asserted",
+                kwargs.callAttr("__contains__", "identity").toBoolean());
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/python/IdentityBridgeTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/python/IdentityBridgeTest.java
@@ -3,9 +3,12 @@ package dev.wander.android.opentagviewer.python;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import android.util.Base64;
 
 import com.chaquo.python.PyObject;
 import com.chaquo.python.Python;
@@ -19,6 +22,8 @@ import dev.wander.android.opentagviewer.anisette.FakeAnisetteSource;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  * Java and Python agreeing about which machine this is.
@@ -158,6 +163,64 @@ public class IdentityBridgeTest {
                 kwargs.callAttr("get", "identity").get("model").toString());
         assertEquals("the serial is a label, and a new sign-in is a new entry either way",
                 "0PENTAGVIEWR", kwargs.callAttr("get", "serial").toString());
+    }
+
+    /**
+     * The two ids cross intact and keep their names.
+     *
+     * <p>That FindMy.py then accepts them under exactly these keywords is asserted in
+     * {@code test_identity.py}, against a real account and the same pinned library. What only a
+     * device can show is the crossing itself - a Java string, through Chaquopy, out of the JSON
+     * an {@code AnisetteSource} actually produces.
+     */
+    @Test
+    public void theIdsThisInstallAlreadyUsedCrossIntact() {
+        final PyObject ids = identity().callAttr(
+                "deviceIdsForNewSession", FakeAnisetteSource.ready());
+
+        assertEquals(FakeAnisetteSource.UID, ids.callAttr("get", "uid").toString());
+        assertEquals(FakeAnisetteSource.DEVID, ids.callAttr("get", "devid").toString());
+    }
+
+    /**
+     * The uid crosses as stored, not as the header renders it.
+     *
+     * <p>FindMy.py base64-encodes it on the way out, and a fresh install's ADI provisioning
+     * already sent base64 of the same string. Handing over the encoded form would encode it
+     * twice - a value Apple has never seen, from a client claiming to be an installation it
+     * has. The alignment is one step away from that mistake in either direction, so both steps
+     * are pinned here together.
+     */
+    @Test
+    public void theUidIsNotEncodedTwice() {
+        final String crossed = identity()
+                .callAttr("deviceIdsForNewSession", FakeAnisetteSource.ready())
+                .callAttr("get", "uid").toString();
+
+        assertEquals(FakeAnisetteSource.UID, crossed);
+        assertNotEquals("this is the header form; FindMy.py would encode it a second time",
+                Hardware.IPHONE.localUserHeader(crossed), crossed);
+        assertEquals("and the header form is exactly what FindMy.py will produce from it",
+                Base64.encodeToString(crossed.getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP),
+                Hardware.IPHONE.localUserHeader(crossed));
+    }
+
+    /**
+     * An install from before profiles existed sends its local user id raw, and cannot not.
+     *
+     * <p>Its ADI was provisioned under the raw convention and is never provisioned again, and
+     * there is no {@code uid} whose base64 is a 64-character hex string. So for these two the
+     * device id aligns and this one does not - stated as a test rather than left as a surprise,
+     * because it is the one part of the alignment that does not hold for everybody.
+     */
+    @Test
+    public void alegacyInstallCannotAlignItsLocalUserId() {
+        final String stored = "3F2A1B0C9D8E7F6A5B4C3D2E1F0A9B8C7D6E5F4A3B2C1D0E9F8A7B6C5D4E3F2A";
+
+        assertEquals(stored, Hardware.LEGACY_MAC.localUserHeader(stored));
+        assertNotEquals("if these ever matched, the two conventions would have converged",
+                Hardware.LEGACY_MAC.localUserHeader(stored),
+                Base64.encodeToString(stored.getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP));
     }
 
     /**

--- a/app/src/main/java/dev/wander/android/opentagviewer/AppleLoginActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/AppleLoginActivity.java
@@ -33,6 +33,7 @@ import androidx.core.os.LocaleListCompat;
 import androidx.databinding.DataBindingUtil;
 import androidx.lifecycle.ViewModelProvider;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.progressindicator.CircularProgressIndicator;
 import com.google.android.material.textfield.MaterialAutoCompleteTextView;
 import com.google.android.material.textfield.TextInputEditText;
@@ -97,6 +98,22 @@ public class AppleLoginActivity extends AppCompatActivity {
             R.id.login_2fa_choice,
             R.id.login_2fa_container,
     };
+
+    /**
+     * Set when the user did not choose to be here - their stored session stopped working.
+     *
+     * <p>Worth distinguishing from an ordinary first run. Being dropped on a login screen with
+     * no explanation reads as the app having lost everything, and the reasonable response to
+     * that is to go and tidy up whatever unfamiliar entry is in your Apple device list - which
+     * is the one action that makes it worse.
+     */
+    public static final String EXTRA_SESSION_EXPIRED = "sessionExpired";
+
+    /**
+     * The address to put in the field, for somebody signing in again rather than for the first
+     * time. Only ever their own, read from the account being discarded.
+     */
+    public static final String EXTRA_PREFILL_EMAIL = "prefillEmail";
 
     private static final int HINT_DIFFERENT_ANISETTE_SERVER_AFTER_FAILED_2FACODES = 3;
 
@@ -221,6 +238,43 @@ public class AppleLoginActivity extends AppCompatActivity {
         this.passwordInput = this.findViewById(R.id.password_input_field);
         this.loginButton = this.findViewById(R.id.login_button_main);
         this.twoFactorAuthChoiceBackButton = this.findViewById(R.id.twofactorauthchoice_back_button);
+
+        this.explainWhySignedOutIfSent();
+    }
+
+    /**
+     * Somebody arriving here because their session stopped working, rather than by choice.
+     *
+     * <p>Being returned to a login screen with no explanation reads as the app having lost
+     * everything - which is exactly the moment somebody goes to their Apple device list, finds
+     * an entry they do not recognise, and removes it. So it says what happened, and says that
+     * the tags and their history are still here.
+     *
+     * <p>Shown on this screen rather than by whoever sent them, because this is the screen that
+     * stays: the sender is finishing, and a dialog on a finishing activity is a leaked window.
+     */
+    private void explainWhySignedOutIfSent() {
+        final String email = this.getIntent().getStringExtra(EXTRA_PREFILL_EMAIL);
+        if (email != null && !email.isEmpty()) {
+            // Prefilled whether or not the dialog is shown, and before it, so the field is
+            // already right the moment the dialog is dismissed rather than filling in
+            // afterwards in front of the user.
+            this.emailOrPhoneInput.setText(email);
+        }
+
+        if (!this.getIntent().getBooleanExtra(EXTRA_SESSION_EXPIRED, false)) {
+            return;
+        }
+
+        // Consumed, so that rotating the device - or coming back to this screen later - does
+        // not re-announce something the user has already read and acted on.
+        this.getIntent().removeExtra(EXTRA_SESSION_EXPIRED);
+
+        new MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.session_expired_title)
+                .setMessage(R.string.session_expired_message)
+                .setPositiveButton(R.string.ok, null)
+                .show();
     }
 
     @Override

--- a/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
@@ -1029,18 +1029,48 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
         return false;
     }
 
+    /**
+     * Send somebody back to sign in, and tell them why.
+     *
+     * <p>This used to be a toast asserting that the FindMy library had been updated - true of
+     * the one migration it was written for, and wrong every other time. What a person needs
+     * here is what happened, and the reassurance that their tags and history are still on the
+     * phone; the explaining is done by the login screen, because this one is finishing.
+     *
+     * <p><b>The address is read before the account is cleared</b>, which is the whole reason
+     * this is not two independent steps: clearing is what destroys it.
+     */
     private void handleAccountRestoreFailureOnUiThread() {
+        final String email = signedInEmailOrNull();
+
         var disposable = this.userAuthRepo.clearUser()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(() -> {
-                    Toast.makeText(this, R.string.relogin_required_after_upgrade, LENGTH_LONG).show();
                     this.finish();
-                    this.sendToLogin();
+                    this.sendToLoginBecauseTheSessionExpired(email);
                 }, err -> {
                     Log.e(TAG, "Failed to clear stale auth blob during restore-failure recovery", err);
                     // Fall through silently — at worst the user has to log out manually.
                 });
+    }
+
+    /**
+     * The signed-in address, or null if it cannot be read.
+     *
+     * <p>Deliberately incurious about why it might not be: this runs while recovering from an
+     * account that has already failed to restore, and a missing address costs a prefilled
+     * field, not the recovery.
+     */
+    private String signedInEmailOrNull() {
+        try {
+            return this.userAuthRepo.getUserAuth().blockingFirst()
+                    .map(stored -> stored.getUser().getAccount().getInfo().getAccountName())
+                    .orElse(null);
+        } catch (final Exception e) {
+            Log.w(TAG, "Could not read the signed-in address to prefill the login screen", e);
+            return null;
+        }
     }
 
     private synchronized void addBeaconToCurrent(final List<BeaconInformation> newBeaconInformation) {
@@ -1343,6 +1373,16 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
 
     private void sendToLogin() {
         Intent intent = new Intent(this, AppleLoginActivity.class);
+        startActivity(intent);
+    }
+
+    /** As above, but for somebody who did not choose to be signed out. */
+    private void sendToLoginBecauseTheSessionExpired(final String email) {
+        Intent intent = new Intent(this, AppleLoginActivity.class);
+        intent.putExtra(AppleLoginActivity.EXTRA_SESSION_EXPIRED, true);
+        if (email != null) {
+            intent.putExtra(AppleLoginActivity.EXTRA_PREFILL_EMAIL, email);
+        }
         startActivity(intent);
     }
 

--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/AdiDeviceIdentity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/AdiDeviceIdentity.java
@@ -1,8 +1,11 @@
 package dev.wander.android.opentagviewer.anisette;
 
+import android.util.Base64;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Locale;
 import java.util.UUID;
@@ -15,10 +18,11 @@ import java.util.UUID;
  * generated exactly like these, which is the working proof that Apple does not check them
  * against anything real.
  *
- * <p>The lengths, however, are not free. ADI rejects an identifier of the wrong size with
- * -45001 (invalid parameters), so these match the reference implementation exactly: 8 random
- * bytes as 16 lowercase hex characters for ADI, and 32 bytes as 64 uppercase hex characters
- * for the local user UUID.
+ * <p>One length is not free. {@code ADISetAndroidID} rejects an identifier of the wrong size
+ * with -45001 (invalid parameters), so {@link #adiIdentifier()} matches the reference
+ * implementation exactly: 8 random bytes as 16 lowercase hex characters. <b>The other two never
+ * reach ADI at all</b> - they are HTTP headers and nothing more - so their shape is a matter of
+ * agreeing with whoever else sends them, which is what {@link Hardware} decides.
  *
  * <p><b>The one rule that matters is that this is generated once and then kept.</b> Regenerating
  * it per login would make every session look like a brand new machine to Apple, which is
@@ -48,12 +52,13 @@ public final class AdiDeviceIdentity {
     /** A fresh identity, claiming to be an iPhone. Call once, persist, never call again. */
     public static AdiDeviceIdentity generate() {
         final SecureRandom random = new SecureRandom();
+        final Hardware hardware = Hardware.IPHONE;
 
         return new AdiDeviceIdentity(
                 UUID.randomUUID().toString().toUpperCase(Locale.ROOT),
                 hex(random, 8).toLowerCase(Locale.ROOT),
-                hex(random, 32).toUpperCase(Locale.ROOT),
-                Hardware.IPHONE);
+                hardware.newLocalUserId(random),
+                hardware);
     }
 
     private static String hex(SecureRandom random, int bytes) {
@@ -93,7 +98,28 @@ public final class AdiDeviceIdentity {
         LEGACY_MAC(
                 "MacBookPro13,2", "macOS", "13.1", "22C65",
                 "1404.0.5", "22.3.0",
-                "com.apple.dt.Xcode/3594.4.19"),
+                "com.apple.dt.Xcode/3594.4.19") {
+
+            /** 32 bytes as 64 uppercase hex, which is what Dadoum's Provision generates. */
+            @Override
+            String newLocalUserId(SecureRandom random) {
+                return hex(random, 32).toUpperCase(Locale.ROOT);
+            }
+
+            /**
+             * Sent exactly as stored, because that is what this install already sent.
+             *
+             * <p>It cannot be brought into line with FindMy.py, and the attempt would make it
+             * worse. FindMy.py sends {@code base64(uid)}; matching that would need a {@code uid}
+             * whose base64 is a 64-character hex string, which is 48 bytes of arbitrary binary
+             * and not a string at all. So for these installs the two halves stay different, the
+             * device id aligns, and this does not.
+             */
+            @Override
+            public String localUserHeader(String localUserUuid) {
+                return localUserUuid;
+            }
+        },
 
         /**
          * What a fresh install claims: an iPhone 14 Pro.
@@ -114,7 +140,49 @@ public final class AdiDeviceIdentity {
         IPHONE(
                 "iPhone15,2", "iPhone OS", "17.4", "21E219",
                 "1494.0.7", "23.4.0",
-                "com.apple.akd/1.0");
+                "com.apple.akd/1.0") {
+
+            /** A UUID, because that is what FindMy.py mints and this has to be the same value. */
+            @Override
+            String newLocalUserId(SecureRandom random) {
+                return UUID.randomUUID().toString().toUpperCase(Locale.ROOT);
+            }
+
+            /**
+             * Base64, matching FindMy.py, so that provisioning and login send the same bytes.
+             *
+             * <p><b>This is the whole reason the convention is per profile.</b> Two conventions
+             * exist for this header: the Anisette servers send the value raw, and FindMy.py
+             * sends {@code base64(uid)} - and there is exactly one place a client can choose,
+             * which is here, before it has told Apple anything. A fresh install provisions ADI
+             * under this and then hands the same string to FindMy.py, which encodes it
+             * identically. One installation, one local user id.
+             */
+            @Override
+            public String localUserHeader(String localUserUuid) {
+                return Base64.encodeToString(
+                        localUserUuid.getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP);
+            }
+        };
+
+        /**
+         * A new local user id in whatever shape this profile sends it.
+         *
+         * <p>Package-private: generating one is {@link #generate()}'s job, and an install that
+         * already has one must never be given another.
+         */
+        abstract String newLocalUserId(SecureRandom random);
+
+        /**
+         * {@code X-Apple-I-MD-LU}, rendered from the stored id.
+         *
+         * <p>Only ADI provisioning actually sends this. The header set {@link AnisetteHeaders}
+         * builds is shaped like an Anisette server's response, but FindMy.py reads two values
+         * out of it and composes the rest itself - so at login this header is Apple's view of
+         * {@code base64(uid)}, and the value here is what Apple saw when the machine was
+         * provisioned. Making those the same is the point.
+         */
+        public abstract String localUserHeader(String localUserUuid);
 
         private final String model;
         private final String osName;

--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/AdiDeviceIdentity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/AdiDeviceIdentity.java
@@ -1,5 +1,8 @@
 package dev.wander.android.opentagviewer.anisette;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.security.SecureRandom;
 import java.util.Locale;
 import java.util.UUID;
@@ -166,6 +169,40 @@ public final class AdiDeviceIdentity {
 
         public String darwin() {
             return this.darwin;
+        }
+
+        /**
+         * This profile as FindMy.py's {@code DeviceIdentity} mapping.
+         *
+         * <p><b>This is the whole point of the enum being reachable from Python.</b> The Python
+         * side used to hold its own copy of these six values, which meant one install could
+         * claim a Mac in its ADI provisioning headers and something else at login - the
+         * contradiction rule 11 exists to prevent, and the one Apple's own clients never
+         * produce. It reads them from here instead, so there is one source of truth and a
+         * profile added later needs no second edit.
+         *
+         * <p>The key names are <b>FindMy.py's</b>, not this class's: they are fed straight to
+         * {@code DeviceIdentity.from_json}. That is deliberate but it is also a trap, because
+         * {@code from_json} fills a missing key from the library's own defaults rather than
+         * failing - so a rename on either side would silently produce a half-Apple, half-us
+         * identity. {@code IdentityBridgeTest} asserts the two agree, on device, through
+         * Chaquopy.
+         */
+        public String toJson() {
+            try {
+                return new JSONObject()
+                        .put("model", this.model)
+                        .put("os_name", this.osName)
+                        .put("os_version", this.osVersion)
+                        .put("os_build", this.osBuild)
+                        .put("cfnetwork", this.cfnetwork)
+                        .put("darwin", this.darwin)
+                        .toString();
+            } catch (final JSONException e) {
+                // Six string literals into a fresh object. Unreachable short of the platform
+                // being broken, and there is no sensible half-identity to return instead.
+                throw new IllegalStateException("could not describe " + name(), e);
+            }
         }
     }
 

--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/AdiDeviceIdentity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/AdiDeviceIdentity.java
@@ -24,44 +24,33 @@ import java.util.UUID;
  */
 public final class AdiDeviceIdentity {
 
-    /**
-     * What we claim to be.
-     *
-     * <p>The value matches anisette-v3-server, which was originally chosen because it is the most
-     * common string Apple sees and therefore the least remarkable thing to send. <b>That reasoning
-     * no longer applies.</b> Rule 11 has this app registering under a name and a serial that exist
-     * to be recognised - a user looking at their Apple device list is meant to know which entry is
-     * this - so blending in stopped being achievable the moment being identifiable became the
-     * point. The string stays because it works, not because it hides.
-     *
-     * <p><b>The parts describe one real release and have to move together.</b> Model, OS version,
-     * build, CFNetwork and Darwin are a set; claiming a Mac here and an iPhone elsewhere is a
-     * contradiction Apple's own clients never produce. See rule 11 and
-     * {@code docs/findmy-export/01-authentication.md} section 2.2, which carries a worked iPhone
-     * set if this ever changes to one.
-     */
-    public static final String CLIENT_INFO =
-            "<MacBookPro13,2> <macOS;13.1;22C65> <com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>";
-
     private final String uniqueDeviceIdentifier;
     private final String adiIdentifier;
     private final String localUserUuid;
+    private final Hardware hardware;
 
+    /**
+     * @param hardware which machine this install claims to be. An install that already existed
+     *                 before profiles were introduced passes {@link Hardware#LEGACY_MAC}, and
+     *                 must keep doing so - see the enum.
+     */
     public AdiDeviceIdentity(String uniqueDeviceIdentifier, String adiIdentifier,
-                             String localUserUuid) {
+                             String localUserUuid, Hardware hardware) {
         this.uniqueDeviceIdentifier = uniqueDeviceIdentifier;
         this.adiIdentifier = adiIdentifier;
         this.localUserUuid = localUserUuid;
+        this.hardware = hardware;
     }
 
-    /** A fresh identity. Call this once, persist the result, and never call it again. */
+    /** A fresh identity, claiming to be an iPhone. Call once, persist, never call again. */
     public static AdiDeviceIdentity generate() {
         final SecureRandom random = new SecureRandom();
 
         return new AdiDeviceIdentity(
                 UUID.randomUUID().toString().toUpperCase(Locale.ROOT),
                 hex(random, 8).toLowerCase(Locale.ROOT),
-                hex(random, 32).toUpperCase(Locale.ROOT));
+                hex(random, 32).toUpperCase(Locale.ROOT),
+                Hardware.IPHONE);
     }
 
     private static String hex(SecureRandom random, int bytes) {
@@ -73,6 +62,116 @@ public final class AdiDeviceIdentity {
             out.append(String.format("%02X", b));
         }
         return out.toString();
+    }
+
+    /**
+     * The machine this install claims to be, chosen once and then kept.
+     *
+     * <p>Two profiles, and <b>which one an install has is not a preference</b>: it is part of
+     * what Apple binds a session to, so moving an install from one to the other costs that user
+     * a sign-in and leaves a second entry in their device list. An install that already has an
+     * ADI identity keeps {@link #LEGACY_MAC} forever; only a fresh one gets {@link #IPHONE}.
+     *
+     * <p>Each carries all six parts because <b>they describe one real release and move
+     * together</b> - model, OS, build, CFNetwork and Darwin. FindMy.py's {@code DeviceIdentity}
+     * takes the same six for the same reason, and the Python side reads whichever one this
+     * install has rather than deciding for itself. Rule 11.
+     */
+    public enum Hardware {
+        /**
+         * What every install before this shipped as, preserved exactly.
+         *
+         * <p><b>Not corrected, deliberately.</b> macOS 13.1 is Darwin 22.2.0, and this sends
+         * 22.3.0 - so the client info and the user agent name different releases. It is wrong,
+         * it has always been wrong, and changing it now would re-identify every existing
+         * install to fix a contradiction Apple has evidently never minded. The new profile does
+         * not have it.
+         */
+        LEGACY_MAC(
+                "MacBookPro13,2", "macOS", "13.1", "22C65",
+                "1404.0.5", "22.3.0",
+                "com.apple.dt.Xcode/3594.4.19"),
+
+        /**
+         * What a fresh install claims: an iPhone 14 Pro.
+         *
+         * <p><b>For the icon, and for the words next to it.</b> Apple synthesises the device-list
+         * entry from the claimed model, so {@code iPhone15,2} renders as "iPhone 14 Pro" with a
+         * phone icon rather than as a bare "MacBookPro" among the user's real Macs. See
+         * {@code docs/findmy-export/01-authentication.md} section 2.2, which is where these
+         * values are from - observed, not invented.
+         *
+         * <p>Safe on both counts that matter. Claiming to be a phone does <b>not</b> make this
+         * eligible as a second factor: that is decided by the push token, which FindMy.py has no
+         * parameter for and never sends, and an iPhone-shaped entry still reports "This device
+         * cannot be used to receive Apple Account verification codes". And it arrives together
+         * with the serial {@code 0PENTAGVIEWR}, which is what keeps it recognisable - an iPhone
+         * claim on its own, unnamed and unserialled, would be worse than the Mac it replaces.
+         */
+        IPHONE(
+                "iPhone15,2", "iPhone OS", "17.4", "21E219",
+                "1494.0.7", "23.4.0",
+                "com.apple.akd/1.0");
+
+        private final String model;
+        private final String osName;
+        private final String osVersion;
+        private final String osBuild;
+        private final String cfnetwork;
+        private final String darwin;
+        private final String authKitApp;
+
+        Hardware(String model, String osName, String osVersion, String osBuild,
+                 String cfnetwork, String darwin, String authKitApp) {
+            this.model = model;
+            this.osName = osName;
+            this.osVersion = osVersion;
+            this.osBuild = osBuild;
+            this.cfnetwork = cfnetwork;
+            this.darwin = darwin;
+            this.authKitApp = authKitApp;
+        }
+
+        /** Sent as X-MMe-Client-Info. */
+        public String clientInfo() {
+            return String.format(Locale.ROOT, "<%s> <%s;%s;%s> <com.apple.AuthKit/1 (%s)>",
+                    this.model, this.osName, this.osVersion, this.osBuild, this.authKitApp);
+        }
+
+        /** The User-Agent the provisioning requests go out under. */
+        public String userAgent() {
+            return String.format(Locale.ROOT, "akd/1.0 CFNetwork/%s Darwin/%s",
+                    this.cfnetwork, this.darwin);
+        }
+
+        public String model() {
+            return this.model;
+        }
+
+        public String osName() {
+            return this.osName;
+        }
+
+        public String osVersion() {
+            return this.osVersion;
+        }
+
+        public String osBuild() {
+            return this.osBuild;
+        }
+
+        public String cfnetwork() {
+            return this.cfnetwork;
+        }
+
+        public String darwin() {
+            return this.darwin;
+        }
+    }
+
+    /** Which machine this install claims to be. Never changes once an install has one. */
+    public Hardware hardware() {
+        return this.hardware;
     }
 
     /** Sent as X-Mme-Device-Id. */

--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/AdiProvisioning.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/AdiProvisioning.java
@@ -248,7 +248,13 @@ public final class AdiProvisioning {
 
         connection.setRequestProperty("X-Mme-Device-Id", this.identity.uniqueDeviceIdentifier());
         connection.setRequestProperty("X-MMe-Client-Info", this.identity.hardware().clientInfo());
-        connection.setRequestProperty("X-Apple-I-MD-LU", this.identity.localUserUuid());
+        // Rendered by the profile, not sent raw. A fresh install sends base64 here so that this
+        // exchange and the login FindMy.py makes later carry the same value - see
+        // AdiDeviceIdentity.Hardware#localUserHeader. This request is the only place the app
+        // sends this header itself, and it runs once, so what goes out here is what Apple
+        // remembers this machine's local user id to be.
+        connection.setRequestProperty("X-Apple-I-MD-LU",
+                this.identity.hardware().localUserHeader(this.identity.localUserUuid()));
         connection.setRequestProperty("X-Apple-Client-App-Name", "Setup");
         connection.setRequestProperty("X-Apple-I-Client-Time", now());
     }

--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/AdiProvisioning.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/AdiProvisioning.java
@@ -242,12 +242,12 @@ public final class AdiProvisioning {
      * from the reference implementation rather than tidied up.
      */
     private void applyHeaders(HttpURLConnection connection) {
-        connection.setRequestProperty("User-Agent", "akd/1.0 CFNetwork/1404.0.5 Darwin/22.3.0");
+        connection.setRequestProperty("User-Agent", this.identity.hardware().userAgent());
         connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
         connection.setRequestProperty("Connection", "keep-alive");
 
         connection.setRequestProperty("X-Mme-Device-Id", this.identity.uniqueDeviceIdentifier());
-        connection.setRequestProperty("X-MMe-Client-Info", AdiDeviceIdentity.CLIENT_INFO);
+        connection.setRequestProperty("X-MMe-Client-Info", this.identity.hardware().clientInfo());
         connection.setRequestProperty("X-Apple-I-MD-LU", this.identity.localUserUuid());
         connection.setRequestProperty("X-Apple-Client-App-Name", "Setup");
         connection.setRequestProperty("X-Apple-I-Client-Time", now());

--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/AnisetteHeaders.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/AnisetteHeaders.java
@@ -71,7 +71,7 @@ public final class AnisetteHeaders {
         headers.put("X-Apple-I-TimeZone", TimeZone.getDefault().getID());
         headers.put("X-Apple-Locale", Locale.getDefault().toString());
         headers.put("X-Mme-Device-Id", this.identity.uniqueDeviceIdentifier());
-        headers.put("X-MMe-Client-Info", AdiDeviceIdentity.CLIENT_INFO);
+        headers.put("X-MMe-Client-Info", this.identity.hardware().clientInfo());
         return headers;
     }
 

--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/AnisetteHeaders.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/AnisetteHeaders.java
@@ -65,7 +65,8 @@ public final class AnisetteHeaders {
         headers.put("X-Apple-I-MD", Base64.encodeToString(oneTimePassword, Base64.NO_WRAP));
         headers.put("X-Apple-I-MD-M", Base64.encodeToString(machineIdentifier, Base64.NO_WRAP));
         headers.put("X-Apple-I-MD-RINFO", ROUTING_INFO);
-        headers.put("X-Apple-I-MD-LU", this.identity.localUserUuid());
+        headers.put("X-Apple-I-MD-LU",
+                this.identity.hardware().localUserHeader(this.identity.localUserUuid()));
         headers.put("X-Apple-I-SRL-NO", "0");
         headers.put("X-Apple-I-Client-Time", clientTime());
         headers.put("X-Apple-I-TimeZone", TimeZone.getDefault().getID());

--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/AnisetteSource.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/AnisetteSource.java
@@ -64,6 +64,21 @@ public interface AnisetteSource {
      */
     String hardwareProfileJson();
 
+    /**
+     * The two ids this installation already introduced itself to Apple with, as
+     * {@code {"uid": ..., "devid": ...}}.
+     *
+     * <p>ADI provisioning is its own exchange with Apple, made before FindMy.py exists, and it
+     * carries {@code X-Mme-Device-Id} and {@code X-Apple-I-MD-LU}. FindMy.py used to mint its
+     * own pair, so <b>one install talked to Apple as two devices</b>; these are what stop that.
+     *
+     * <p>Both or neither - FindMy.py refuses one of two, and is right to. A client matching one
+     * id and inventing the other is a shape no real client produces.
+     *
+     * <p>Answerable without ADI, for the same reason as {@link #hardwareProfileJson}.
+     */
+    String deviceIdsJson();
+
     /** Short human-readable state, for logs and diagnostics. */
     String describe();
 }

--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/AnisetteSource.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/AnisetteSource.java
@@ -50,6 +50,20 @@ public interface AnisetteSource {
     /** What {@link #recordSessionProvenance} last recorded. False if nothing has. */
     boolean wasSessionEstablishedLocally();
 
+    /**
+     * The machine this install claims to be, as FindMy.py's {@code DeviceIdentity} mapping.
+     *
+     * <p><b>Answerable when nothing else here is.</b> Every other method on this interface
+     * describes locally produced Anisette, and returns nothing useful when it is unavailable -
+     * but a sign-in relayed through a remote server still has to tell Apple which machine it
+     * is, and it must be the same answer either way. So this does not consult ADI, does not
+     * download anything, and does not care whether {@link #ensureReady} succeeded: the profile
+     * is persisted beside the device identity and read straight back.
+     *
+     * <p>Called from Python at sign-in. See {@code identity.identityForNewSession}.
+     */
+    String hardwareProfileJson();
+
     /** Short human-readable state, for logs and diagnostics. */
     String describe();
 }

--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/LocalAnisette.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/LocalAnisette.java
@@ -34,10 +34,19 @@ import java.util.Map;
 public final class LocalAnisette implements AnisetteSource {
     private static final String TAG = "LocalAnisette";
 
-    private static final String PREFERENCES = "anisette-identity";
-    private static final String KEY_DEVICE_ID = "uniqueDeviceIdentifier";
-    private static final String KEY_ADI_ID = "adiIdentifier";
-    private static final String KEY_LOCAL_USER = "localUserUuid";
+    /**
+     * Where the identity lives.
+     *
+     * <p>Visible because this is a <b>storage contract with installs already in the field</b>,
+     * not an implementation detail. What is written here decides whether an upgrade keeps
+     * somebody signed in, and the only way to test that is to write the older shape and read it
+     * back - so the test names these rather than a copy of them, which would keep passing after
+     * the real ones moved.
+     */
+    public static final String PREFERENCES = "anisette-identity";
+    public static final String KEY_DEVICE_ID = "uniqueDeviceIdentifier";
+    public static final String KEY_ADI_ID = "adiIdentifier";
+    public static final String KEY_LOCAL_USER = "localUserUuid";
 
     /**
      * Which machine this install claims to be.
@@ -45,7 +54,7 @@ public final class LocalAnisette implements AnisetteSource {
      * <p>Added after the other three, so <b>its absence beside them is meaningful</b>: it marks
      * an install from before there was a choice, which can only have been the Mac.
      */
-    private static final String KEY_HARDWARE = "hardwareProfile";
+    public static final String KEY_HARDWARE = "hardwareProfile";
 
     /** Apple's, in dependency order. CoreFoundation and mediaplatform are our stubs. */
     private static final List<String> FROM_APPLE = Arrays.asList(
@@ -241,6 +250,26 @@ public final class LocalAnisette implements AnisetteSource {
             Log.w(TAG, "unknown stored hardware profile " + stored + ", using " + fallback);
             return fallback;
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Deliberately does not go through {@link #ensureReady}. A sign-in that falls back to a
+     * remote server needs this answer too, and it must be the <i>same</i> answer - which kind
+     * of Anisette produced a session is a transport detail, and a user whose local Anisette
+     * failed must not thereby become a different machine.
+     *
+     * <p>Reads the loaded identity when there is one, and otherwise reads - or, on a genuinely
+     * fresh install, writes - the persisted one. Generating it here rather than in
+     * {@link #load} is intentional: an install that only ever uses a remote server still has an
+     * identity, and it is the same one it will use if local Anisette is turned on later.
+     */
+    @Override
+    public synchronized String hardwareProfileJson() {
+        final AdiDeviceIdentity current =
+                this.identity != null ? this.identity : loadOrCreateIdentity();
+        return current.hardware().toJson();
     }
 
     /** Why local Anisette is not being used, or null if it is. */

--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/LocalAnisette.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/LocalAnisette.java
@@ -39,6 +39,14 @@ public final class LocalAnisette implements AnisetteSource {
     private static final String KEY_ADI_ID = "adiIdentifier";
     private static final String KEY_LOCAL_USER = "localUserUuid";
 
+    /**
+     * Which machine this install claims to be.
+     *
+     * <p>Added after the other three, so <b>its absence beside them is meaningful</b>: it marks
+     * an install from before there was a choice, which can only have been the Mac.
+     */
+    private static final String KEY_HARDWARE = "hardwareProfile";
+
     /** Apple's, in dependency order. CoreFoundation and mediaplatform are our stubs. */
     private static final List<String> FROM_APPLE = Arrays.asList(
             "libc++_shared.so", "libstoreservicescore.so");
@@ -188,7 +196,17 @@ public final class LocalAnisette implements AnisetteSource {
         final String localUser = preferences.getString(KEY_LOCAL_USER, null);
 
         if (deviceId != null && adiId != null && localUser != null) {
-            return new AdiDeviceIdentity(deviceId, adiId, localUser);
+            // **An install that already has an identity keeps the machine it has always
+            // claimed to be.** The absence of the hardware key is what says "from before
+            // profiles existed", and that can only mean the Mac: it is the only thing this app
+            // ever sent. Defaulting a pre-existing install to the new profile instead would
+            // re-identify it to Apple, which costs the user a sign-in and leaves a second
+            // device-list entry - to change the icon on a row they already recognise.
+            final AdiDeviceIdentity.Hardware hardware =
+                    hardwareFrom(preferences.getString(KEY_HARDWARE, null),
+                            AdiDeviceIdentity.Hardware.LEGACY_MAC);
+
+            return new AdiDeviceIdentity(deviceId, adiId, localUser, hardware);
         }
 
         final AdiDeviceIdentity fresh = AdiDeviceIdentity.generate();
@@ -196,10 +214,33 @@ public final class LocalAnisette implements AnisetteSource {
                 .putString(KEY_DEVICE_ID, fresh.uniqueDeviceIdentifier())
                 .putString(KEY_ADI_ID, fresh.adiIdentifier())
                 .putString(KEY_LOCAL_USER, fresh.localUserUuid())
+                .putString(KEY_HARDWARE, fresh.hardware().name())
                 .apply();
 
-        Log.i(TAG, "generated a new device identity - this must now be kept");
+        Log.i(TAG, "generated a new device identity as " + fresh.hardware()
+                + " - this must now be kept");
         return fresh;
+    }
+
+    /**
+     * The stored profile, or {@code fallback} when there is nothing usable stored.
+     *
+     * <p>An unrecognised name falls back rather than throwing. A profile removed in a later
+     * version would otherwise make an install that has one unable to start at all, and the
+     * identity is not worth crashing over - the fallback re-identifies that install, which is
+     * bad, but it is recoverable and a crash loop is not.
+     */
+    private static AdiDeviceIdentity.Hardware hardwareFrom(
+            final String stored, final AdiDeviceIdentity.Hardware fallback) {
+        if (stored == null) {
+            return fallback;
+        }
+        try {
+            return AdiDeviceIdentity.Hardware.valueOf(stored);
+        } catch (final IllegalArgumentException e) {
+            Log.w(TAG, "unknown stored hardware profile " + stored + ", using " + fallback);
+            return fallback;
+        }
     }
 
     /** Why local Anisette is not being used, or null if it is. */

--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/LocalAnisette.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/LocalAnisette.java
@@ -7,6 +7,9 @@ import android.util.Log;
 
 import dev.wander.android.opentagviewer.db.repo.model.UserSettings;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -267,9 +270,33 @@ public final class LocalAnisette implements AnisetteSource {
      */
     @Override
     public synchronized String hardwareProfileJson() {
-        final AdiDeviceIdentity current =
-                this.identity != null ? this.identity : loadOrCreateIdentity();
-        return current.hardware().toJson();
+        return currentIdentity().hardware().toJson();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The local user id is handed over <b>as stored</b>, not as the header renders it.
+     * FindMy.py base64-encodes it on the way out, so passing the encoded form would encode it
+     * twice - which is a value Apple has never seen, from a client claiming to be the same
+     * installation. See {@code AdiDeviceIdentity.Hardware#localUserHeader}.
+     */
+    @Override
+    public synchronized String deviceIdsJson() {
+        final AdiDeviceIdentity current = currentIdentity();
+        try {
+            return new JSONObject()
+                    .put("uid", current.localUserUuid())
+                    .put("devid", current.uniqueDeviceIdentifier())
+                    .toString();
+        } catch (final JSONException e) {
+            throw new IllegalStateException("could not describe this installation", e);
+        }
+    }
+
+    /** The identity in memory if it has been loaded, and the persisted one otherwise. */
+    private AdiDeviceIdentity currentIdentity() {
+        return this.identity != null ? this.identity : loadOrCreateIdentity();
     }
 
     /** Why local Anisette is not being used, or null if it is. */

--- a/app/src/main/python/identity.py
+++ b/app/src/main/python/identity.py
@@ -20,9 +20,24 @@ recognised and removed on its own.
 
 from __future__ import annotations
 
+import json
+import traceback
 from typing import Any
 
 from findmy.reports.anisette import DeviceIdentity
+
+IDENTITY_FIELDS = frozenset(
+    {"model", "os_name", "os_version", "os_build", "cfnetwork", "darwin"}
+)
+"""
+The six fields Java has to send, checked before they are used.
+
+`DeviceIdentity.from_json` fills a missing key from FindMy.py's *own* identity rather than
+failing, which is right for reading back an identity written by an older version and wrong
+here: a renamed key on either side would quietly produce a machine that is part this app and
+part the library - a MacBook Pro 18,3 on macOS 13.1, a release that does not exist. Checking
+first turns that into a visible fallback instead of an invisible hybrid.
+"""
 
 APP_SERIAL = "0PENTAGVIEWR"
 """
@@ -36,31 +51,6 @@ Without this a session presents FindMy.py's default, `0FINDMYPY001` - which name
 rather than the program, in the one place the user ever looks.
 """
 
-APP_IDENTITY = DeviceIdentity(
-    model="MacBookPro13,2",
-    os_name="macOS",
-    os_version="13.1",
-    os_build="22C65",
-    cfnetwork="1404.0.5",
-    darwin="22.2.0",
-)
-"""
-The machine a new session claims to be - **the same one ADI is initialised with**.
-
-This is the whole point of it. `AdiDeviceIdentity.CLIENT_INFO` on the Java side sends
-`<MacBookPro13,2> <macOS;13.1;22C65>` when it provisions ADI, and FindMy.py used to send a
-MacBook Pro 18,3 on macOS 13.4.1 from its own defaults. One app, one session, two different
-Macs - down to the OS *name*, `macOS` against `Mac OS X`. Rule 11 exists to prevent exactly
-that, and until FindMy.py grew `DeviceIdentity` there was nowhere to say otherwise.
-
-**Moved to match Java rather than the other way round**, because the ADI string is the half
-that is also baked into how ADI was provisioned on the device.
-
-The six parts describe one real release and move together: macOS 13.1 is build 22C65,
-CFNetwork 1404.0.5, Darwin 22.2.0. Nothing validates that - FindMy.py has no copy of Apple's
-release table - so changing one means changing all six deliberately.
-"""
-
 # **There is deliberately no device name here, and no announce_device() call.**
 #
 # Naming the device-list entry needs `announce_device()`, which authenticates with the
@@ -72,6 +62,74 @@ release table - so changing one means changing all six deliberately.
 # The serial carries the recognisability on its own: an entry reading `0PENTAGVIEWR` is
 # identifiable as software the user installed, which is the thing that stops them removing it.
 # The row is still titled after the claimed model, and that is accepted.
+
+
+def hardwareProfile(localAnisette: Any) -> DeviceIdentity | None:
+    """
+    The machine this install claims to be, **read from Java rather than decided here**.
+
+    This used to be a constant, and a constant is wrong for a reason that only shows up in one
+    case. Java persists the profile per install: an install that predates the choice keeps the
+    Mac it has always claimed, and a fresh one is an iPhone. So there is no single right answer
+    for the Python side to hold - somebody signed in before all this, who signs out and signs
+    back in, must present the Mac their ADI was provisioned with, while the install beside
+    theirs must present the iPhone. A copy here would be right for one of them.
+
+    It is also the contradiction rule 11 is about. The same six values reach Apple twice: once
+    in the client info Java sends when it provisions ADI, and once in the client info FindMy.py
+    sends at login. Apple's own clients never disagree with themselves about which machine they
+    are, and two values maintained in two languages disagree eventually.
+
+    Returns None when there is nothing to ask or the answer is unusable, which leaves FindMy.py
+    on its own identity. That is a real mismatch, and worth saying so loudly - but it is a
+    mismatch on a *new* sign-in, which costs a device-list entry that is wrong rather than a
+    session that stops working, and failing the login outright would be worse.
+    """
+    if localAnisette is None:
+        # No bridge at all: nothing to align with, so nothing to impose.
+        return None
+
+    try:
+        payload = json.loads(str(localAnisette.hardwareProfileJson()))
+    except Exception:
+        print(f"Could not read the hardware profile from Java: {traceback.format_exc()}")
+        return None
+
+    missing = IDENTITY_FIELDS - payload.keys()
+    if missing:
+        print(
+            "The hardware profile from Java is missing "
+            f"{sorted(missing)} - falling back to FindMy.py's own identity, which will not "
+            "match what ADI was provisioned with. AdiDeviceIdentity.Hardware.toJson and "
+            "DeviceIdentity have drifted apart."
+        )
+        return None
+
+    return DeviceIdentity.from_json(payload)
+
+
+def identityForNewSession(localAnisette: Any) -> dict:
+    """
+    The identity a **new** sign-in presents: this app's serial, and Java's machine.
+
+    Only for a new sign-in. Everything restored from a stored account keeps whatever it was
+    established with - see `identityForRestore`, and the warning at the top of this module.
+
+    The two halves are not the same kind of thing, which is why only one of them is asked for.
+    The serial is a label, chosen by this app and free to be the same on every install. The
+    machine is not a choice at all: it has to match what this particular install already told
+    Apple during ADI provisioning, so it is read rather than decided.
+
+    Returns keyword arguments for the provider, so a library that grows another identity field
+    fails loudly here instead of silently dropping it.
+    """
+    kwargs: dict = {"serial": APP_SERIAL}
+
+    identity = hardwareProfile(localAnisette)
+    if identity is not None:
+        kwargs["identity"] = identity
+
+    return kwargs
 
 
 def identityForRestore(previous: Any) -> dict:

--- a/app/src/main/python/identity.py
+++ b/app/src/main/python/identity.py
@@ -12,49 +12,94 @@ the other. Two entries sharing a prefix sort together and read as one project, w
 recognised and removed on its own.
 
 .. warning::
-    **Changing the serial adds an entry rather than renaming one**, and may require signing in
-    again: Apple binds a session to the identity that established it. Not a thing to adjust once
-    it has shipped.
+    **This applies to new sessions only.** Apple binds a session to the identity that
+    established it, so handing this to an account that was signed in under FindMy.py's default
+    would cost that user a sign-in and leave a second, unrecognisable entry in their device
+    list. Somebody already signed in keeps what they have - see `identityForRestore`.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
+from findmy.reports.anisette import DeviceIdentity
+
 APP_SERIAL = "0PENTAGVIEWR"
 """
-The serial this app presents, in `X-Apple-I-SRL-NO`.
+The serial a new session presents, in `X-Apple-I-SRL-NO`.
 
 Twelve uppercase alphanumeric characters, which is the shape Apple accepts, and deliberately
 implausible as real hardware so nothing mistakes it for a Mac. It shares its prefix with the
 exporter's `0PENTAGXPORT` so a user seeing both recognises them as the same project.
 
-Without this the app presents FindMy.py's default, `0FINDMYPY001` - which names the library
+Without this a session presents FindMy.py's default, `0FINDMYPY001` - which names the library
 rather than the program, in the one place the user ever looks.
 """
 
-KNOWN_IDENTITY_MISMATCH = (
-    "<MacBookPro13,2> <macOS;13.1;22C65>",
-    "<MacBookPro18,3> <Mac OS X;13.4.1;22F8>",
+APP_IDENTITY = DeviceIdentity(
+    model="MacBookPro13,2",
+    os_name="macOS",
+    os_version="13.1",
+    os_build="22C65",
+    cfnetwork="1404.0.5",
+    darwin="22.2.0",
 )
 """
-**The one part of the identity that does not agree with itself yet.**
+The machine a new session claims to be - **the same one ADI is initialised with**.
 
-Rule 11 requires the model, OS version and build to describe one real release. They do not:
+This is the whole point of it. `AdiDeviceIdentity.CLIENT_INFO` on the Java side sends
+`<MacBookPro13,2> <macOS;13.1;22C65>` when it provisions ADI, and FindMy.py used to send a
+MacBook Pro 18,3 on macOS 13.4.1 from its own defaults. One app, one session, two different
+Macs - down to the OS *name*, `macOS` against `Mac OS X`. Rule 11 exists to prevent exactly
+that, and until FindMy.py grew `DeviceIdentity` there was nowhere to say otherwise.
 
-- `AdiDeviceIdentity.CLIENT_INFO` on the Java side sends the first of these, a 2016 13-inch
-  MacBook Pro on macOS 13.1.
-- FindMy.py sends the second from `reports/anisette.py` and `reports/account.py` - a 2021 14-inch
-  M1 Pro on 13.4.1. Note even the OS *name* differs, `macOS` against `Mac OS X`.
+**Moved to match Java rather than the other way round**, because the ADI string is the half
+that is also baked into how ADI was provisioned on the device.
 
-So one app claims to be two different Macs in one session, which is the contradiction rule 11
-exists to prevent. It is recorded here rather than fixed because the second string is hardcoded
-inside the library - `reports/anisette.py` and `reports/account.py` both carry a copy - and there
-is nowhere to pass one in. A request to expose it has gone to FindMy.py, the sibling of the one
-that produced `serial=`.
-
-**Do not "fix" this by editing the Java string to match.** That changes the login identity, which
-costs every existing user a sign-in and leaves a stale entry in their device list - the same cost
-as the serial change, and worth paying once rather than twice. When the library can be told, both
-move together in one deliberate change.
-
-This constant is not sent anywhere. It exists so the discrepancy has a name and a test.
+The six parts describe one real release and move together: macOS 13.1 is build 22C65,
+CFNetwork 1404.0.5, Darwin 22.2.0. Nothing validates that - FindMy.py has no copy of Apple's
+release table - so changing one means changing all six deliberately.
 """
+
+# **There is deliberately no device name here, and no announce_device() call.**
+#
+# Naming the device-list entry needs `announce_device()`, which authenticates with the
+# `com.apple.gs.idms.hb` heartbeat token. That token arrives once, in the same set as the PET,
+# and an account serialised before FindMy.py started keeping it has nothing to announce with -
+# so for the installed base it does not work, and getting it to work means those users signing
+# in again. Not worth a re-login for a label.
+#
+# The serial carries the recognisability on its own: an entry reading `0PENTAGVIEWR` is
+# identifiable as software the user installed, which is the thing that stops them removing it.
+# The row is still titled after the claimed model, and that is accepted.
+
+
+def identityForRestore(previous: Any) -> dict:
+    """
+    The identity a *restored* account should keep: whatever it already had.
+
+    **Not this app's.** A session signed in before any of this was bound to FindMy.py's
+    defaults, and handing it `APP_SERIAL` now would present Apple with a different machine on
+    an existing session - a sign-in for the user, and a second device-list entry they did not
+    ask for. The gain would be a nicer name on an entry they have already learned to recognise.
+
+    So the identity is read off the provider FindMy.py rebuilt from the stored account, and
+    carried across unchanged. That matters because this is called while swapping the Anisette
+    *transport* - local for remote - and **swapping the transport must not change the machine**.
+    Rule 4 says the same thing from the other side: local and remote Anisette present different
+    identities, and changing identity requires a re-login.
+
+    Returns the keyword arguments to construct the replacement provider with, so a library that
+    grows another identity field fails here loudly rather than silently dropping it.
+    """
+    kwargs: dict = {}
+
+    serial = getattr(previous, "serial", None)
+    if serial is not None:
+        kwargs["serial"] = serial
+
+    identity = getattr(previous, "identity", None)
+    if identity is not None:
+        kwargs["identity"] = identity
+
+    return kwargs

--- a/app/src/main/python/identity.py
+++ b/app/src/main/python/identity.py
@@ -132,6 +132,46 @@ def identityForNewSession(localAnisette: Any) -> dict:
     return kwargs
 
 
+def deviceIdsForNewSession(localAnisette: Any) -> dict:
+    """
+    The two ids this installation **already introduced itself to Apple with**.
+
+    ADI provisioning is its own exchange, made before FindMy.py is involved, and it carries
+    `X-Mme-Device-Id` and `X-Apple-I-MD-LU`. Without these FindMy.py mints a fresh random pair,
+    so one install talks to Apple as two devices - and `X-Mme-Device-Id` is the field Apple is
+    most likely to correlate on, since identifying a particular installation is what it is for.
+
+    **The uid is passed as Java stores it, not as Java sends it.** FindMy.py base64-encodes it
+    on the way out; handing over the encoded form would encode it twice and produce a value
+    nobody has ever seen. Which of the two conventions Java's own header used is decided per
+    hardware profile - see `AdiDeviceIdentity.Hardware#localUserHeader`. A fresh install agrees
+    on both. An install from before profiles existed provisioned under the raw convention, which
+    cannot be reproduced through base64, so for those two the device id aligns and the local
+    user id does not; passing it anyway at least keeps it stable across sign-ins.
+
+    Both or neither. FindMy.py raises on one of two, deliberately: a client matching one id and
+    minting the other is a shape no real client produces, and looks worse than matching neither.
+
+    New sessions only, like everything else here. A restored account keeps the pair it was
+    established with, and `state_info` wins over these upstream in any case.
+    """
+    if localAnisette is None:
+        return {}
+
+    try:
+        payload = json.loads(str(localAnisette.deviceIdsJson()))
+        ids = {"uid": payload["uid"], "devid": payload["devid"]}
+    except Exception:
+        print(f"Could not read this installation's ids from Java: {traceback.format_exc()}")
+        return {}
+
+    if not all(ids.values()):
+        print(f"Java gave an incomplete pair of ids ({ids}) - letting FindMy.py mint its own.")
+        return {}
+
+    return ids
+
+
 def identityForRestore(previous: Any) -> dict:
     """
     The identity a *restored* account should keep: whatever it already had.

--- a/app/src/main/python/main.py
+++ b/app/src/main/python/main.py
@@ -251,7 +251,10 @@ def loginSync(email: str, password: str, anisetteServerUrl: str,
             localAnisette,
             **app_identity.identityForNewSession(localAnisette),
         )
-        acc = AppleAccount(anisette)
+        # And the two ids the same install already used when it provisioned ADI, so this is one
+        # device rather than two that happen to share a serial. Empty when Java cannot say, in
+        # which case FindMy.py mints its own pair exactly as it always did.
+        acc = AppleAccount(anisette, **app_identity.deviceIdsForNewSession(localAnisette))
 
         state = acc.login(email, password)
 

--- a/app/src/main/python/main.py
+++ b/app/src/main/python/main.py
@@ -241,11 +241,15 @@ def loginSync(email: str, password: str, anisetteServerUrl: str,
         # A new sign-in, so this is the one place the app's own identity is used. Everything
         # restored from a stored account keeps whatever it was established with - see
         # identity.identityForRestore, and the warning on identity.APP_SERIAL.
+        #
+        # The machine half comes from Java, which persists it per install: an install from
+        # before there was a choice keeps the Mac its ADI was provisioned with, and a fresh one
+        # is an iPhone. Passed even when local Anisette turns out to be unusable, because a
+        # sign-in relayed through a server must still claim the same machine.
         anisette = _anisetteProvider(
             anisetteServerUrl,
             localAnisette,
-            serial=app_identity.APP_SERIAL,
-            identity=app_identity.APP_IDENTITY,
+            **app_identity.identityForNewSession(localAnisette),
         )
         acc = AppleAccount(anisette)
 

--- a/app/src/main/python/main.py
+++ b/app/src/main/python/main.py
@@ -22,7 +22,7 @@ from findmy.reports.twofactor import (
     SyncSecondFactorMethod
 )
 
-from identity import APP_SERIAL
+import identity as app_identity
 
 
 class TwoFactorMethods(Enum):
@@ -167,12 +167,13 @@ class LocalAnisetteProvider(BaseAnisetteProvider):
     came from here or from a server is a transport detail, not part of the account.
     """
 
-    def __init__(self, bridge: Any, fallbackServerUrl: str) -> None:
-        # The app's own serial, not the library's default - see identity.APP_SERIAL. Both
-        # providers have to pass it: which one produced a session is a transport detail, and a
-        # user whose Anisette fell back to a server must not acquire a second device-list entry
-        # for it.
-        super().__init__(serial=APP_SERIAL)
+    def __init__(self, bridge: Any, fallbackServerUrl: str, **identityKwargs: Any) -> None:
+        # Whatever identity the caller decides - the app's for a new sign-in, and the one the
+        # restored account already had when this is replacing a rebuilt provider. Defaulted to
+        # nothing rather than to the app's, so that a path which forgets to say inherits
+        # FindMy.py's default and costs nobody a re-login, instead of silently re-identifying
+        # an existing session.
+        super().__init__(**identityKwargs)
         self._bridge = bridge
         self._fallbackServerUrl = fallbackServerUrl
 
@@ -206,19 +207,24 @@ class LocalAnisetteProvider(BaseAnisetteProvider):
         pass
 
 
-def _anisetteProvider(anisetteServerUrl: str, localAnisette: Any = None):
+def _anisetteProvider(anisetteServerUrl: str, localAnisette: Any = None, **identityKwargs: Any):
     """Prefer this device, fall back to the configured server.
 
     The fallback is not a nicety. Apple can change their libraries at any time, the download
     needs network the first time, and the whole mechanism is an optimisation over something
     that already works - so anything going wrong here has to degrade to the old behaviour
     rather than fail a login.
+
+    **The identity is the caller's to supply, and both branches get the same one.** Which kind
+    of Anisette produced a session is a transport detail; a user whose local Anisette fell back
+    to a server must not thereby become a different machine, because that is a re-login and a
+    second device-list entry for something they did not do.
     """
     if localAnisette is not None:
         try:
             if localAnisette.ensureReady():
                 print(f"Using local Anisette: {localAnisette.describe()}")
-                return LocalAnisetteProvider(localAnisette, anisetteServerUrl)
+                return LocalAnisetteProvider(localAnisette, anisetteServerUrl, **identityKwargs)
             print(
                 "Local Anisette unavailable, using the remote server instead: "
                 f"{localAnisette.unavailableReason()}"
@@ -226,13 +232,21 @@ def _anisetteProvider(anisetteServerUrl: str, localAnisette: Any = None):
         except Exception:
             print(f"Local Anisette failed, using the remote server: {traceback.format_exc()}")
 
-    return RemoteAnisetteProvider(anisetteServerUrl, serial=APP_SERIAL)
+    return RemoteAnisetteProvider(anisetteServerUrl, **identityKwargs)
 
 
 def loginSync(email: str, password: str, anisetteServerUrl: str,
               localAnisette: Any = None) -> dict:
     try:
-        anisette = _anisetteProvider(anisetteServerUrl, localAnisette)
+        # A new sign-in, so this is the one place the app's own identity is used. Everything
+        # restored from a stored account keeps whatever it was established with - see
+        # identity.identityForRestore, and the warning on identity.APP_SERIAL.
+        anisette = _anisetteProvider(
+            anisetteServerUrl,
+            localAnisette,
+            serial=app_identity.APP_SERIAL,
+            identity=app_identity.APP_IDENTITY,
+        )
         acc = AppleAccount(anisette)
 
         state = acc.login(email, password)
@@ -379,10 +393,19 @@ def _preferLocalAnisette(acc: AppleAccount, localAnisette: Any) -> None:
             print("FindMy's account internals have changed; keeping the remote provider")
             return
 
+        # Carried across from the provider FindMy just rebuilt, not taken from this app's
+        # identity: swapping the Anisette transport must not change the machine Apple sees.
+        # An account signed in before any of this restores to FindMy.py's defaults and keeps
+        # them, which is what spares that user a re-login.
+        carried = app_identity.identityForRestore(previous)
+
         inner._anisette = LocalAnisetteProvider(
-            localAnisette, getattr(previous, "_server_url", "")
+            localAnisette, getattr(previous, "_server_url", ""), **carried
         )
-        print(f"Restored account switched to local Anisette: {localAnisette.describe()}")
+        print(
+            f"Restored account switched to local Anisette: {localAnisette.describe()}"
+            f" (keeping serial {carried.get('serial', 'FindMy default')})"
+        )
     except Exception:
         print(f"Could not switch to local Anisette: {traceback.format_exc()}")
 

--- a/app/src/main/python/main.py
+++ b/app/src/main/python/main.py
@@ -441,13 +441,21 @@ def getAccount(
 
         print(f"Restored account, login state: {acc.login_state}")
         if acc.login_state != LoginState.LOGGED_IN:
-            # Worth saying plainly rather than leaving to the traceback that follows minutes
-            # later from somewhere else entirely. This is the state that makes every fetch
-            # raise InvalidStateError with nothing sent.
+            # **Not a successful restore, and it used to be treated as one.** This account is
+            # readable and unusable: every fetch fails its state check before a request is even
+            # made, so the app came up showing stale pins and spinners that stopped, with the
+            # reason only in the log. Issue #43.
+            #
+            # Reported as a failure so the caller can do the one thing that helps - send the
+            # user to sign in again. That is safe here because the app only ever stores an
+            # account after a completed sign-in: mid-2FA state is never written, so this state
+            # can only mean the session went bad afterwards.
             print(
-                "Restored account is NOT logged in - every report fetch will fail its state "
-                "check before any request is made. See issue #43."
+                f"Restored account is not logged in (state: {acc.login_state}) - Apple has "
+                "stopped accepting this session. Treating it as a failed restore so the user "
+                "is asked to sign in again rather than left with a map that never updates."
             )
+            return None
 
         return acc
     except Exception:

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -108,7 +108,6 @@
     <string name="map_provider">Kartenanbieter</string>
     <string name="map_provider_google">Google Maps</string>
     <string name="map_provider_amap">AMap (高德地图)</string>
-    <string name="relogin_required_after_upgrade">Bitte melden Sie sich erneut an – die FindMy-Bibliothek wurde aktualisiert.</string>
     <string name="maps_api_key_missing_title">Google Maps API-Schlüssel fehlt</string>
     <string name="maps_api_key_missing_message">Dieser Build enthält keinen Google Maps API-Schlüssel, daher wird die Karte nicht geladen. Fügen Sie MAPS_API_KEY zu secrets.properties hinzu und erstellen Sie den Build neu, oder wählen Sie in den Einstellungen einen anderen Kartenanbieter.</string>
     <string name="resolving_tags_banner">Ihre Tags werden zum ersten Mal geortet. Das kann einige Minuten dauern – bitte lassen Sie die App geöffnet.</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">Mit diesem Code ließ sich das Bündel nicht öffnen. Vergleiche ihn mit dem, den der Exporter angezeigt hat.</string>
     <string name="import_failed_locked">Dieses Bündel ist gesperrt und es wurde kein Code eingegeben.</string>
     <string name="bundle_passcode_malformed">Ein Code besteht nur aus Ziffern und Buchstaben.</string>
+    <string name="session_expired_title">Bitte erneut anmelden</string>
+    <string name="session_expired_message">Apple akzeptiert die gespeicherte Anmeldung dieses Geräts nicht mehr. Ihre Tags können erst wieder geortet werden, wenn Sie sich erneut anmelden.
+
+Ihre Tags und deren Standortverlauf bleiben auf diesem Telefon – es ist nichts verloren gegangen.</string>
+    <string name="ok">OK</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -108,7 +108,6 @@
     <string name="map_provider">Map Provider</string>
     <string name="map_provider_google">Google Maps</string>
     <string name="map_provider_amap">AMap (高德地图)</string>
-    <string name="relogin_required_after_upgrade">Please sign in again — the FindMy library has been updated.</string>
     <string name="maps_api_key_missing_title">Google Maps API key missing</string>
     <string name="maps_api_key_missing_message">This build has no Google Maps API key, so the map will not load. Add MAPS_API_KEY to secrets.properties and rebuild, or pick a different map provider in Settings.</string>
     <string name="resolving_tags_banner">Locating your tags for the first time. This can take a few minutes — please keep the app open.</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">That code did not open the bundle. Check it against the one the exporter showed.</string>
     <string name="import_failed_locked">This bundle is locked and no code was entered.</string>
     <string name="bundle_passcode_malformed">A code is made of digits and letters only.</string>
+    <string name="session_expired_title">Please sign in again</string>
+    <string name="session_expired_message">Apple no longer accepts the saved sign-in for this device, so your tags cannot be located until you sign in again.
+
+Your tags and their location history stay on this phone — nothing has been lost.</string>
+    <string name="ok">OK</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -108,7 +108,6 @@
     <string name="map_provider">Fournisseur de cartes</string>
     <string name="map_provider_google">Google Maps</string>
     <string name="map_provider_amap">AMap (高德地图)</string>
-    <string name="relogin_required_after_upgrade">Veuillez vous reconnecter : la bibliothèque FindMy a été mise à jour.</string>
     <string name="maps_api_key_missing_title">Clé API Google Maps manquante</string>
     <string name="maps_api_key_missing_message">Cette version ne contient pas de clé API Google Maps, la carte ne se chargera donc pas. Ajoutez MAPS_API_KEY à secrets.properties et recompilez, ou choisissez un autre fournisseur de cartes dans les paramètres.</string>
     <string name="resolving_tags_banner">Localisation de vos balises pour la première fois. Cela peut prendre quelques minutes : veuillez laisser l’application ouverte.</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">Ce code n’a pas ouvert l’archive. Vérifiez-le par rapport à celui affiché par l’exportateur.</string>
     <string name="import_failed_locked">Cette archive est verrouillée et aucun code n’a été saisi.</string>
     <string name="bundle_passcode_malformed">Un code se compose uniquement de chiffres et de lettres.</string>
+    <string name="session_expired_title">Veuillez vous reconnecter</string>
+    <string name="session_expired_message">Apple n’accepte plus la connexion enregistrée pour cet appareil : vos balises ne peuvent pas être localisées tant que vous ne vous reconnectez pas.
+
+Vos balises et leur historique de position restent sur ce téléphone — rien n’a été perdu.</string>
+    <string name="ok">OK</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -108,7 +108,6 @@
     <string name="map_provider">地図プロバイダ</string>
     <string name="map_provider_google">Google マップ</string>
     <string name="map_provider_amap">AMap (高德地图)</string>
-    <string name="relogin_required_after_upgrade">FindMy ライブラリが更新されました。もう一度サインインしてください。</string>
     <string name="maps_api_key_missing_title">Google マップ API キーがありません</string>
     <string name="maps_api_key_missing_message">このビルドには Google マップ API キーがないため、地図を読み込めません。secrets.properties に MAPS_API_KEY を追加してビルドし直すか、設定で別の地図プロバイダを選択してください。</string>
     <string name="resolving_tags_banner">タグの位置を初めて特定しています。数分かかる場合があります。アプリを開いたままにしてください。</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">このコードではバンドルを開けませんでした。エクスポーターが表示したコードと照らし合わせてください。</string>
     <string name="import_failed_locked">このバンドルはロックされていますが、コードが入力されていません。</string>
     <string name="bundle_passcode_malformed">コードは数字と英字のみで構成されます。</string>
+    <string name="session_expired_title">もう一度サインインしてください</string>
+    <string name="session_expired_message">この端末に保存されたサインインが Apple に受け付けられなくなりました。もう一度サインインするまで、タグの位置を取得できません。
+
+タグと位置履歴はこの端末に残っています。失われたものはありません。</string>
+    <string name="ok">OK</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -108,7 +108,6 @@
     <string name="map_provider">지도 제공자</string>
     <string name="map_provider_google">Google 지도</string>
     <string name="map_provider_amap">AMap (高德地图)</string>
-    <string name="relogin_required_after_upgrade">FindMy 라이브러리가 업데이트되었습니다. 다시 로그인해 주세요.</string>
     <string name="maps_api_key_missing_title">Google 지도 API 키가 없습니다</string>
     <string name="maps_api_key_missing_message">이 빌드에는 Google 지도 API 키가 없어 지도를 불러올 수 없습니다. secrets.properties에 MAPS_API_KEY를 추가한 후 다시 빌드하거나, 설정에서 다른 지도 제공자를 선택하세요.</string>
     <string name="resolving_tags_banner">태그의 위치를 처음으로 확인하는 중입니다. 몇 분 정도 걸릴 수 있으니 앱을 열어 두세요.</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">이 코드로는 번들을 열 수 없습니다. 내보내기 도구가 표시한 코드와 대조해 보세요.</string>
     <string name="import_failed_locked">이 번들은 잠겨 있으며 코드가 입력되지 않았습니다.</string>
     <string name="bundle_passcode_malformed">코드는 숫자와 영문자로만 이루어집니다.</string>
+    <string name="session_expired_title">다시 로그인해 주세요</string>
+    <string name="session_expired_message">Apple이 이 기기에 저장된 로그인을 더 이상 받아들이지 않습니다. 다시 로그인하기 전까지는 태그의 위치를 찾을 수 없습니다.
+
+태그와 위치 기록은 이 휴대전화에 그대로 남아 있습니다. 사라진 것은 없습니다.</string>
+    <string name="ok">확인</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -108,7 +108,6 @@
     <string name="map_provider">Kaartaanbieder</string>
     <string name="map_provider_google">Google Maps</string>
     <string name="map_provider_amap">AMap (高德地图)</string>
-    <string name="relogin_required_after_upgrade">Log opnieuw in — de FindMy-bibliotheek is bijgewerkt.</string>
     <string name="maps_api_key_missing_title">Google Maps API-sleutel ontbreekt</string>
     <string name="maps_api_key_missing_message">Deze build heeft geen Google Maps API-sleutel, dus de kaart wordt niet geladen. Voeg MAPS_API_KEY toe aan secrets.properties en bouw opnieuw, of kies een andere kaartaanbieder in de instellingen.</string>
     <string name="resolving_tags_banner">Je tags worden voor het eerst gelokaliseerd. Dit kan een paar minuten duren — houd de app open.</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">Met die code ging de bundel niet open. Vergelijk hem met de code die de exporter toonde.</string>
     <string name="import_failed_locked">Deze bundel is vergrendeld en er is geen code ingevoerd.</string>
     <string name="bundle_passcode_malformed">Een code bestaat alleen uit cijfers en letters.</string>
+    <string name="session_expired_title">Log opnieuw in</string>
+    <string name="session_expired_message">Apple accepteert de opgeslagen aanmelding van dit apparaat niet meer, dus je tags kunnen pas weer worden gelokaliseerd nadat je opnieuw inlogt.
+
+Je tags en hun locatiegeschiedenis blijven op deze telefoon staan — er is niets verloren gegaan.</string>
+    <string name="ok">OK</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -108,7 +108,6 @@
     <string name="map_provider">Поставщик карт</string>
     <string name="map_provider_google">Google Карты</string>
     <string name="map_provider_amap">AMap (高德地图)</string>
-    <string name="relogin_required_after_upgrade">Пожалуйста, войдите снова — библиотека FindMy была обновлена.</string>
     <string name="maps_api_key_missing_title">Отсутствует ключ API Google Карт</string>
     <string name="maps_api_key_missing_message">В этой сборке нет ключа API Google Карт, поэтому карта не загрузится. Добавьте MAPS_API_KEY в secrets.properties и пересоберите приложение или выберите другого поставщика карт в настройках.</string>
     <string name="resolving_tags_banner">Первое определение местоположения ваших меток. Это может занять несколько минут — не закрывайте приложение.</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">Этот код не открыл архив. Сверьте его с тем, что показал экспортёр.</string>
     <string name="import_failed_locked">Этот архив заблокирован, а код не введён.</string>
     <string name="bundle_passcode_malformed">Код состоит только из цифр и букв.</string>
+    <string name="session_expired_title">Войдите снова</string>
+    <string name="session_expired_message">Apple больше не принимает сохранённый вход для этого устройства, поэтому найти метки не получится, пока вы не войдёте снова.
+
+Ваши метки и история их местоположений остаются на этом телефоне — ничего не потеряно.</string>
+    <string name="ok">ОК</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -96,7 +96,6 @@
     <string name="map_provider">地图提供商</string>
     <string name="map_provider_google">Google 地图</string>
     <string name="map_provider_amap">高德地图 (AMap)</string>
-    <string name="relogin_required_after_upgrade">FindMy 库已更新，请重新登录。</string>
     <string name="amap_api_key_explanation">高德地图需要您自行提供 API Key。请前往 lbs.amap.com 注册，平台选择“Android 平台 SDK”，然后将 Key 粘贴到此处。</string>
     <string name="amap_copy_registration_details">复制包名和 SHA1</string>
     <string name="amap_registration_details_copied">已复制。创建 Key 时请将这些信息粘贴到高德控制台。</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">该代码无法解开此导出包。请与导出工具显示的代码核对。</string>
     <string name="import_failed_locked">此导出包已加密，但未输入代码。</string>
     <string name="bundle_passcode_malformed">代码仅由数字和字母组成。</string>
+    <string name="session_expired_title">请重新登录</string>
+    <string name="session_expired_message">Apple 不再接受本设备上保存的登录信息，重新登录后才能定位你的标签。
+
+标签及其位置历史仍保存在这部手机上，没有任何数据丢失。</string>
+    <string name="ok">好</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -96,7 +96,6 @@
     <string name="map_provider">地圖提供商</string>
     <string name="map_provider_google">Google 地圖</string>
     <string name="map_provider_amap">高德地圖 (AMap)</string>
-    <string name="relogin_required_after_upgrade">FindMy 函式庫已更新，請重新登入。</string>
     <string name="amap_api_key_explanation">高德地圖需要您自行提供 API Key。請前往 lbs.amap.com 註冊，平台選擇「Android 平台 SDK」，然後將 Key 貼到此處。</string>
     <string name="amap_copy_registration_details">複製套件名稱與 SHA1</string>
     <string name="amap_registration_details_copied">已複製。建立 Key 時請將這些資訊貼到高德主控台。</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">該代碼無法解開此匯出包。請與匯出工具顯示的代碼核對。</string>
     <string name="import_failed_locked">此匯出包已加密，但未輸入代碼。</string>
     <string name="bundle_passcode_malformed">代碼僅由數字和字母組成。</string>
+    <string name="session_expired_title">請重新登入</string>
+    <string name="session_expired_message">Apple 不再接受本裝置上儲存的登入資訊，重新登入後才能定位你的標籤。
+
+標籤及其位置紀錄仍保留在這支手機上，沒有任何資料遺失。</string>
+    <string name="ok">好</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,7 +129,6 @@
     <string name="map_provider">Map Provider</string>
     <string name="map_provider_google">Google Maps</string>
     <string name="map_provider_amap">高德地图 (AMap)</string>
-    <string name="relogin_required_after_upgrade">Please sign in again — the FindMy library has been updated.</string>
     <string name="amap_api_key" translatable="false">AMap API Key</string>
     <string name="amap_api_key_explanation">AMap requires each user to supply their own API key. Register one at lbs.amap.com, choosing "Android SDK" as the platform, and paste it here.</string>
     <string name="amap_copy_registration_details">Copy package name and SHA1</string>
@@ -195,4 +194,9 @@
     <string name="import_failed_locked">This bundle is locked and no code was entered.</string>
     <string name="bundle_passcode_malformed">A code is made of digits and letters only.</string>
     <string name="bundle_passcode_group_separator" translatable="false">-</string>
+    <string name="session_expired_title">Please sign in again</string>
+    <string name="session_expired_message">Apple no longer accepts the saved sign-in for this device, so your tags cannot be located until you sign in again.
+
+Your tags and their location history stay on this phone — nothing has been lost.</string>
+    <string name="ok">OK</string>
 </resources>

--- a/app/src/test/python/requirements.txt
+++ b/app/src/test/python/requirements.txt
@@ -9,7 +9,7 @@
 # `FindMy==0.9.8` here for as long as the app built the fork, so every bridge test
 # ran against a library the app does not ship - which is not a small difference:
 # the fork's Anisette providers take `serial=` and PyPI's do not.
-git+https://github.com/parawanderer/FindMy.py@acd17c507b63e8bd0e56d8b4c5a92c096050bfa3
+git+https://github.com/parawanderer/FindMy.py@7bb292dc469cf087db942cda24d77b2e3ff511ff
 NSKeyedUnArchiver==1.5
 
 pytest>=8.0

--- a/app/src/test/python/requirements.txt
+++ b/app/src/test/python/requirements.txt
@@ -9,7 +9,7 @@
 # `FindMy==0.9.8` here for as long as the app built the fork, so every bridge test
 # ran against a library the app does not ship - which is not a small difference:
 # the fork's Anisette providers take `serial=` and PyPI's do not.
-git+https://github.com/parawanderer/FindMy.py@7bb292dc469cf087db942cda24d77b2e3ff511ff
+git+https://github.com/parawanderer/FindMy.py@2ea738aafbf86b2f9455704b81fc731c732c863b
 NSKeyedUnArchiver==1.5
 
 pytest>=8.0

--- a/app/src/test/python/requirements.txt
+++ b/app/src/test/python/requirements.txt
@@ -9,7 +9,7 @@
 # `FindMy==0.9.8` here for as long as the app built the fork, so every bridge test
 # ran against a library the app does not ship - which is not a small difference:
 # the fork's Anisette providers take `serial=` and PyPI's do not.
-git+https://github.com/parawanderer/FindMy.py@2ea738aafbf86b2f9455704b81fc731c732c863b
+git+https://github.com/parawanderer/FindMy.py@102dd8ea14767d2a2aa745186ac23276f32689f1
 NSKeyedUnArchiver==1.5
 
 pytest>=8.0

--- a/app/src/test/python/test_identity.py
+++ b/app/src/test/python/test_identity.py
@@ -15,11 +15,13 @@ login succeeds or does not, and the evidence is in somebody else's Apple account
 
 from __future__ import annotations
 
+import base64
 import json
 
 import identity
 import main
-from findmy.reports import RemoteAnisetteProvider
+import pytest
+from findmy.reports import AppleAccount, RemoteAnisetteProvider
 from findmy.reports.anisette import CLIENT_IDENTITY, CLIENT_SERIAL, DeviceIdentity
 
 # What Java sends for each of its two profiles. Copies, and only usable as copies: nothing here
@@ -44,11 +46,19 @@ IPHONE = {
 }
 
 
+UID = "9E1D0C4B-77A2-4E3F-8D51-2B6A0F9C3D74"
+DEVID = "1A2B3C4D-5E6F-4071-8293-A4B5C6D7E8F9"
+
+
 class Bridge:
     """A local-Anisette bridge that works."""
 
-    def __init__(self, profile=None):
+    def __init__(self, profile=None, ids=None):
         self._profile = IPHONE if profile is None else profile
+        self._ids = {"uid": UID, "devid": DEVID} if ids is None else ids
+
+    def deviceIdsJson(self):
+        return json.dumps(self._ids)
 
     def ensureReady(self):
         return True
@@ -151,6 +161,91 @@ class TestTheIdentityANewSessionPresents:
         assert identity.identityForNewSession(Bridge(LEGACY_MAC))["serial"] == identity.APP_SERIAL
 
 
+class TestTheIdsANewSessionIntroducesItselfWith:
+    """
+    The half that stops one install being two devices.
+
+    ADI provisioning tells Apple `X-Mme-Device-Id` and `X-Apple-I-MD-LU` before FindMy.py
+    exists. Left to itself the library mints a fresh random pair, so the same app arrives twice
+    under two identifiers — which already cost the desktop exporter a device-list entry per run.
+    """
+
+    def test_both_ids_come_from_java(self):
+        assert identity.deviceIdsForNewSession(Bridge()) == {"uid": UID, "devid": DEVID}
+
+    def test_the_account_actually_sends_them(self):
+        """
+        Through the library, not just out of this function.
+
+        `uid` and `devid` are private attributes; the only honest check is to build an account
+        and read back what it says it is.
+        """
+        account = AppleAccount(
+            RemoteAnisetteProvider("https://example.invalid"),
+            **identity.deviceIdsForNewSession(Bridge()),
+        )
+
+        assert account.device_uuid == DEVID
+        assert account.local_user_uuid == UID
+
+    def test_the_uid_is_passed_as_stored_and_not_as_java_sends_it(self):
+        """
+        The trap this whole design turns on.
+
+        FindMy.py base64-encodes the uid on the way out, and Java's own header for a fresh
+        install is base64 of the same string. Passing the *encoded* form here would encode it
+        twice and produce a value Apple has never seen from anybody.
+        """
+        account = AppleAccount(
+            RemoteAnisetteProvider("https://example.invalid"),
+            **identity.deviceIdsForNewSession(Bridge()),
+        )
+
+        assert account.local_user_uuid == UID
+        assert base64.b64decode(
+            base64.b64encode(account.local_user_uuid.encode())
+        ).decode() == UID
+
+    def test_one_of_two_is_refused_by_the_library(self):
+        """
+        Not this module's rule, but the reason it never passes a half pair.
+
+        A client matching one id and minting the other is a shape no real client produces.
+        """
+        with pytest.raises(ValueError):
+            AppleAccount(RemoteAnisetteProvider("https://example.invalid"), uid=UID)
+
+    def test_a_half_pair_from_java_is_dropped_entirely(self):
+        for ids in ({"uid": UID, "devid": ""}, {"uid": "", "devid": DEVID}):
+            assert identity.deviceIdsForNewSession(Bridge(ids=ids)) == {}
+
+    def test_a_missing_key_is_dropped_rather_than_half_applied(self):
+        assert identity.deviceIdsForNewSession(Bridge(ids={"uid": UID})) == {}
+
+    def test_a_restored_account_keeps_its_own_pair_whatever_is_passed(self):
+        """
+        `state_info` wins upstream, and this app depends on that.
+
+        Somebody already signed in has a pair Apple associates with their session; replacing it
+        because this install happens to know a different one is a re-identification.
+        """
+        established = AppleAccount(
+            RemoteAnisetteProvider("https://example.invalid"),
+            **identity.deviceIdsForNewSession(Bridge()),
+        )
+        stored = established.to_json()
+
+        restored = AppleAccount(
+            RemoteAnisetteProvider("https://example.invalid"),
+            state_info=stored,
+            uid="00000000-0000-4000-8000-000000000000",
+            devid="11111111-1111-4111-8111-111111111111",
+        )
+
+        assert restored.device_uuid == DEVID
+        assert restored.local_user_uuid == UID
+
+
 class TestWhenJavaCannotBeAsked:
     """
     Every one of these ends in a login that works and a device-list entry that is wrong.
@@ -162,6 +257,14 @@ class TestWhenJavaCannotBeAsked:
     def test_no_bridge_at_all_imposes_nothing(self):
         assert identity.hardwareProfile(None) is None
         assert identity.identityForNewSession(None) == {"serial": identity.APP_SERIAL}
+        assert identity.deviceIdsForNewSession(None) == {}
+
+    def test_a_bridge_that_cannot_give_ids_lets_the_library_mint_its_own(self):
+        class Broken(Bridge):
+            def deviceIdsJson(self):
+                raise RuntimeError("no such method")
+
+        assert identity.deviceIdsForNewSession(Broken()) == {}
 
     def test_a_bridge_that_throws_does_not_take_the_login_with_it(self):
         class Broken(Bridge):

--- a/app/src/test/python/test_identity.py
+++ b/app/src/test/python/test_identity.py
@@ -1,12 +1,16 @@
 """
-What the app presents itself as to Apple.
+What the app presents itself as to Apple, and — the harder half — when it does not.
 
-This is not a cosmetic string. It becomes a row in the user's Apple account device list, next to
-a *Remove from Account* button and the words "If you do not recognise this device" - so a wrong
-or inconsistent value gets the user to remove the thing that was working. Rule 11.
+This becomes a row in the user's Apple account device list, next to a *Remove from Account*
+button and the words "If you do not recognise this device". Rule 11.
 
-Tested here rather than trusted because the failure is silent and remote: nothing throws, the
-login succeeds, and the only symptom is an entry the user cannot identify.
+**The rule that shapes all of it: a new identity is for a new session only.** Apple binds a
+session to the identity that established it, so re-identifying an existing one costs that user
+a sign-in and leaves a second entry they never asked for. Someone already signed in keeps what
+they have, unrecognisable name and all, because the alternative is worse for them.
+
+Tested rather than trusted because every failure here is silent and remote: nothing throws, the
+login succeeds or does not, and the evidence is in somebody else's Apple account.
 """
 
 from __future__ import annotations
@@ -14,120 +18,166 @@ from __future__ import annotations
 import identity
 import main
 from findmy.reports import RemoteAnisetteProvider
-from findmy.reports.anisette import CLIENT_SERIAL
+from findmy.reports.anisette import CLIENT_IDENTITY, CLIENT_SERIAL, DeviceIdentity
 
 
-class TestTheSerialTheAppPresents:
-    def test_it_is_the_apps_own_and_not_the_librarys(self):
-        # 0FINDMYPY001 names FindMy.py. A user reading their device list should see this app.
+class Bridge:
+    """A local-Anisette bridge that works."""
+
+    def ensureReady(self):
+        return True
+
+    def describe(self):
+        return "a fake"
+
+    def otp(self):
+        return "otp"
+
+    def machine(self):
+        return "machine"
+
+
+class Unavailable:
+    def ensureReady(self):
+        return False
+
+    def unavailableReason(self):
+        return "no libraries"
+
+
+class TestTheIdentityANewSessionPresents:
+    def test_the_serial_is_the_apps_own_and_not_the_librarys(self):
         assert identity.APP_SERIAL == "0PENTAGVIEWR"
         assert identity.APP_SERIAL != CLIENT_SERIAL
 
-    def test_it_is_the_shape_apple_accepts(self):
+    def test_the_serial_is_the_shape_apple_accepts(self):
         assert len(identity.APP_SERIAL) == 12
         assert identity.APP_SERIAL.isalnum()
         assert identity.APP_SERIAL.upper() == identity.APP_SERIAL
 
-    def test_it_is_not_the_exporters(self):
-        # Two installs, two entries, each removable without breaking the other. Sharing a prefix
-        # is deliberate; sharing the whole serial would make them one device.
+    def test_the_serial_is_not_the_exporters(self):
+        # Two installs, two entries, each removable without breaking the other.
         assert identity.APP_SERIAL != "0PENTAGXPORT"
         assert identity.APP_SERIAL[:5] == "0PENT"
 
+    def test_the_identity_matches_the_one_adi_is_initialised_with(self):
+        """
+        The whole reason `DeviceIdentity` was asked for upstream.
 
-class TestEveryProviderPresentsIt:
+        `AdiDeviceIdentity.CLIENT_INFO` on the Java side sends this exact string when it
+        provisions ADI. FindMy.py used to send a MacBook Pro 18,3 on macOS 13.4.1 from its own
+        defaults — one app, one session, two different Macs, differing even in the OS *name*.
+        If this assertion ever fails, the two halves have drifted apart again.
+        """
+        composed = (
+            f"<{identity.APP_IDENTITY.model}> "
+            f"<{identity.APP_IDENTITY.os_name};{identity.APP_IDENTITY.os_version};"
+            f"{identity.APP_IDENTITY.os_build}>"
+        )
+
+        assert composed == "<MacBookPro13,2> <macOS;13.1;22C65>", (
+            "This must stay identical to AdiDeviceIdentity.CLIENT_INFO in the Java sources."
+        )
+
+    def test_the_identity_is_not_the_librarys(self):
+        assert identity.APP_IDENTITY != CLIENT_IDENTITY
+
+    def test_a_new_login_uses_it_on_both_transports(self):
+        """
+        Local and remote must present the same machine.
+
+        The fallback from local Anisette to a server is automatic, so if the two disagreed a
+        user would silently become a second device without doing anything to cause it.
+        """
+        for bridge in (Bridge(), Unavailable(), None):
+            provider = main._anisetteProvider(
+                "https://example.invalid",
+                bridge,
+                serial=identity.APP_SERIAL,
+                identity=identity.APP_IDENTITY,
+            )
+
+            assert provider.serial == identity.APP_SERIAL
+            assert provider.identity == identity.APP_IDENTITY
+
+
+class TestARestoredSessionKeepsWhatItHad:
     """
-    Both providers, because which one produced a session is a transport detail.
+    The half that protects people who are already signed in.
 
-    A user whose local Anisette fell back to a server must not thereby acquire a second entry in
-    their device list - and that fallback is automatic, so it would happen without them doing
-    anything to cause it.
+    An account established before any of this was bound to FindMy.py's defaults. Handing it the
+    app's identity now would present Apple with a different machine on an existing session.
     """
 
-    def test_the_remote_provider_presents_it(self):
+    def test_a_provider_with_no_identity_asked_for_gets_the_librarys(self):
+        # Which is what an account file written before this change restores to, and what the
+        # library promises never to move.
         provider = main._anisetteProvider("https://example.invalid")
 
-        assert isinstance(provider, RemoteAnisetteProvider)
-        assert provider.serial == identity.APP_SERIAL
+        assert provider.serial == CLIENT_SERIAL
+        assert provider.identity == CLIENT_IDENTITY
 
-    def test_the_local_provider_presents_it(self):
-        class Bridge:
-            def ensureReady(self):
-                return True
-
-            def describe(self):
-                return "a fake"
-
-            def otp(self):
-                return "otp"
-
-            def machine(self):
-                return "machine"
-
-        provider = main._anisetteProvider("https://example.invalid", Bridge())
-
-        assert isinstance(provider, main.LocalAnisetteProvider)
-        assert provider.serial == identity.APP_SERIAL
-
-    def test_a_local_provider_that_falls_back_still_presents_it(self):
-        class Unavailable:
-            def ensureReady(self):
-                return False
-
-            def unavailableReason(self):
-                return "no libraries"
-
-        provider = main._anisetteProvider("https://example.invalid", Unavailable())
-
-        assert isinstance(provider, RemoteAnisetteProvider)
-        assert provider.serial == identity.APP_SERIAL
-
-
-class TestTheKnownMismatch:
-    """
-    The part of the identity that does not agree with itself yet.
-
-    Recorded rather than fixed: the second string is hardcoded inside FindMy.py and there is
-    nowhere to pass one in, so a request to expose it has gone upstream. These tests exist so
-    that the day the library grows the knob - or moves the value - something fails and says so,
-    rather than the discrepancy quietly outliving the reason for it.
-    """
-
-    def test_the_two_client_info_strings_still_disagree(self):
-        ours, theirs = identity.KNOWN_IDENTITY_MISMATCH
-
-        assert ours != theirs, (
-            "If these now agree, the mismatch is fixed - delete KNOWN_IDENTITY_MISMATCH, this"
-            " test, and docs/findmy-py-client-info-request.md."
-        )
-
-    def test_it_records_what_the_library_actually_sends(self):
+    def test_the_local_provider_defaults_to_no_opinion(self):
         """
-        Composed from the library's own constants, not scraped out of its source.
+        `LocalAnisetteProvider` must not bake the app's identity into itself.
 
-        The first version of this searched `anisette.py` for the finished string, and broke
-        the moment the fork split the identity into parts - which it had already done at the
-        commit the app pins, so the test failed on a library that had not changed its identity
-        at all. Reading the values means a refactor is free and a *changed identity* is not.
+        It did, briefly, and that was the bug: it is constructed on the *restore* path too, so
+        an upgrading user's next request would have gone out under a new serial.
         """
-        from findmy.reports import anisette
+        provider = main.LocalAnisetteProvider(Bridge(), "https://example.invalid")
 
-        parts = ("CLIENT_MODEL", "CLIENT_OS", "CLIENT_OS_VERSION", "CLIENT_OS_BUILD")
-        missing = [name for name in parts if not hasattr(anisette, name)]
-        assert not missing, (
-            f"findmy.reports.anisette has no {', '.join(missing)}. The installed FindMy is not"
-            " the commit app/build.gradle.kts pins - check requirements.txt and your venv."
+        assert provider.serial == CLIENT_SERIAL
+        assert provider.identity == CLIENT_IDENTITY
+
+    def test_a_restored_identity_is_carried_across_unchanged(self):
+        established = DeviceIdentity(
+            model="MacBookPro18,3", os_name="Mac OS X", os_version="13.4.1",
+            os_build="22F8", cfnetwork="1408.0.4", darwin="22.5.0",
+        )
+        previous = RemoteAnisetteProvider(
+            "https://example.invalid", serial="0FINDMYPY001", identity=established,
         )
 
-        theirs_now = (
-            f"<{anisette.CLIENT_MODEL}> "
-            f"<{anisette.CLIENT_OS};{anisette.CLIENT_OS_VERSION};{anisette.CLIENT_OS_BUILD}>"
+        carried = identity.identityForRestore(previous)
+        replacement = main.LocalAnisetteProvider(Bridge(), "https://example.invalid", **carried)
+
+        assert replacement.serial == "0FINDMYPY001"
+        assert replacement.identity == established
+
+    def test_a_restored_new_style_account_keeps_the_apps_identity_too(self):
+        """Someone who signed in *after* this shipped must not revert on the next restore."""
+        previous = RemoteAnisetteProvider(
+            "https://example.invalid",
+            serial=identity.APP_SERIAL,
+            identity=identity.APP_IDENTITY,
         )
 
-        _, theirs_recorded = identity.KNOWN_IDENTITY_MISMATCH
+        carried = identity.identityForRestore(previous)
+        replacement = main.LocalAnisetteProvider(Bridge(), "https://example.invalid", **carried)
 
-        assert theirs_recorded == theirs_now, (
-            f"FindMy.py now presents {theirs_now}, not {theirs_recorded}. Update"
-            " KNOWN_IDENTITY_MISMATCH - and check whether it now agrees with"
-            " AdiDeviceIdentity.CLIENT_INFO, in which case the mismatch is over."
-        )
+        assert replacement.serial == identity.APP_SERIAL
+        assert replacement.identity == identity.APP_IDENTITY
+
+    def test_reading_an_identity_off_something_that_has_none_asks_for_nothing(self):
+        # A library rename must degrade to "keep the default", not to a crash on every restore.
+        assert identity.identityForRestore(object()) == {}
+
+
+class TestTheLibraryDefaultIsStillWhereWeLeftIt:
+    """
+    Existing sessions depend on FindMy.py's default never moving, and the library says so.
+
+    If it ever does, every account that never asked for an identity silently becomes a
+    different machine — the exact harm this design avoids, arriving from underneath.
+    """
+
+    def test_the_default_serial_has_not_moved(self):
+        assert CLIENT_SERIAL == "0FINDMYPY001"
+
+    def test_the_default_identity_has_not_moved(self):
+        assert CLIENT_IDENTITY.model == "MacBookPro18,3"
+        assert CLIENT_IDENTITY.os_name == "Mac OS X"
+        assert CLIENT_IDENTITY.os_version == "13.4.1"
+        # Deliberately a character short of a real macOS build (13.4.1 is 22F82). Kept wrong
+        # because every existing session is bound to it; correcting it would cost a re-login.
+        assert CLIENT_IDENTITY.os_build == "22F8"

--- a/app/src/test/python/test_identity.py
+++ b/app/src/test/python/test_identity.py
@@ -15,14 +15,40 @@ login succeeds or does not, and the evidence is in somebody else's Apple account
 
 from __future__ import annotations
 
+import json
+
 import identity
 import main
 from findmy.reports import RemoteAnisetteProvider
 from findmy.reports.anisette import CLIENT_IDENTITY, CLIENT_SERIAL, DeviceIdentity
 
+# What Java sends for each of its two profiles. Copies, and only usable as copies: nothing here
+# can reach the Java enum, so these say "given this shape, do that". That the shapes are the
+# ones Java actually produces is asserted on device, by IdentityBridgeTest.
+LEGACY_MAC = {
+    "model": "MacBookPro13,2",
+    "os_name": "macOS",
+    "os_version": "13.1",
+    "os_build": "22C65",
+    "cfnetwork": "1404.0.5",
+    "darwin": "22.2.0",
+}
+
+IPHONE = {
+    "model": "iPhone15,2",
+    "os_name": "iPhone OS",
+    "os_version": "17.4",
+    "os_build": "21E219",
+    "cfnetwork": "1494.0.7",
+    "darwin": "23.4.0",
+}
+
 
 class Bridge:
     """A local-Anisette bridge that works."""
+
+    def __init__(self, profile=None):
+        self._profile = IPHONE if profile is None else profile
 
     def ensureReady(self):
         return True
@@ -36,8 +62,13 @@ class Bridge:
     def machine(self):
         return "machine"
 
+    def hardwareProfileJson(self):
+        return json.dumps(self._profile)
 
-class Unavailable:
+
+class Unavailable(Bridge):
+    """Local Anisette failed - but it still knows which machine this install is."""
+
     def ensureReady(self):
         return False
 
@@ -60,45 +91,113 @@ class TestTheIdentityANewSessionPresents:
         assert identity.APP_SERIAL != "0PENTAGXPORT"
         assert identity.APP_SERIAL[:5] == "0PENT"
 
-    def test_the_identity_matches_the_one_adi_is_initialised_with(self):
+    def test_the_machine_is_whichever_one_java_says_this_install_is(self):
         """
-        The whole reason `DeviceIdentity` was asked for upstream.
+        The whole reason `DeviceIdentity` was asked for upstream, and the reason this is not a
+        constant any more.
 
-        `AdiDeviceIdentity.CLIENT_INFO` on the Java side sends this exact string when it
-        provisions ADI. FindMy.py used to send a MacBook Pro 18,3 on macOS 13.4.1 from its own
-        defaults — one app, one session, two different Macs, differing even in the OS *name*.
-        If this assertion ever fails, the two halves have drifted apart again.
+        Java sends the same six values in the client info it provisions ADI under. Which six
+        depends on the install — one that predates the choice keeps the Mac, a fresh one is an
+        iPhone — so a copy on this side would be right for one of them and wrong for the other.
         """
-        composed = (
-            f"<{identity.APP_IDENTITY.model}> "
-            f"<{identity.APP_IDENTITY.os_name};{identity.APP_IDENTITY.os_version};"
-            f"{identity.APP_IDENTITY.os_build}>"
-        )
+        assert identity.hardwareProfile(Bridge(LEGACY_MAC)) == DeviceIdentity(**LEGACY_MAC)
+        assert identity.hardwareProfile(Bridge(IPHONE)) == DeviceIdentity(**IPHONE)
 
-        assert composed == "<MacBookPro13,2> <macOS;13.1;22C65>", (
-            "This must stay identical to AdiDeviceIdentity.CLIENT_INFO in the Java sources."
-        )
-
-    def test_the_identity_is_not_the_librarys(self):
-        assert identity.APP_IDENTITY != CLIENT_IDENTITY
+    def test_neither_profile_is_the_librarys(self):
+        assert DeviceIdentity(**LEGACY_MAC) != CLIENT_IDENTITY
+        assert DeviceIdentity(**IPHONE) != CLIENT_IDENTITY
 
     def test_a_new_login_uses_it_on_both_transports(self):
         """
         Local and remote must present the same machine.
 
         The fallback from local Anisette to a server is automatic, so if the two disagreed a
-        user would silently become a second device without doing anything to cause it.
+        user would silently become a second device without doing anything to cause it. Note
+        `Unavailable` still answers the profile question: that is the point of it not going
+        through `ensureReady`.
         """
-        for bridge in (Bridge(), Unavailable(), None):
+        for bridge in (Bridge(IPHONE), Unavailable(IPHONE)):
             provider = main._anisetteProvider(
                 "https://example.invalid",
                 bridge,
-                serial=identity.APP_SERIAL,
-                identity=identity.APP_IDENTITY,
+                **identity.identityForNewSession(bridge),
             )
 
             assert provider.serial == identity.APP_SERIAL
-            assert provider.identity == identity.APP_IDENTITY
+            assert provider.identity == DeviceIdentity(**IPHONE)
+
+    def test_a_legacy_install_signing_in_again_presents_the_mac_it_provisioned_with(self):
+        """
+        The case a constant could not have got right.
+
+        Somebody who installed before profiles existed, signs out, and signs back in. Their ADI
+        is provisioned as a MacBookPro13,2 and is not re-provisioned, so the login has to claim
+        the same thing — even though every fresh install alongside them now claims an iPhone.
+        """
+        bridge = Bridge(LEGACY_MAC)
+
+        kwargs = identity.identityForNewSession(bridge)
+
+        assert kwargs["identity"] == DeviceIdentity(**LEGACY_MAC)
+        assert kwargs["identity"].platform == "<MacBookPro13,2> <macOS;13.1;22C65>"
+
+    def test_the_serial_is_the_apps_even_for_a_legacy_install(self):
+        """
+        The serial is a label and the machine is not, so they are not gated together.
+
+        A new sign-in gets a new device-list entry whatever happens, so there is nothing to
+        preserve by withholding a recognisable name from it.
+        """
+        assert identity.identityForNewSession(Bridge(LEGACY_MAC))["serial"] == identity.APP_SERIAL
+
+
+class TestWhenJavaCannotBeAsked:
+    """
+    Every one of these ends in a login that works and a device-list entry that is wrong.
+
+    That is the deliberate trade: a mismatched identity is a bad row in a list, and refusing to
+    sign in is an app that does not work. All of them print, because none of them should happen.
+    """
+
+    def test_no_bridge_at_all_imposes_nothing(self):
+        assert identity.hardwareProfile(None) is None
+        assert identity.identityForNewSession(None) == {"serial": identity.APP_SERIAL}
+
+    def test_a_bridge_that_throws_does_not_take_the_login_with_it(self):
+        class Broken(Bridge):
+            def hardwareProfileJson(self):
+                raise RuntimeError("no such method")
+
+        assert identity.hardwareProfile(Broken()) is None
+
+    def test_something_that_is_not_json_is_not_guessed_at(self):
+        class Garbage(Bridge):
+            def hardwareProfileJson(self):
+                return "not json"
+
+        assert identity.hardwareProfile(Garbage()) is None
+
+    def test_a_renamed_field_is_refused_rather_than_half_filled(self):
+        """
+        The failure this check exists for, and it is genuinely silent without it.
+
+        `DeviceIdentity.from_json` fills a missing key from FindMy.py's own identity, so a
+        rename on either side would produce a MacBookPro13,2 on macOS 13.1 with FindMy's
+        CFNetwork — a release that does not exist, sent to Apple as though it did.
+        """
+        renamed = dict(IPHONE)
+        renamed["osName"] = renamed.pop("os_name")
+
+        assert DeviceIdentity.from_json(renamed).os_name == CLIENT_IDENTITY.os_name, (
+            "from_json stopped back-filling; this test no longer describes the risk"
+        )
+        assert identity.hardwareProfile(Bridge(renamed)) is None
+
+    def test_an_extra_field_is_tolerated(self):
+        # Java adding a field this version has no use for must not stop it signing in.
+        assert identity.hardwareProfile(Bridge({**IPHONE, "chip": "A16"})) == DeviceIdentity(
+            **IPHONE
+        )
 
 
 class TestARestoredSessionKeepsWhatItHad:
@@ -146,17 +245,41 @@ class TestARestoredSessionKeepsWhatItHad:
 
     def test_a_restored_new_style_account_keeps_the_apps_identity_too(self):
         """Someone who signed in *after* this shipped must not revert on the next restore."""
+        established = DeviceIdentity(**IPHONE)
         previous = RemoteAnisetteProvider(
             "https://example.invalid",
             serial=identity.APP_SERIAL,
-            identity=identity.APP_IDENTITY,
+            identity=established,
         )
 
         carried = identity.identityForRestore(previous)
         replacement = main.LocalAnisetteProvider(Bridge(), "https://example.invalid", **carried)
 
         assert replacement.serial == identity.APP_SERIAL
-        assert replacement.identity == identity.APP_IDENTITY
+        assert replacement.identity == established
+
+    def test_a_restore_never_asks_java_what_this_install_is(self):
+        """
+        The bridge is not consulted on the restore path, and must not be.
+
+        An install can be `LEGACY_MAC` while the session stored on it was established under
+        FindMy.py's defaults — the profile describes the *install*, the stored identity
+        describes the *session*, and on a restore only the session's answer is right.
+        """
+        class Loud(Bridge):
+            def hardwareProfileJson(self):
+                raise AssertionError("a restore asked Java which machine this is")
+
+        established = DeviceIdentity(**LEGACY_MAC)
+        previous = RemoteAnisetteProvider(
+            "https://example.invalid", serial=CLIENT_SERIAL, identity=established,
+        )
+
+        carried = identity.identityForRestore(previous)
+        replacement = main.LocalAnisetteProvider(Loud(), "https://example.invalid", **carried)
+
+        assert replacement.serial == CLIENT_SERIAL
+        assert replacement.identity == established
 
     def test_reading_an_identity_off_something_that_has_none_asks_for_nothing(self):
         # A library rename must degrade to "keep the default", not to a crash on every restore.

--- a/app/src/test/python/test_main.py
+++ b/app/src/test/python/test_main.py
@@ -460,6 +460,45 @@ def test_getAccount_refuses_local_anisette():
 
 
 # --------------------------------------------------------------------------
+# A session Apple has stopped accepting
+#
+# It deserializes perfectly and is completely unusable: every fetch fails its state
+# check before a request is made. Returning it as a success is how the app came up
+# showing stale pins and spinners that stopped, with the reason only in the log.
+# Issue #43.
+# --------------------------------------------------------------------------
+
+def _storedAccount(loggedIn: bool) -> str:
+    from findmy.reports import AppleAccount, RemoteAnisetteProvider
+    from findmy.reports.state import LoginState
+
+    account = AppleAccount(RemoteAnisetteProvider("https://ani.example.com"))
+    stored = account.to_json()
+
+    # A fresh account is LOGGED_OUT, which is exactly the shape an invalidated session
+    # restores to. The logged-in case is the same blob with the one field moved, so the
+    # two tests differ in nothing else.
+    stored["login"]["state"] = (
+        LoginState.LOGGED_IN.value if loggedIn else LoginState.LOGGED_OUT.value
+    )
+    return json.dumps(stored)
+
+
+def test_a_session_apple_no_longer_accepts_is_a_failed_restore():
+    assert main.getAccount(_storedAccount(loggedIn=False)) is None
+
+
+def test_a_session_that_still_works_restores_normally():
+    """
+    The other half, and the one that matters more.
+
+    Reporting a working session as failed would sign people out for no reason - a far worse
+    bug than the one above, and the obvious way to get this wrong.
+    """
+    assert main.getAccount(_storedAccount(loggedIn=True)) is not None
+
+
+# --------------------------------------------------------------------------
 # Guard against the test environment drifting from what the app ships
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
Everything this app does against Apple is attributed to a device identity it invents, and the
user sees the result: a row in their Apple account's device list, next to a *Remove from
Account* button and the words "If you do not recognise this device". This makes that row
recognisable for new installs, without disturbing anyone already signed in.

## The rule

**Everybody who can keep the old identity keeps it. Everybody new gets the clean one.**

Apple binds a session to the identity that established it, so re-identifying an existing
install costs that user a sign-in and leaves a second entry they never asked for. That is a
bad trade for a nicer icon on a row they have already learned to recognise.

## What a fresh install now claims

| | Before | Now |
| --- | --- | --- |
| Model | `MacBookPro13,2` | `iPhone15,2` — renders as **iPhone 14 Pro**, with a phone icon |
| Serial | `0FINDMYPY001` | `0PENTAGVIEWR` |
| `X-Mme-Device-Id` | one at provisioning, another at login | the same one for both |
| `X-Apple-I-MD-LU` | provisioned raw, login sent `base64(random)` | the same value for both |

The iPhone values are from `docs/findmy-export/01-authentication.md` §2.2 — observed, not
invented. Claiming to be a phone does **not** make it eligible as a second factor: that is
decided by the push token, which FindMy.py has no parameter for and never sends.

An install that already has an ADI identity gets none of this. It keeps `LEGACY_MAC`,
byte-for-byte, including the `Darwin/22.3.0` that contradicts macOS 13.1 — correcting that
would re-identify every existing install to fix something Apple has evidently never minded.

## How the halves are kept honest

The absence of a stored hardware profile beside the other three keys is what means "from
before there was a choice", and that can only have been the Mac.

Python no longer holds a copy of the six identity values. It asks Java, because there is no
single right answer to hold: somebody who signs out and signs back in must present the Mac
their ADI was provisioned with, while the install beside theirs presents the iPhone.

The bridge deliberately does not go through `ensureReady()`. A sign-in relayed through a
remote server still claims a machine and must claim the *same* one — otherwise a failed
library download would silently make somebody a second device.

## The trap in the uid/devid alignment

FindMy.py sends `base64(uid)` for `X-Apple-I-MD-LU`; Java sent it raw, which is what every
Anisette server does. **Passing the same string would have aligned `devid` and left `MD-LU` as
two different values** — alignment that reads as alignment and is not. Flagged by @parawanderer
on the upstream request, and confirmed here against the installed library rather than reasoned
about.

So the convention is per profile. `IPHONE` mints a UUID and sends base64 of it, exactly as
FindMy.py will, so provisioning and login carry identical bytes. `LEGACY_MAC` keeps the raw hex
it provisioned with — it cannot be aligned, since matching `base64(uid)` to a 64-character hex
string would need a `uid` of 48 bytes of arbitrary binary. For those installs `devid` aligns and
`MD-LU` does not, which is stated as a test rather than left as a surprise.

Two things established by reading rather than assumption: the `MD-LU` that `AnisetteHeaders`
builds never reaches Apple, because FindMy.py takes two values out of that map and composes the
rest itself — so ADI provisioning is the only place the app sends it, and it runs once. And the
local user id never reaches ADI, only `adiIdentifier` does, so its shape was free to change. The
class comment claiming an ADI length constraint on it was wrong, and is corrected.

## Upstream

FindMy.py is bumped to `2ea738a`, where `uid`/`devid` became settable and `local_user_uuid`
became readable. The app pin and the bridge requirements move together, as
`test_pinned_versions_match_the_app_build` asserts.

## Testing

Three layers, because the failure is invisible from inside any one of them.

- **`LocalAnisetteIdentityTest`** writes the pre-profile shape into SharedPreferences and reads
  it back through the same door the app uses. Reaching this for real means having installed an
  older build, signed in to a real Apple account, and upgraded.
- **`AdiDeviceIdentityTest`** pins the `LEGACY_MAC` strings as literals. A failure there is not a
  value to update; it means every install with that profile has been re-identified.
- **`IdentityBridgeTest`** runs both halves together on the device. `DeviceIdentity.from_json`
  back-fills an unrecognised key from FindMy.py's own identity instead of failing, so a rename
  on either side throws nothing and logs nothing — it just claims a `MacBookPro13,2` on macOS
  13.1 with FindMy's CFNetwork, a release that never existed.

**Checked that they can fail.** Four mutations, each caught by exactly the tests written for it:

| Broken on purpose | Went red |
| --- | --- |
| `os_name` renamed to `osName` | 3 `AdiDeviceIdentityTest`, all 6 bridge cases — the Python suite stayed green, which is why the on-device layer exists |
| Legacy install defaulted to `IPHONE` | exactly the 2 that exist to catch it |
| `IPHONE` sending `MD-LU` raw | the provisioning equality and the bridge check |
| Handing over the header form instead of the stored value | the fresh-install case — needed its own test, since legacy sends raw and a double-encode is invisible there |

200 instrumented tests pass, 83 Python tests pass.

**Not verified against a real Apple account** — none is available here. The reasoning that an
existing session survives this is set out above and tested at every point it can be, but the
last word belongs to Apple.

Which is why #105 is merged in here rather than shipping later: whatever this does or does not
do to an existing session, the app can now say so.

---

## Also here: saying when a session has expired (#105)

A session can stop working for reasons the user did nothing to cause. Three gaps met on that
path, and the middle one hid the other two.

**A session Apple no longer accepts restored as a success.** `getAccount` printed a warning
about issue #43 and returned the account anyway. That account is readable and completely
unusable — every fetch fails its state check before a request is made. So the app came up with
stale pins and spinners that stopped, and the only statement of what had happened was in
logcat. The recovery code below existed the whole time and never ran once.

Safe to treat as terminal: the app only ever stores an account after a completed sign-in, so a
stored account that is not logged in can only mean the session went bad afterwards.

**The recovery said the wrong thing, in the wrong way** — a toast asserting the FindMy library
had been updated. True of the one migration it was written for; wrong for Apple invalidating a
session, a password change, or the machine identity moving because local Anisette fell back to
a server. **And they had to type their address again.**

Now a dialog on the login screen, with the email already filled in:

> **Please sign in again**
>
> Apple no longer accepts the saved sign-in for this device, so your tags cannot be located
> until you sign in again.
>
> Your tags and their location history stay on this phone — nothing has been lost.

That second paragraph is the point. Somebody dropped on a login form with no explanation
reasonably concludes the app has lost everything, and a reasonable next step is to tidy up
whatever unfamiliar entry is in their Apple device list — which is the one action that makes it
worse, because that entry is this app.

The address is read **before** the account is cleared, which is why those are not two
independent steps: clearing is what destroys it. The login screen shows the dialog rather than
the sender, because `MapsActivity` is finishing and a dialog on a finishing activity is a leaked
window.

Making that dialog unconditional reddened **16** tests — the two negative cases plus every
existing login test.

One thing worth knowing for the next dialog test: a dialog owns the focused window, so Espresso
resolves views against the dialog's hierarchy and not the activity's. Looking for a field behind
it fails with `NoMatchingViewException` even though the field is there.

**206 instrumented tests pass, 85 Python tests pass** — and this is the first CI run that covers
any of it. As #105 it had a rollup of zero, because every workflow is
`pull_request: branches: [ "main" ]` and a stacked PR triggers nothing at all. The `watch-pr`
skill and its monitor now know that: `[] | all(...)` is `true` in jq, so an empty rollup used to
be reported as "all checks finished".

