### PR TITLE
Call the exporter's tests what they are, on the badge that says otherwise

### DIFF
--- a/.github/workflows/macos-scripts-python.yml
+++ b/.github/workflows/macos-scripts-python.yml
@@ -1,7 +1,14 @@
 # Lints and tests everything under python/: the desktop exporter and the shared export package.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: MacOS Scripts
+# **"MacOS Scripts" was the old name and described none of this.** There are no scripts here, and
+# macOS is only where the runner happens to be - the local export route needs a Mac of 14 or older
+# to test, and everything else under python/ is platform-agnostic. The name is what shows on the
+# README badge, so it was telling every visitor that the exporter's tests were something else.
+#
+# The filename stays as it is: the badge URL is built from it, and renaming would break the badge
+# on every page that already links it, for a cosmetic gain.
+name: Exporter Tests
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 
 [![Android build & tests](https://github.com/parawanderer/OpenTagViewer/actions/workflows/build-debug.yml/badge.svg?branch=main)](https://github.com/parawanderer/OpenTagViewer/actions/workflows/build-debug.yml)
-[![macOS export wizard](https://github.com/parawanderer/OpenTagViewer/actions/workflows/macos-scripts-python.yml/badge.svg?branch=main)](https://github.com/parawanderer/OpenTagViewer/actions/workflows/macos-scripts-python.yml)
+[![Exporter tests](https://github.com/parawanderer/OpenTagViewer/actions/workflows/macos-scripts-python.yml/badge.svg?branch=main)](https://github.com/parawanderer/OpenTagViewer/actions/workflows/macos-scripts-python.yml)
 [![Release](https://github.com/parawanderer/OpenTagViewer/actions/workflows/build-release.yml/badge.svg)](https://github.com/parawanderer/OpenTagViewer/actions/workflows/build-release.yml)
 
 Apparently, this is the first **<img src="https://github.com/user-attachments/assets/aa0531f6-6a5e-4c9f-b3c4-dfc3899c8a49" width="20"/> Android App** to allow you to view/track your **<img src="https://github.com/user-attachments/assets/fa3b912f-d204-4252-9449-465eb62f128c" height="20"/> official Apple AirTags**.


### PR DESCRIPTION
The README's middle badge read **"MacOS Scripts"**, which describes none of that workflow.

There are no scripts in it, and macOS is only where the runner happens to be — the local export route needs a Mac of 14 or older to exercise, and the rest of `python/` is platform-agnostic. The badge label comes from the workflow's `name:`, so the front page was telling every visitor that the exporter's test suite was something else.

Now **Exporter Tests**, and the README's alt text matches.

## What is deliberately unchanged

**The filename.** The badge URL is built from `macos-scripts-python.yml`, so renaming the file breaks the badge on every page that already links it — for a cosmetic gain. Same reasoning that kept `macos-exporter-python.yml` its name when it stopped being macOS-only, which its own header comment records.

**CONTRIBUTING's CI table.** It refers to the workflow by filename and already describes it accurately.

The three exporter workflows now read distinctly: **Exporter Tests** (lint and pytest), **Exporter Build Check** (Windows binary on PRs), **Exporter App** (release builds).

---

*PR description summarised by Claude Code.*