### PR TITLE
Say why bundles are still unlocked, which is not the reason written down

### DIFF
--- a/python/exporter/cli.py
+++ b/python/exporter/cli.py
@@ -116,8 +116,8 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "Write a plain zip. The bundle is locked with a generated code by default, because it"
-            " holds keys that cannot be revoked - but no OpenTagViewer release can open a locked"
-            " one yet."
+            " holds keys that cannot be revoked - but no released version of the Android app can"
+            " open a locked one yet, so a bundle for somebody else needs this."
         ),
     )
     parser.add_argument(

--- a/python/exporter/wizard.py
+++ b/python/exporter/wizard.py
@@ -564,9 +564,18 @@ class WizardApp(tk.Tk):
             messagebox.showerror("That selection cannot be exported", str(e))
             return
 
-        # No password from the window yet: nothing that imports these can open a locked one, so
-        # offering it here would produce a file the recipient cannot use. See the CLI's
-        # --no-password, and docs/android-import-handover.md.
+        # **No password yet, and the reason is release ordering rather than a missing feature.**
+        # The app on `main` imports locked bundles - zip4j is in `app/build.gradle.kts` and
+        # `AppleZipImporterUtil` uses it - but no *released* APK does: the newest is 1.0.5, from
+        # before that work, and `versionName` has not moved past it.
+        #
+        # So locking bundles now would produce files that nobody's installed app can open, and the
+        # people worst affected would be recipients, who did not choose the exporter's version and
+        # cannot fix it from their side.
+        #
+        # **What unblocks this is an Android release containing zip4j, not a change here.** Once
+        # one exists, this becomes a decision about how long to keep supporting the versions before
+        # it. See the CLI's --no-password, and docs/android-import-handover.md.
         write_zip(bundle, path, password=None)
 
         messagebox.showinfo(


### PR DESCRIPTION
Two comments claimed nothing can open a locked bundle. That is no longer true, and the way it is false matters — because the obvious next step from the old wording is to switch locking on, which would break things for users.

## What is actually true

| | |
| --- | --- |
| The app on `main` | **reads locked bundles** — zip4j is in `app/build.gradle.kts` and `AppleZipImporterUtil` uses it |
| Newest Android release | **1.0.5**, from 2026-08-09, before that work |
| `versionName` on `main` | still `1.0.5` — the import support is unreleased and has no version number |

So the constraint is **release ordering, not a missing feature**. Locking bundles now would produce files that no *installed* app can open, and it lands hardest on recipients — who did not choose the exporter's version and cannot fix it from their side.

## What changed

Only comments and one `--help` string. No behaviour.

Both now name the condition that unblocks this — **an Android release containing zip4j** — rather than describing a capability that already exists. Once one ships, this becomes a decision about how long to support the versions before it, which is a real decision rather than a TODO.

## Checked and left alone

- The CLI guide's `--no-password` row already says *"Required for any released version of the app"*, which is exactly right.
- `docs/android-import-handover.md` §3 is already marked **done** and documents the zip4j work.

---

*PR description summarised by Claude Code.*