### PR TITLE
Say when Apple has stopped accepting a session, instead of showing an empty map

### DIFF
--- a/.claude/skills/watch-pr/SKILL.md
+++ b/.claude/skills/watch-pr/SKILL.md
@@ -30,18 +30,32 @@ gh pr view "$PR" --json statusCheckRollup --jq \
 
 ## First check whether this PR gets checks at all
 
-An **empty** rollup is not "too early" — it may mean nothing will ever run. Every workflow here
-is path-filtered (`app/**`, `scripts/**`, `gradle/**`, `pyrightconfig.json`, `.flake8`), so a PR
-touching only docs, `.gitattributes`, `.claude/`, or `.github/` itself produces no checks and a
-monitor on it waits out its whole timeout for nothing.
+An **empty** rollup is not "too early" — it may mean nothing will ever run.
 
 ```bash
-gh pr view <n> --json statusCheckRollup --jq '.statusCheckRollup | length'
+gh pr view <n> --json statusCheckRollup,baseRefName \
+  --jq '{base: .baseRefName, checks: (.statusCheckRollup | length)}'
 ```
 
-Zero, and the diff touches no filtered path? **Do not arm a monitor.** Say the change is not
-covered by CI and why, and let the human decide — that is more useful than a green tick would
-have been, because it names what is *not* being verified.
+Two independent reasons it comes back zero, and **the second one is invisible in the diff**:
+
+- **Path filters.** Every workflow here is filtered (`app/**`, `scripts/**`, `gradle/**`,
+  `pyrightconfig.json`, `.flake8`), so a PR touching only docs, `.gitattributes`, `.claude/`, or
+  `.github/` itself produces nothing.
+- **A base that is not `main`.** Every workflow is `pull_request: branches: [ "main" ]`, so a
+  **stacked PR gets no checks whatsoever**, however much application code it touches. This is
+  the one that catches you out: the obvious test — "does the diff touch a filtered path?" —
+  says yes, and still nothing runs. Seen on #105, which changed `app/**` heavily and had a
+  rollup of zero because it was based on the branch of #104.
+
+Zero either way? **Do not arm a monitor.** Say the change is not covered by CI and why, and let
+the human decide — that is more useful than a green tick would have been, because it names what
+is *not* being verified. For a stack, the choice is theirs: merge the base so GitHub retargets
+the child onto `main`, or retarget it now and accept the parent's commits showing in the diff.
+
+**Whichever they pick, local runs are the only evidence until then.** Say what you ran, in
+numbers — `./gradlew :app:testEmulatorDebugAndroidTest` and the pytest suites — rather than
+letting "no checks" read as "nothing to check".
 
 ## Use `gh pr view`, not `gh pr checks`
 
@@ -68,14 +82,23 @@ while true; do
         '.statusCheckRollup[] | select(.status == "COMPLETED") | "\(.name): \(.conclusion)"' 2>/dev/null | sort)
   comm -13 <(printf '%s\n' "$seen") <(printf '%s\n' "$now")
   seen="$now"
+  total=$(gh pr view "$PR" --json statusCheckRollup --jq '.statusCheckRollup | length' 2>/dev/null)
+  if [ "$total" = "0" ]; then
+    echo "PR #$PR: NO CHECKS EXIST - nothing is verifying this. See the section above."
+    break
+  fi
   if [ "$(gh pr view "$PR" --json statusCheckRollup --jq \
           '[.statusCheckRollup[].status] | all(. == "COMPLETED")' 2>/dev/null)" = "true" ]; then
