### PR TITLE
Bump the exporter to 1.3.0

### DIFF
--- a/python/exporter/version.py
+++ b/python/exporter/version.py
@@ -19,7 +19,7 @@ exports stamp `via:` too, so a build-time patch would make two artifacts from on
 
 from __future__ import annotations
 
-VERSION = "1.2.1"
+VERSION = "1.3.0"
 
 APP_TITLE = f"OpenTagViewer AirTag Exporter {VERSION}"
 


### PR DESCRIPTION
Version bump only. Everything it releases is already on `main`:

| | |
| --- | --- |
| [#117](https://github.com/parawanderer/OpenTagViewer/pull/117) | Save logs button, with identifier stripping |
| [#121](https://github.com/parawanderer/OpenTagViewer/pull/121) | Apple's terms of service in the wizard |
| [#122](https://github.com/parawanderer/OpenTagViewer/pull/122) | Requests get thirty seconds instead of five |

Minor rather than patch: two of the three are new things the exporter can do, not repairs to things it already did.

This has to land before the tag exists, and the tag has to match — `scripts/release_version.py` enforces that in `test-release-version` before any build job runs. See AGENTS.md rule 9.

---
*PR description summarised by Claude Code.*
