### PR TITLE
Say on the front page what this works with, and what it does not

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,34 @@ This project is a relatively polished looking Android/Java UI-wrapper around the
 - UI customisation options
 
 
+## What it works with 🏷️
+
+**The short version: if it shows up under _Items_ in Apple's own Find My app, it is in scope.**
+AirTags are not a special case — they are just the most common thing in that list, and third-party
+trackers that advertise "Works with Apple Find My" use the same network and the same keys.
+
+| What | Works? | |
+| --- | --- | --- |
+| **AirTag** | ✅ Yes | What most people are here for |
+| **Third-party trackers that work with Apple Find My** — Chipolo, Pebblebee, Mili MiTag, eufy and similar | ✅ Should work | Same network, same keys, nothing special about them. Not tested by the maintainers, who do not own any — [reports welcome](https://github.com/parawanderer/OpenTagViewer/issues) |
+| **AirPods, and other Find My accessories** | ✅ Mostly | Works where Apple stores a usable key for it. Lightly tested |
+| **Your own iPhone, iPad or Mac** | ✅ Yes | They are findable devices too, and appear alongside your tags |
+| **Self-made tags** — [OpenHaystack](https://github.com/seemoo-lab/openhaystack), [Macless Haystack](https://github.com/dchristl/macless-haystack) | ⚠️ Exporter only | The exporter can package them; the app cannot read them yet ([#45](https://github.com/parawanderer/OpenTagViewer/issues/45)) |
+| **A tag someone shared with you** through Apple's own sharing | ❌ No | Only the account that *owns* a tag can export it. Ask the owner to export it and send you the zip |
+| **Tile, Samsung SmartTag, Google Find My Device trackers** | ❌ No | Different networks entirely, with nothing in common with Apple's. Out of scope |
+
+> [!NOTE]
+> This app reads Apple's Find My network. Anything not on that network cannot be tracked with it,
+> no matter how similar the device looks.
+
+
 ## How To Use 📖
 
 ### Requirements 🤓
 
 1. An Android phone with [the `OpenTagViewer` app installed](https://github.com/parawanderer/OpenTagViewer/wiki/How-To:-Install-App)
 2. A (free) [Apple Account](https://account.apple.com/) with 2FA enabled to be via either `SMS` or `Trusted Device`
-3. One or more **AirTags**, which need to be already registered to some Apple account via the `FindMy` app
+3. One or more **AirTags** — or any other tracker that appears under *Items* in Apple's `FindMy` app (see [what it works with](#what-it-works-with-)) — already registered to an Apple account you own
 4. Any computer to run the exporter on — Windows, Linux or a Mac (only needed once/initially). See [the export guide](https://github.com/parawanderer/OpenTagViewer/wiki/How-To:-Export-AirTags#prerequisites)
 
 


### PR DESCRIPTION
Adds a user-facing support table to the README, from the idea in #111.

## Why

#111 asked whether a Mili MiTag works. It does — and that it had to be asked is the problem. Nothing user-facing said that **"AirTag" and "third-party tracker that works with Apple Find My" are the same case here**. The README says "AirTags" throughout, so someone holding a Chipolo has no way to tell whether they are the audience.

## What it says

One rule does most of the work, so it leads:

> **If it shows up under _Items_ in Apple's own Find My app, it is in scope.**

Then a table of the cases people actually arrive with — including the two answers that are **no**, which is the half a support matrix usually omits:

- a tag **shared to you** through Apple's own sharing, which only its owner can export
- **Tile, Samsung SmartTag, Google Find My Device** — different networks, nothing in common with this one

Third-party trackers are marked **"should work"**, not "yes", because nobody here owns one to try. Overstating it would turn a documentation gap into a bug report.

The requirements list said *"One or more AirTags"* — the same confusion, in the one place a reader checks whether to keep going — so it now points at the table.

## What it does not change

`docs/export-modes.md` already carried a version of this and stays as it is. It is written for whoever implements the modes, splits things by trust-circle behaviour, and is not what somebody deciding whether to install the app needs. This is the front-page answer; that is the design note.

Closes #111.

---

*PR description summarised by Claude Code.*