-    echo "PR #$PR: all checks finished"
+    echo "PR #$PR: all $total checks finished"
     break
   fi
   sleep 30
 done
 ```
+
+**The zero case is checked separately, and that is not belt-and-braces.** `[] | all(...)` is
+`true` in jq, so without it an empty rollup exits immediately announcing "all checks finished" —
+a monitor reporting success over a PR that ran nothing at all. That happened on #105.
 
 `timeout_ms`: the emulator suite here takes several minutes and the whole run rarely exceeds 20,
 so 2700000 (45 min) is comfortable. `persistent: false` — it ends itself.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -287,7 +287,7 @@ chaquopy {
             // wheel for desktop platforms and a pure-Python `py3-none-any` one as well.
             // There is no Android wheel, so pip falls back to the pure-Python build - which
             // is correct but markedly slower. The messages here are small enough not to care.
-            install("git+https://github.com/parawanderer/FindMy.py@2ea738aafbf86b2f9455704b81fc731c732c863b")
+            install("git+https://github.com/parawanderer/FindMy.py@102dd8ea14767d2a2aa745186ac23276f32689f1")
 
             install("NSKeyedUnArchiver==1.5")
         }

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/SessionExpiredLoginTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/SessionExpiredLoginTest.java
@@ -1,0 +1,288 @@
+package dev.wander.android.opentagviewer;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertFalse;
+import static org.hamcrest.Matchers.not;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.SystemClock;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import dev.wander.android.opentagviewer.anisette.FakeAnisetteSource;
+import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
+import dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStore;
+import dev.wander.android.opentagviewer.db.repo.UserAuthRepository;
+import dev.wander.android.opentagviewer.db.repo.UserSettingsRepository;
+import dev.wander.android.opentagviewer.db.repo.model.UserSettings;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.python.FakeAppleAuthService;
+import dev.wander.android.opentagviewer.service.web.FakeAnisetteServerTester;
+import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Being signed out by Apple rather than by choice.
+ *
+ * <p>A session can stop working for reasons the user did nothing to cause: Apple invalidating
+ * it, a password change, or the machine identity moving because local Anisette fell back to a
+ * server. Before this, all of them arrived as a toast asserting that the FindMy library had
+ * been updated - true of one migration and wrong every other time - or, in the case that
+ * actually matters, as nothing at all.
+ *
+ * <p><b>The reason this is worth a screen and not a log line.</b> Somebody dropped on a login
+ * form with no explanation reasonably concludes the app has lost everything, and a reasonable
+ * next step is to go and tidy up whatever unfamiliar entry is sitting in their Apple device
+ * list - which is the single action that makes it worse, because that entry is this app.
+ *
+ * <p>The activity is driven directly with the extras rather than through a failing restore.
+ * Producing the real thing needs Apple to reject a session, which cannot be arranged; what can
+ * be asserted is that the screen honours what it is sent, and {@code MapsActivityTest} covers
+ * nothing here, so the contract between them is stated in {@code MapsActivity} and in
+ * {@code AppleLoginActivity}'s constants.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class SessionExpiredLoginTest {
+
+    private static final String EMAIL = "someone@example.com";
+
+    private ActivityScenario<AppleLoginActivity> scenario;
+    private DeviceStateGuard deviceState;
+
+    @Before
+    public void startSignedOut() {
+        this.deviceState = DeviceStateGuard.capture(getInstrumentation().getTargetContext());
+
+        signEverybodyOut();
+        forgetAnyChosenServer();
+
+        // Ready, so the screen goes straight to the account form and the dialog is the only
+        // thing in front of it. An unavailable source would add the welcome step and make
+        // "is the email field filled in" a question about a different page.
+        AppDependencies.replaceAuthService(FakeAppleAuthService.signsInImmediately());
+        AppDependencies.replaceServerTester(FakeAnisetteServerTester.thatIsUp());
+        AppDependencies.replaceAnisette(settings -> FakeAnisetteSource.ready());
+    }
+
+    @After
+    public void putTheRealOnesBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        AppDependencies.reset();
+
+        getInstrumentation().waitForIdleSync();
+        signEverybodyOut();
+        this.deviceState.restore();
+    }
+
+    /**
+     * The explanation appears, and says the thing that stops somebody making it worse.
+     *
+     * <p>Asserted on the words, not on "a dialog is up". What matters is that it says the tags
+     * are still here - a dialog that only said "sign in again" would leave the same fear.
+     */
+    @Test
+    public void somebodySignedOutByAppleIsToldWhatHappened() {
+        launchAfterExpiry(EMAIL);
+
+        final Context context = getInstrumentation().getTargetContext();
+        Eventually.check(() -> onView(withText(context.getString(R.string.session_expired_title)))
+                .check(matches(isDisplayed())));
+        onView(withText(context.getString(R.string.session_expired_message)))
+                .check(matches(isDisplayed()));
+    }
+
+    /**
+     * And once they dismiss it, their address is already in the field.
+     *
+     * <p>Read from the account being discarded, which is why {@code MapsActivity} reads it
+     * before clearing rather than after.
+     *
+     * <p>Dismissed first because a dialog owns the focused window, so Espresso resolves views
+     * against the dialog's hierarchy and not the activity's - looking for the field while it is
+     * up fails with {@code NoMatchingViewException} even though the field is there. It is also
+     * the order a person meets it in.
+     */
+    @Test
+    public void theirAddressIsAlreadyFilledIn() {
+        launchAfterExpiry(EMAIL);
+        dismissTheExplanation();
+
+        Eventually.check(() -> onView(withId(R.id.email_or_phone_input_field))
+                .perform(scrollTo()).check(matches(withText(EMAIL))));
+    }
+
+    /**
+     * Dismissing it leaves them on the sign-in form, not somewhere else.
+     *
+     * <p>The dialog is an explanation, not a decision - there is nothing to accept or decline,
+     * and no other screen to go to.
+     */
+    @Test
+    public void dismissingItLeavesThemOnTheSignInForm() {
+        launchAfterExpiry(EMAIL);
+        dismissTheExplanation();
+
+        onView(withId(R.id.email_or_phone_input_field))
+                .perform(scrollTo()).check(matches(isDisplayed()));
+        onView(withId(R.id.password_input_field)).perform(scrollTo()).check(matches(isDisplayed()));
+    }
+
+    /**
+     * An ordinary first run says none of this.
+     *
+     * <p>The half that makes the other three mean something. A dialog shown unconditionally
+     * would pass every test above and tell every new user their session had expired.
+     */
+    @Test
+    public void anordinaryFirstRunIsNotToldAnything() {
+        this.scenario = ActivityScenario.launch(AppleLoginActivity.class);
+        TestPace.afterAStep();
+
+        Eventually.check(() -> onView(withId(R.id.email_or_phone_input_field))
+                .perform(scrollTo()).check(matches(isDisplayed())));
+
+        final Context context = getInstrumentation().getTargetContext();
+        onView(withId(R.id.email_or_phone_input_field))
+                .perform(scrollTo()).check(matches(not(withText(EMAIL))));
+        assertFalse("a first run has no expired session to explain",
+                isShowing(context.getString(R.string.session_expired_title)));
+    }
+
+    /**
+     * An address alone prefills without announcing anything.
+     *
+     * <p>The two extras are independent on purpose: an address can be known when nothing has
+     * expired, and something can expire when the address cannot be read.
+     */
+    @Test
+    public void anaddressWithoutAnExpiryPrefillsQuietly() {
+        final Intent intent = new Intent(
+                getInstrumentation().getTargetContext(), AppleLoginActivity.class);
+        intent.putExtra(AppleLoginActivity.EXTRA_PREFILL_EMAIL, EMAIL);
+        this.scenario = ActivityScenario.launch(intent);
+        TestPace.afterAStep();
+
+        final Context context = getInstrumentation().getTargetContext();
+        Eventually.check(() -> onView(withId(R.id.email_or_phone_input_field))
+                .perform(scrollTo()).check(matches(withText(EMAIL))));
+        assertFalse("nothing expired, so nothing to explain",
+                isShowing(context.getString(R.string.session_expired_title)));
+    }
+
+    /**
+     * An expiry with no address still explains itself.
+     *
+     * <p>{@code MapsActivity} reads the address defensively - it is recovering from an account
+     * that has already failed to restore - so "expired, and we could not read who you are" is
+     * a state that can genuinely arrive, and it must not silently show nothing.
+     */
+    @Test
+    public void anexpiryWithoutAnAddressStillExplainsItself() {
+        launchAfterExpiry(null);
+
+        final Context context = getInstrumentation().getTargetContext();
+        Eventually.check(() -> onView(withText(context.getString(R.string.session_expired_title)))
+                .check(matches(isDisplayed())));
+    }
+
+    // ------------------------------------------------------------------------------------
+
+    /**
+     * Wait for the explanation, then dismiss it.
+     *
+     * <p>{@code perform} rather than a bare click: the dialog animates in, so a tap can land
+     * before it is touchable and needs retrying - but a tap that works removes the very view
+     * being clicked, which Espresso reports from the same call. "Has the title gone" separates
+     * the two; the exception cannot.
+     */
+    private void dismissTheExplanation() {
+        final Context context = getInstrumentation().getTargetContext();
+
+        Eventually.check(() -> onView(withText(context.getString(R.string.session_expired_title)))
+                .check(matches(isDisplayed())));
+        Eventually.perform("the dismiss button",
+                () -> !isShowing(context.getString(R.string.session_expired_title)),
+                () -> onView(withText(context.getString(R.string.ok))).perform(click()));
+        TestPace.afterAStep();
+    }
+
+    private void launchAfterExpiry(final String email) {
+        final Intent intent = new Intent(
+                getInstrumentation().getTargetContext(), AppleLoginActivity.class);
+        intent.putExtra(AppleLoginActivity.EXTRA_SESSION_EXPIRED, true);
+        if (email != null) {
+            intent.putExtra(AppleLoginActivity.EXTRA_PREFILL_EMAIL, email);
+        }
+
+        this.scenario = ActivityScenario.launch(intent);
+        TestPace.afterAStep();
+    }
+
+    /**
+     * Whether some text is on screen, as a question rather than an assertion.
+     *
+     * <p>Needed because two of these assert an absence, and an absence cannot be an expected
+     * exception: {@code NoMatchingViewException} is also what a mistyped matcher throws.
+     */
+    private static boolean isShowing(final String text) {
+        try {
+            onView(withText(text)).check(matches(isDisplayed()));
+            return true;
+        } catch (final NoMatchingViewException | AssertionError e) {
+            return false;
+        }
+    }
+
+    private static void forgetAnyChosenServer() {
+        new UserSettingsRepository(
+                UserSettingsDataStore.getInstance(getInstrumentation().getTargetContext()))
+                .storeUserSettings(UserSettings.builder()
+                        .anisetteMode(UserSettings.ANISETTE_LOCAL)
+                        .build())
+                .blockingAwait();
+    }
+
+    /**
+     * A stored session would send this screen straight to the map in {@code onCreate}, so every
+     * test here depends on there being none.
+     */
+    private static void signEverybodyOut() {
+        final UserAuthRepository auth = new UserAuthRepository(
+                UserAuthDataStore.getInstance(getInstrumentation().getTargetContext()),
+                new AppCryptographyUtil());
+
+        int consecutivelyEmpty = 0;
+
+        for (int attempt = 0; attempt < 40 && consecutivelyEmpty < 3; attempt++) {
+            if (auth.getUserAuth().blockingFirst().isEmpty()) {
+                consecutivelyEmpty++;
+            } else {
+                consecutivelyEmpty = 0;
+                auth.clearUser().blockingAwait();
+            }
+            SystemClock.sleep(50);
+        }
+
+        if (consecutivelyEmpty < 3) {
+            throw new IllegalStateException("a stored session kept coming back");
+        }
+    }
+}

--- a/app/src/main/java/dev/wander/android/opentagviewer/AppleLoginActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/AppleLoginActivity.java
@@ -33,6 +33,7 @@ import androidx.core.os.LocaleListCompat;
 import androidx.databinding.DataBindingUtil;
 import androidx.lifecycle.ViewModelProvider;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.progressindicator.CircularProgressIndicator;
 import com.google.android.material.textfield.MaterialAutoCompleteTextView;
 import com.google.android.material.textfield.TextInputEditText;
@@ -97,6 +98,22 @@ public class AppleLoginActivity extends AppCompatActivity {
             R.id.login_2fa_choice,
             R.id.login_2fa_container,
     };
+
+    /**
+     * Set when the user did not choose to be here - their stored session stopped working.
+     *
+     * <p>Worth distinguishing from an ordinary first run. Being dropped on a login screen with
+     * no explanation reads as the app having lost everything, and the reasonable response to
+     * that is to go and tidy up whatever unfamiliar entry is in your Apple device list - which
+     * is the one action that makes it worse.
+     */
+    public static final String EXTRA_SESSION_EXPIRED = "sessionExpired";
+
+    /**
+     * The address to put in the field, for somebody signing in again rather than for the first
+     * time. Only ever their own, read from the account being discarded.
+     */
+    public static final String EXTRA_PREFILL_EMAIL = "prefillEmail";
 
     private static final int HINT_DIFFERENT_ANISETTE_SERVER_AFTER_FAILED_2FACODES = 3;
 
@@ -221,6 +238,43 @@ public class AppleLoginActivity extends AppCompatActivity {
         this.passwordInput = this.findViewById(R.id.password_input_field);
         this.loginButton = this.findViewById(R.id.login_button_main);
         this.twoFactorAuthChoiceBackButton = this.findViewById(R.id.twofactorauthchoice_back_button);
+
+        this.explainWhySignedOutIfSent();
+    }
+
+    /**
+     * Somebody arriving here because their session stopped working, rather than by choice.
+     *
+     * <p>Being returned to a login screen with no explanation reads as the app having lost
+     * everything - which is exactly the moment somebody goes to their Apple device list, finds
+     * an entry they do not recognise, and removes it. So it says what happened, and says that
+     * the tags and their history are still here.
+     *
+     * <p>Shown on this screen rather than by whoever sent them, because this is the screen that
+     * stays: the sender is finishing, and a dialog on a finishing activity is a leaked window.
+     */
+    private void explainWhySignedOutIfSent() {
+        final String email = this.getIntent().getStringExtra(EXTRA_PREFILL_EMAIL);
+        if (email != null && !email.isEmpty()) {
+            // Prefilled whether or not the dialog is shown, and before it, so the field is
+            // already right the moment the dialog is dismissed rather than filling in
+            // afterwards in front of the user.
+            this.emailOrPhoneInput.setText(email);
+        }
+
+        if (!this.getIntent().getBooleanExtra(EXTRA_SESSION_EXPIRED, false)) {
+            return;
+        }
+
+        // Consumed, so that rotating the device - or coming back to this screen later - does
+        // not re-announce something the user has already read and acted on.
+        this.getIntent().removeExtra(EXTRA_SESSION_EXPIRED);
+
+        new MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.session_expired_title)
+                .setMessage(R.string.session_expired_message)
+                .setPositiveButton(R.string.ok, null)
+                .show();
     }
 
     @Override

--- a/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
@@ -1029,18 +1029,48 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
         return false;
     }
 
+    /**
+     * Send somebody back to sign in, and tell them why.
+     *
+     * <p>This used to be a toast asserting that the FindMy library had been updated - true of
+     * the one migration it was written for, and wrong every other time. What a person needs
+     * here is what happened, and the reassurance that their tags and history are still on the
+     * phone; the explaining is done by the login screen, because this one is finishing.
+     *
+     * <p><b>The address is read before the account is cleared</b>, which is the whole reason
+     * this is not two independent steps: clearing is what destroys it.
+     */
     private void handleAccountRestoreFailureOnUiThread() {
+        final String email = signedInEmailOrNull();
+
         var disposable = this.userAuthRepo.clearUser()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(() -> {
-                    Toast.makeText(this, R.string.relogin_required_after_upgrade, LENGTH_LONG).show();
                     this.finish();
-                    this.sendToLogin();
+                    this.sendToLoginBecauseTheSessionExpired(email);
                 }, err -> {
                     Log.e(TAG, "Failed to clear stale auth blob during restore-failure recovery", err);
                     // Fall through silently — at worst the user has to log out manually.
                 });
+    }
+
+    /**
+     * The signed-in address, or null if it cannot be read.
+     *
+     * <p>Deliberately incurious about why it might not be: this runs while recovering from an
+     * account that has already failed to restore, and a missing address costs a prefilled
+     * field, not the recovery.
+     */
+    private String signedInEmailOrNull() {
+        try {
+            return this.userAuthRepo.getUserAuth().blockingFirst()
+                    .map(stored -> stored.getUser().getAccount().getInfo().getAccountName())
+                    .orElse(null);
+        } catch (final Exception e) {
+            Log.w(TAG, "Could not read the signed-in address to prefill the login screen", e);
+            return null;
+        }
     }
 
     private synchronized void addBeaconToCurrent(final List<BeaconInformation> newBeaconInformation) {
@@ -1343,6 +1373,16 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
 
     private void sendToLogin() {
         Intent intent = new Intent(this, AppleLoginActivity.class);
+        startActivity(intent);
+    }
+
+    /** As above, but for somebody who did not choose to be signed out. */
+    private void sendToLoginBecauseTheSessionExpired(final String email) {
+        Intent intent = new Intent(this, AppleLoginActivity.class);
+        intent.putExtra(AppleLoginActivity.EXTRA_SESSION_EXPIRED, true);
+        if (email != null) {
+            intent.putExtra(AppleLoginActivity.EXTRA_PREFILL_EMAIL, email);
+        }
         startActivity(intent);
     }
 

--- a/app/src/main/python/main.py
+++ b/app/src/main/python/main.py
@@ -441,13 +441,21 @@ def getAccount(
 
         print(f"Restored account, login state: {acc.login_state}")
         if acc.login_state != LoginState.LOGGED_IN:
-            # Worth saying plainly rather than leaving to the traceback that follows minutes
-            # later from somewhere else entirely. This is the state that makes every fetch
-            # raise InvalidStateError with nothing sent.
+            # **Not a successful restore, and it used to be treated as one.** This account is
+            # readable and unusable: every fetch fails its state check before a request is even
+            # made, so the app came up showing stale pins and spinners that stopped, with the
+            # reason only in the log. Issue #43.
+            #
+            # Reported as a failure so the caller can do the one thing that helps - send the
+            # user to sign in again. That is safe here because the app only ever stores an
+            # account after a completed sign-in: mid-2FA state is never written, so this state
+            # can only mean the session went bad afterwards.
             print(
-                "Restored account is NOT logged in - every report fetch will fail its state "
-                "check before any request is made. See issue #43."
+                f"Restored account is not logged in (state: {acc.login_state}) - Apple has "
+                "stopped accepting this session. Treating it as a failed restore so the user "
+                "is asked to sign in again rather than left with a map that never updates."
             )
+            return None
 
         return acc
     except Exception:

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -108,7 +108,6 @@
     <string name="map_provider">Kartenanbieter</string>
     <string name="map_provider_google">Google Maps</string>
     <string name="map_provider_amap">AMap (高德地图)</string>
-    <string name="relogin_required_after_upgrade">Bitte melden Sie sich erneut an – die FindMy-Bibliothek wurde aktualisiert.</string>
     <string name="maps_api_key_missing_title">Google Maps API-Schlüssel fehlt</string>
     <string name="maps_api_key_missing_message">Dieser Build enthält keinen Google Maps API-Schlüssel, daher wird die Karte nicht geladen. Fügen Sie MAPS_API_KEY zu secrets.properties hinzu und erstellen Sie den Build neu, oder wählen Sie in den Einstellungen einen anderen Kartenanbieter.</string>
     <string name="resolving_tags_banner">Ihre Tags werden zum ersten Mal geortet. Das kann einige Minuten dauern – bitte lassen Sie die App geöffnet.</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">Mit diesem Code ließ sich das Bündel nicht öffnen. Vergleiche ihn mit dem, den der Exporter angezeigt hat.</string>
     <string name="import_failed_locked">Dieses Bündel ist gesperrt und es wurde kein Code eingegeben.</string>
     <string name="bundle_passcode_malformed">Ein Code besteht nur aus Ziffern und Buchstaben.</string>
+    <string name="session_expired_title">Bitte erneut anmelden</string>
+    <string name="session_expired_message">Apple akzeptiert die gespeicherte Anmeldung dieses Geräts nicht mehr. Ihre Tags können erst wieder geortet werden, wenn Sie sich erneut anmelden.
+
+Ihre Tags und deren Standortverlauf bleiben auf diesem Telefon – es ist nichts verloren gegangen.</string>
+    <string name="ok">OK</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -108,7 +108,6 @@
     <string name="map_provider">Map Provider</string>
     <string name="map_provider_google">Google Maps</string>
     <string name="map_provider_amap">AMap (高德地图)</string>
-    <string name="relogin_required_after_upgrade">Please sign in again — the FindMy library has been updated.</string>
     <string name="maps_api_key_missing_title">Google Maps API key missing</string>
     <string name="maps_api_key_missing_message">This build has no Google Maps API key, so the map will not load. Add MAPS_API_KEY to secrets.properties and rebuild, or pick a different map provider in Settings.</string>
     <string name="resolving_tags_banner">Locating your tags for the first time. This can take a few minutes — please keep the app open.</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">That code did not open the bundle. Check it against the one the exporter showed.</string>
     <string name="import_failed_locked">This bundle is locked and no code was entered.</string>
     <string name="bundle_passcode_malformed">A code is made of digits and letters only.</string>
+    <string name="session_expired_title">Please sign in again</string>
+    <string name="session_expired_message">Apple no longer accepts the saved sign-in for this device, so your tags cannot be located until you sign in again.
+
+Your tags and their location history stay on this phone — nothing has been lost.</string>
+    <string name="ok">OK</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -108,7 +108,6 @@
     <string name="map_provider">Fournisseur de cartes</string>
     <string name="map_provider_google">Google Maps</string>
     <string name="map_provider_amap">AMap (高德地图)</string>
-    <string name="relogin_required_after_upgrade">Veuillez vous reconnecter : la bibliothèque FindMy a été mise à jour.</string>
     <string name="maps_api_key_missing_title">Clé API Google Maps manquante</string>
     <string name="maps_api_key_missing_message">Cette version ne contient pas de clé API Google Maps, la carte ne se chargera donc pas. Ajoutez MAPS_API_KEY à secrets.properties et recompilez, ou choisissez un autre fournisseur de cartes dans les paramètres.</string>
     <string name="resolving_tags_banner">Localisation de vos balises pour la première fois. Cela peut prendre quelques minutes : veuillez laisser l’application ouverte.</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">Ce code n’a pas ouvert l’archive. Vérifiez-le par rapport à celui affiché par l’exportateur.</string>
     <string name="import_failed_locked">Cette archive est verrouillée et aucun code n’a été saisi.</string>
     <string name="bundle_passcode_malformed">Un code se compose uniquement de chiffres et de lettres.</string>
+    <string name="session_expired_title">Veuillez vous reconnecter</string>
+    <string name="session_expired_message">Apple n’accepte plus la connexion enregistrée pour cet appareil : vos balises ne peuvent pas être localisées tant que vous ne vous reconnectez pas.
+
+Vos balises et leur historique de position restent sur ce téléphone — rien n’a été perdu.</string>
+    <string name="ok">OK</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -108,7 +108,6 @@
     <string name="map_provider">地図プロバイダ</string>
     <string name="map_provider_google">Google マップ</string>
     <string name="map_provider_amap">AMap (高德地图)</string>
-    <string name="relogin_required_after_upgrade">FindMy ライブラリが更新されました。もう一度サインインしてください。</string>
     <string name="maps_api_key_missing_title">Google マップ API キーがありません</string>
     <string name="maps_api_key_missing_message">このビルドには Google マップ API キーがないため、地図を読み込めません。secrets.properties に MAPS_API_KEY を追加してビルドし直すか、設定で別の地図プロバイダを選択してください。</string>
     <string name="resolving_tags_banner">タグの位置を初めて特定しています。数分かかる場合があります。アプリを開いたままにしてください。</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">このコードではバンドルを開けませんでした。エクスポーターが表示したコードと照らし合わせてください。</string>
     <string name="import_failed_locked">このバンドルはロックされていますが、コードが入力されていません。</string>
     <string name="bundle_passcode_malformed">コードは数字と英字のみで構成されます。</string>
+    <string name="session_expired_title">もう一度サインインしてください</string>
+    <string name="session_expired_message">この端末に保存されたサインインが Apple に受け付けられなくなりました。もう一度サインインするまで、タグの位置を取得できません。
+
+タグと位置履歴はこの端末に残っています。失われたものはありません。</string>
+    <string name="ok">OK</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -108,7 +108,6 @@
     <string name="map_provider">지도 제공자</string>
     <string name="map_provider_google">Google 지도</string>
     <string name="map_provider_amap">AMap (高德地图)</string>
-    <string name="relogin_required_after_upgrade">FindMy 라이브러리가 업데이트되었습니다. 다시 로그인해 주세요.</string>
     <string name="maps_api_key_missing_title">Google 지도 API 키가 없습니다</string>
     <string name="maps_api_key_missing_message">이 빌드에는 Google 지도 API 키가 없어 지도를 불러올 수 없습니다. secrets.properties에 MAPS_API_KEY를 추가한 후 다시 빌드하거나, 설정에서 다른 지도 제공자를 선택하세요.</string>
     <string name="resolving_tags_banner">태그의 위치를 처음으로 확인하는 중입니다. 몇 분 정도 걸릴 수 있으니 앱을 열어 두세요.</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">이 코드로는 번들을 열 수 없습니다. 내보내기 도구가 표시한 코드와 대조해 보세요.</string>
     <string name="import_failed_locked">이 번들은 잠겨 있으며 코드가 입력되지 않았습니다.</string>
     <string name="bundle_passcode_malformed">코드는 숫자와 영문자로만 이루어집니다.</string>
+    <string name="session_expired_title">다시 로그인해 주세요</string>
+    <string name="session_expired_message">Apple이 이 기기에 저장된 로그인을 더 이상 받아들이지 않습니다. 다시 로그인하기 전까지는 태그의 위치를 찾을 수 없습니다.
+
+태그와 위치 기록은 이 휴대전화에 그대로 남아 있습니다. 사라진 것은 없습니다.</string>
+    <string name="ok">확인</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -108,7 +108,6 @@
     <string name="map_provider">Kaartaanbieder</string>
     <string name="map_provider_google">Google Maps</string>
     <string name="map_provider_amap">AMap (高德地图)</string>
-    <string name="relogin_required_after_upgrade">Log opnieuw in — de FindMy-bibliotheek is bijgewerkt.</string>
     <string name="maps_api_key_missing_title">Google Maps API-sleutel ontbreekt</string>
     <string name="maps_api_key_missing_message">Deze build heeft geen Google Maps API-sleutel, dus de kaart wordt niet geladen. Voeg MAPS_API_KEY toe aan secrets.properties en bouw opnieuw, of kies een andere kaartaanbieder in de instellingen.</string>
     <string name="resolving_tags_banner">Je tags worden voor het eerst gelokaliseerd. Dit kan een paar minuten duren — houd de app open.</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">Met die code ging de bundel niet open. Vergelijk hem met de code die de exporter toonde.</string>
     <string name="import_failed_locked">Deze bundel is vergrendeld en er is geen code ingevoerd.</string>
     <string name="bundle_passcode_malformed">Een code bestaat alleen uit cijfers en letters.</string>
+    <string name="session_expired_title">Log opnieuw in</string>
+    <string name="session_expired_message">Apple accepteert de opgeslagen aanmelding van dit apparaat niet meer, dus je tags kunnen pas weer worden gelokaliseerd nadat je opnieuw inlogt.
+
+Je tags en hun locatiegeschiedenis blijven op deze telefoon staan — er is niets verloren gegaan.</string>
+    <string name="ok">OK</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -108,7 +108,6 @@
     <string name="map_provider">Поставщик карт</string>
     <string name="map_provider_google">Google Карты</string>
     <string name="map_provider_amap">AMap (高德地图)</string>
-    <string name="relogin_required_after_upgrade">Пожалуйста, войдите снова — библиотека FindMy была обновлена.</string>
     <string name="maps_api_key_missing_title">Отсутствует ключ API Google Карт</string>
     <string name="maps_api_key_missing_message">В этой сборке нет ключа API Google Карт, поэтому карта не загрузится. Добавьте MAPS_API_KEY в secrets.properties и пересоберите приложение или выберите другого поставщика карт в настройках.</string>
     <string name="resolving_tags_banner">Первое определение местоположения ваших меток. Это может занять несколько минут — не закрывайте приложение.</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">Этот код не открыл архив. Сверьте его с тем, что показал экспортёр.</string>
     <string name="import_failed_locked">Этот архив заблокирован, а код не введён.</string>
     <string name="bundle_passcode_malformed">Код состоит только из цифр и букв.</string>
+    <string name="session_expired_title">Войдите снова</string>
+    <string name="session_expired_message">Apple больше не принимает сохранённый вход для этого устройства, поэтому найти метки не получится, пока вы не войдёте снова.
+
+Ваши метки и история их местоположений остаются на этом телефоне — ничего не потеряно.</string>
+    <string name="ok">ОК</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -96,7 +96,6 @@
     <string name="map_provider">地图提供商</string>
     <string name="map_provider_google">Google 地图</string>
     <string name="map_provider_amap">高德地图 (AMap)</string>
-    <string name="relogin_required_after_upgrade">FindMy 库已更新，请重新登录。</string>
     <string name="amap_api_key_explanation">高德地图需要您自行提供 API Key。请前往 lbs.amap.com 注册，平台选择“Android 平台 SDK”，然后将 Key 粘贴到此处。</string>
     <string name="amap_copy_registration_details">复制包名和 SHA1</string>
     <string name="amap_registration_details_copied">已复制。创建 Key 时请将这些信息粘贴到高德控制台。</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">该代码无法解开此导出包。请与导出工具显示的代码核对。</string>
     <string name="import_failed_locked">此导出包已加密，但未输入代码。</string>
     <string name="bundle_passcode_malformed">代码仅由数字和字母组成。</string>
+    <string name="session_expired_title">请重新登录</string>
+    <string name="session_expired_message">Apple 不再接受本设备上保存的登录信息，重新登录后才能定位你的标签。
+
+标签及其位置历史仍保存在这部手机上，没有任何数据丢失。</string>
+    <string name="ok">好</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -96,7 +96,6 @@
     <string name="map_provider">地圖提供商</string>
     <string name="map_provider_google">Google 地圖</string>
     <string name="map_provider_amap">高德地圖 (AMap)</string>
-    <string name="relogin_required_after_upgrade">FindMy 函式庫已更新，請重新登入。</string>
     <string name="amap_api_key_explanation">高德地圖需要您自行提供 API Key。請前往 lbs.amap.com 註冊，平台選擇「Android 平台 SDK」，然後將 Key 貼到此處。</string>
     <string name="amap_copy_registration_details">複製套件名稱與 SHA1</string>
     <string name="amap_registration_details_copied">已複製。建立 Key 時請將這些資訊貼到高德主控台。</string>
@@ -160,4 +159,9 @@
     <string name="import_failed_wrong_passcode">該代碼無法解開此匯出包。請與匯出工具顯示的代碼核對。</string>
     <string name="import_failed_locked">此匯出包已加密，但未輸入代碼。</string>
     <string name="bundle_passcode_malformed">代碼僅由數字和字母組成。</string>
+    <string name="session_expired_title">請重新登入</string>
+    <string name="session_expired_message">Apple 不再接受本裝置上儲存的登入資訊，重新登入後才能定位你的標籤。
+
+標籤及其位置紀錄仍保留在這支手機上，沒有任何資料遺失。</string>
+    <string name="ok">好</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,7 +129,6 @@
     <string name="map_provider">Map Provider</string>
     <string name="map_provider_google">Google Maps</string>
     <string name="map_provider_amap">高德地图 (AMap)</string>
-    <string name="relogin_required_after_upgrade">Please sign in again — the FindMy library has been updated.</string>
     <string name="amap_api_key" translatable="false">AMap API Key</string>
     <string name="amap_api_key_explanation">AMap requires each user to supply their own API key. Register one at lbs.amap.com, choosing "Android SDK" as the platform, and paste it here.</string>
     <string name="amap_copy_registration_details">Copy package name and SHA1</string>
@@ -195,4 +194,9 @@
     <string name="import_failed_locked">This bundle is locked and no code was entered.</string>
     <string name="bundle_passcode_malformed">A code is made of digits and letters only.</string>
     <string name="bundle_passcode_group_separator" translatable="false">-</string>
+    <string name="session_expired_title">Please sign in again</string>
+    <string name="session_expired_message">Apple no longer accepts the saved sign-in for this device, so your tags cannot be located until you sign in again.
+
+Your tags and their location history stay on this phone — nothing has been lost.</string>
+    <string name="ok">OK</string>
 </resources>

--- a/app/src/test/python/requirements.txt
+++ b/app/src/test/python/requirements.txt
@@ -9,7 +9,7 @@
 # `FindMy==0.9.8` here for as long as the app built the fork, so every bridge test
 # ran against a library the app does not ship - which is not a small difference:
 # the fork's Anisette providers take `serial=` and PyPI's do not.
-git+https://github.com/parawanderer/FindMy.py@2ea738aafbf86b2f9455704b81fc731c732c863b
+git+https://github.com/parawanderer/FindMy.py@102dd8ea14767d2a2aa745186ac23276f32689f1
 NSKeyedUnArchiver==1.5
 
 pytest>=8.0

--- a/app/src/test/python/test_main.py
+++ b/app/src/test/python/test_main.py
@@ -460,6 +460,45 @@ def test_getAccount_refuses_local_anisette():
 
 
 # --------------------------------------------------------------------------
+# A session Apple has stopped accepting
+#
+# It deserializes perfectly and is completely unusable: every fetch fails its state
+# check before a request is made. Returning it as a success is how the app came up
+# showing stale pins and spinners that stopped, with the reason only in the log.
+# Issue #43.
+# --------------------------------------------------------------------------
+
+def _storedAccount(loggedIn: bool) -> str:
+    from findmy.reports import AppleAccount, RemoteAnisetteProvider
+    from findmy.reports.state import LoginState
+
+    account = AppleAccount(RemoteAnisetteProvider("https://ani.example.com"))
+    stored = account.to_json()
+
+    # A fresh account is LOGGED_OUT, which is exactly the shape an invalidated session
+    # restores to. The logged-in case is the same blob with the one field moved, so the
+    # two tests differ in nothing else.
+    stored["login"]["state"] = (
+        LoginState.LOGGED_IN.value if loggedIn else LoginState.LOGGED_OUT.value
+    )
+    return json.dumps(stored)
+
+
+def test_a_session_apple_no_longer_accepts_is_a_failed_restore():
+    assert main.getAccount(_storedAccount(loggedIn=False)) is None
+
+
+def test_a_session_that_still_works_restores_normally():
+    """
+    The other half, and the one that matters more.
+
+    Reporting a working session as failed would sign people out for no reason - a far worse
+    bug than the one above, and the obvious way to get this wrong.
+    """
+    assert main.getAccount(_storedAccount(loggedIn=True)) is not None
+
+
+# --------------------------------------------------------------------------
 # Guard against the test environment drifting from what the app ships
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
Stacked on #104 — review that first; the diff below is the last commit only.

Companion to the identity work, and worth having whatever that turns out to do: a session can
stop working for reasons the user did nothing to cause, and until now the app said either the
wrong thing or nothing at all.

## Three gaps, and the middle one hid the others

**A session Apple no longer accepts restored as a success.** `getAccount` printed a warning
about issue #43 and returned the account anyway. That account is readable and completely
unusable — every fetch fails its state check before a request is made. So the app came up with
stale pins and spinners that stopped, and the only statement of what had happened was in
logcat. The recovery code below existed the whole time and never ran.

Safe to treat as terminal: the app only ever stores an account after a completed sign-in —
`AppleLoginActivity` writes it post-2FA or on already-logged-in, never mid-flow — so a stored
account that is not logged in can only mean the session went bad afterwards.

**The recovery said the wrong thing, in the wrong way.** A toast asserting the FindMy library
had been updated. True of the single migration it was written for; wrong for Apple invalidating
a session, a password change, or the machine identity moving because local Anisette fell back
to a server.

**And they had to type their address again.**

## What it does now

A dialog on the login screen, with the email already filled in.

> **Please sign in again**
>
> Apple no longer accepts the saved sign-in for this device, so your tags cannot be located
> until you sign in again.
>
> Your tags and their location history stay on this phone — nothing has been lost.

That second paragraph is the part that matters. Somebody dropped on a login form with no
explanation reasonably concludes the app has lost everything, and a reasonable next step is to
tidy up whatever unfamiliar entry is sitting in their Apple device list — which is the one
action that makes it worse, because that entry is this app.

Three details that are load-bearing rather than incidental:

- **The address is read before the account is cleared**, which is why those are not two
  independent steps — clearing is what destroys it. Read defensively, since this runs while
  recovering from an account that has already failed to restore: a missing address costs a
  prefilled field, not the recovery.
- **The login screen shows the dialog, not the sender.** `MapsActivity` is finishing, and a
  dialog on a finishing activity is a leaked window.
- **The two extras are independent.** An address can be known when nothing expired, and
  something can expire when the address cannot be read. Both are covered.

`relogin_required_after_upgrade` is removed rather than reworded, since its text named a cause
that is no longer the general one. New strings in all ten locales.

## Testing

`SessionExpiredLoginTest` drives the screen with the extras, and Python covers the restore
decision on both sides — a dead session must fail, and a working one must not.

The real trigger cannot be produced on demand, since it needs Apple to reject a session. What
can be asserted is that the screen honours what it is sent, and that an ordinary first run is
told nothing.

**Checked that they can fail:**

| Broken on purpose | Went red |
| --- | --- |
| A dead session restoring as a success | the Python case written for it |
| The dialog showing unconditionally | **16 tests** — the two negative cases here plus every existing login test |

That second number is the useful one: it says as clearly as anything could that this must never
fire on an ordinary first run.

One thing found while writing it, worth knowing for the next dialog test: a dialog owns the
focused window, so Espresso resolves views against the dialog's hierarchy and not the
activity's. Looking for a field behind it fails with `NoMatchingViewException` even though the
field is there. Dismiss first — which is the order a person meets it in anyway.

206 instrumented tests pass, 85 Python tests pass.

## Also here

FindMy.py moves to `102dd8e`, which fixes an object that was never built raising from
`__del__` when the `uid`/`devid` pair is rejected — the nit found while testing #104.
