### PR TITLE
Fix eight bugs the new tests found, and order the first import usefully

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,8 +285,14 @@ Three consequences worth knowing:
   emulator's own window has focus on the host desktop, so against a hand-started emulator any
   UI test fails with `RootViewWithoutFocusException` the moment you alt-tab away. There is
   nothing to fix in the test when that happens — run it on the managed device.
-- `./gradlew testDebugUnitTest` is close to meaningless: there is exactly one JVM test and it
-  asserts `2 + 2 == 4`. Everything real is instrumented. Do not report "tests pass" off it.
+- `./gradlew testDebugUnitTest` runs **118 JVM tests in about ten seconds**, and is worth
+  running constantly while working on anything it covers: the pure logic. Refresh policy, scan
+  order, marker focus, the long-fetch banner, passcode parsing, the CSV and zip writers,
+  coordinate conversion. Anything that needs neither Android nor a device belongs there, not on
+  the emulator — it is two orders of magnitude faster to run.
+
+  It is still **not** the suite to report "tests pass" from. Every screen, every repository and
+  the whole Python bridge are instrumented, so a green JVM run says nothing about them.
 
 ### Writing an Espresso test that is not flaky
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,27 @@ wizard).
 | Shared export package | `python/opentagviewer_export/tests/` | pytest | no |
 | Tooling tests | `scripts/test/` | pytest | no |
 | Test doubles for the bridge | `app/src/debug/python/` | installed from an instrumented test | provisioned for you |
+| Fakes for the screens | `app/src/androidTest/java/.../ui/maps/` | used directly by a test | provisioned for you |
+
+### Faking the world the screens sit in
+
+The Python doubles below get a session to restore. Three Java-side fakes get a *screen* to
+render, and they exist because the managed device cannot provide what the real ones need.
+
+| Fake | Stands in for | Why the real one cannot run here |
+| --- | --- | --- |
+| `FakeMapProvider` | `IMapProvider` | `aosp-atd` has no Play Services, so no real map initialises. It records what was drawn rather than drawing it, which is the more useful half: "there is a pin for this tag, at these coordinates" is a claim about the app's decision |
+| `FakeMapView` | the map surface | Only so a screenshot shows something. It draws a flat ground, a graticule and the pins, captioned as a fake — **nothing asserts on what it paints** |
+| `FakeGeocoder` | `AddressLookup` | The image has no geocoding backend, so `getFromLocation` returns empty for every point on earth — and the app's fallback for "no address" is to print the coordinates, so a missing geocoder is indistinguishable from an honest answer |
+
+`AddressLookup` is an interface rather than a `Geocoder` subclass because `Geocoder` is final;
+`AppDependencies.replaceGeocoder` is the seam.
+
+**`AMapWithTagsOnIt` is the fixture that arranges all of it.** Reaching a drawn map takes eight
+steps — a stored session, the Python double, a substituted provider, a geocoder, beacons with
+usable `accessory_json`, locations to draw them at, and `RefreshPolicy.resetShared()` so the
+startup fetch is not skipped. Seven tests need exactly that, and a copy of it that forgets the
+last step passes for a year because the fetch it meant to observe never ran.
 
 ### Faking Apple, on the Python side of the bridge
 
@@ -156,7 +177,7 @@ So there are two doubles, and they sit **below** the code under test rather than
 | Module | Replaces | So a test can |
 | --- | --- | --- |
 | `icloud_test_double` | the two functions in `exporter.icloud` that talk to Apple | drive sign-in, unlock, join, fetch, rename and close for real |
-| `apple_test_double` | `main.getAccount` and `main.accessoryFromJson` | have a stored session restore, so screens that wait on one will draw |
+| `apple_test_double` | `main.getAccount` and `main.accessoryFromJson` | have a stored session restore, so screens that wait on one will draw — and answer both fetch paths, so the map and the history screen both work |
 
 They live in the **debug source set**. Chaquopy compiles `src/<variant>/python` alongside
 `src/main/python`, so they are in the debug APK the instrumented tests run against and in no
@@ -338,8 +359,10 @@ python scripts/update_adi_stub_symbols.py --check   # what CI runs weekly
 
 ### Android unit tests
 
-Plain JVM, no Android framework, so these are the fastest tests in the project — seconds, no
-emulator.
+Plain JVM, no Android framework, so these are the fastest tests in the project — **118 of them
+in about ten seconds**, no emulator. Worth running constantly while working on anything they
+cover; anything needing neither Android nor a device belongs here rather than on the managed
+device, which is two orders of magnitude slower.
 
 Most of what lives here is in `util/rx/`: the stream compositions and decision logic behind
 the map, extracted out of `MapsActivity` precisely so it could be tested. They assert that a
@@ -347,6 +370,13 @@ call *happens* rather than that a value looks right, because the failures in thi
 silent — a stream disposed early, a marker that stops being raised, a fetch that returns
 nothing being indistinguishable from a fetch that failed. None of those throw, and none show
 up in logcat.
+
+`ui/maps/CoordinateConverterTest` is here for a different reason, and is worth knowing about:
+it is the **only** coverage of the AMap path that exists. Both real map providers need a device
+this project cannot provision — `aosp-atd` has no Play Services, and the AMap SDK is optional at
+compile time — so everything else runs against `FakeMapProvider`. The GCJ-02 conversion is the
+one piece that is pure arithmetic, and a wrong one puts every pin a few hundred metres out for
+every user in mainland China, silently.
 
 ```bash
 ./gradlew testDebugUnitTest

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -469,6 +469,22 @@ dependencies {
     // MapsActivity is the end of the sign-in flow and needs Play Services, which the aosp-atd
     // managed device does not have.
     androidTestImplementation(libs.espresso.intents)
+    // RecyclerViewActions, for the two screens that are lists: the history of one tag, and the
+    // device list. Espresso's own matchers cannot reach a row that has not been scrolled to,
+    // and a test that only ever touches the first visible row is a test of the first row.
+    //
+    // **protobuf-lite is excluded, and without that this breaks unrelated tests.** contrib
+    // pulls com.google.protobuf:protobuf-lite:3.0.1 for its accessibility checks, which this
+    // suite does not use. That version predates
+    // `GeneratedMessageLite.registerDefaultInstance(Class, GeneratedMessageLite)`, and Cronet
+    // calls exactly that while deciding whether to use the HTTP engine - so anything that
+    // builds a CronetEngine dies with NoSuchMethodError. In this app that is the Anisette
+    // server tester, which SettingsActivity constructs, so simply adding this dependency
+    // stopped every Settings test from running - with a failure naming protobuf and Chromium
+    // and nothing about the test.
+    androidTestImplementation(libs.espresso.contrib) {
+        exclude(group = "com.google.protobuf", module = "protobuf-lite")
+    }
     androidTestImplementation(libs.android.room.testing)
 
     annotationProcessor(libs.projectlombok)

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/FetchFromICloudBackPressTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/FetchFromICloudBackPressTest.java
@@ -231,4 +231,84 @@ public class FetchFromICloudBackPressTest {
 
         Eventually.check(() -> assertTrue("the session was left open", this.icloud.wasClosed()));
     }
+
+    /**
+     * <b>Back gets you out while the screen is still loading.</b>
+     *
+     * <p><b>The screen used to swallow every back press whenever the loading step was up</b> -
+     * the in-app arrow and the device's own back button alike - on the reasoning that there is
+     * nothing to go back to mid-call. That reasoning holds for an unlock and for nothing else.
+     *
+     * <p>What it produced in practice: every call into Python is serialised through
+     * {@code PythonLock}, because the iCloud flow and the location fetch drive the same asyncio
+     * loop, and a first import holds that lock for <b>minutes</b> walking key indices for tags
+     * with no alignment record. Opening this screen during that wait left the user on a spinner
+     * they could not leave by any means, reading "Looking for a device that can unlock it" -
+     * which was not what was happening and, for an account already linked, never would be.
+     *
+     * <p>The delay here stands in for that wait. What is asserted is only that the screen can be
+     * left, which is the part that was impossible.
+     */
+    @Test
+    public void backLeavesWhileTheScreenIsStillLoading() {
+        this.open(FakeICloudService.withTags().takingItsTime(20_000));
+
+        Eventually.check(() -> assertTrue("the loading step should be up",
+                isShown(R.id.icloud_loading_container)));
+
+        // **Unconditionally, because succeeding is what throws.** A plain pressBack() raises
+        // NoActivityResumedException when the press finishes the last activity - which is
+        // precisely the outcome under test here, so the ordinary call reports the fix working
+        // as a failure.
+        pressBackUnconditionally();
+
+        Eventually.check(() -> assertTrue(
+                "back did nothing while the screen was loading, so there is no way out of a"
+                        + " wait that can last minutes", hasLeft()));
+    }
+
+    /**
+     * <b>And an unlock attempt is still not something you can walk out of.</b>
+     *
+     * <p>The exception the rule above is written around, and it is a real one: by then a
+     * passcode is being tried against Apple, attempts are probably limited on their end, and
+     * abandoning one half way risks spending it for nothing.
+     *
+     * <p>Pinned so that fixing the lock-in did not quietly remove the one case it was right
+     * about.
+     */
+    @Test
+    public void backIsStillIgnoredWhileAPasscodeIsBeingTried() {
+        // **The unlock is what is held open, and only the unlock.** The general delay applies
+        // to recoveryOptions alone, so setting it here would slow a call that has already
+        // happened and leave the unlock instant - the flow would finish before the back press
+        // and the screen would be gone for an ordinary reason.
+        this.open(FakeICloudService.withTags().withOneDevice());
+
+        Eventually.check(() -> onView(withId(R.id.icloud_device_container))
+                .check(matches(isDisplayed())));
+        Eventually.perform("the only device", () -> isShown(R.id.icloud_passcode_container),
+                () -> onView(withText(containsString(FakeICloudService.AN_IPHONE.getSerial())))
+                        .perform(click()));
+
+        this.icloud.takingItsTimeToUnlock(20_000);
+        onView(withId(R.id.icloud_passcode_input)).perform(replaceText("123456"));
+        Eventually.perform("unlock", () -> this.icloud.timesCalled("unlock") > 0,
+                () -> onView(withId(R.id.icloud_primary_button)).perform(click()));
+
+        // **Waited for, because unlock itself answers instantly.** The fake's delay lands on
+        // the fetch later in the chain, so `timesCalled("unlock") > 0` is true a moment before
+        // the screen has actually moved to the loading step - and a back press in that gap is
+        // handled by the passcode step, which with a single device correctly leaves.
+        Eventually.check(() -> assertTrue("the unlock step never came up",
+                isShown(R.id.icloud_loading_container)));
+
+        pressBack();
+
+        // Asked after giving it a moment to act on the press, so this is "it stayed" rather
+        // than "it has not left yet".
+        Eventually.check(() -> assertTrue("the unlock step should still be waiting",
+                isShown(R.id.icloud_loading_container)));
+        assertTrue("back abandoned an unlock that was already talking to Apple", !hasLeft());
+    }
 }

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/TheWholeAppJourneyTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/TheWholeAppJourneyTest.java
@@ -1,0 +1,524 @@
+package dev.wander.android.opentagviewer;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.pressBack;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isPlatformPopup;
+import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
+import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.Manifest;
+import android.content.Context;
+import android.os.SystemClock;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.GrantPermissionRule;
+
+import com.chaquo.python.PyObject;
+import com.chaquo.python.Python;
+import com.chaquo.python.android.AndroidPlatform;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import dev.wander.android.opentagviewer.anisette.FakeAnisetteSource;
+import dev.wander.android.opentagviewer.db.AccountBeaconsForTests;
+import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
+import dev.wander.android.opentagviewer.db.repo.KeychainMembershipRepository;
+import dev.wander.android.opentagviewer.db.repo.UserAuthRepository;
+import dev.wander.android.opentagviewer.db.room.OpenTagViewerDatabase;
+import dev.wander.android.opentagviewer.db.room.entity.OwnedBeacon;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.python.FakeAppleAuthService;
+import dev.wander.android.opentagviewer.python.icloud.FakeICloudService;
+import dev.wander.android.opentagviewer.ui.maps.FakeGeocoder;
+import dev.wander.android.opentagviewer.ui.maps.FakeMapProvider;
+import dev.wander.android.opentagviewer.ui.maps.MapProviderFactory;
+import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
+import dev.wander.android.opentagviewer.util.rx.RefreshPolicy;
+
+/**
+ * The app, from a signed-out install to a tag's history, without stopping.
+ *
+ * <p><b>Every screen here is covered, and the joins between them were not.</b> Signing in has a
+ * test, reading the account has a test, the map has a test, and each of them starts from a state
+ * the previous one is trusted to have produced - written by hand, in a {@code @Before}. This one
+ * produces them. Nothing is seeded: the tags on the map are the tags the account handed over
+ * minutes earlier, through the real importer, the real repository and the real bridge.
+ *
+ * <p><b>Two joins already broke here and nowhere else.</b> {@code SignInThenGetTagsJourneyTest}
+ * stubs {@code MapsActivity} at the door, because the {@code aosp-atd} image carries no Play
+ * Services, so nothing had ever gone from a completed sign-in to a drawn map. And
+ * {@code HistoryViewActivity} reads {@code PythonAppleService.getInstance()} - a process-wide
+ * singleton that only the map sets up - so it could not be launched by any test that did not
+ * start the map first. It had none, and no coverage at all.
+ *
+ * <p><b>What is faked is the outside world, and only that.</b> Four edges:
+ *
+ * <ul>
+ *   <li>{@link FakeAppleAuthService} and {@link FakeAnisetteSource} - signing in reaches Apple
+ *       and downloads Apple's ADI libraries, neither arrangeable on a build machine</li>
+ *   <li>{@link FakeICloudService} - the keychain escrow read, which needs an Apple account with
+ *       a device on it</li>
+ *   <li>{@code apple_test_double}, on the Python side of the bridge - session restore and the
+ *       fetches. Placed there rather than in Java deliberately: two shipped bugs lived in the
+ *       bridge itself, so a Java-side fake would have skipped exactly the seam that broke</li>
+ *   <li>{@link FakeMapProvider} - which is what the request excludes. It records what the app
+ *       asked to be drawn instead of drawing it, which is the more useful half: "there is a pin
+ *       for this tag, at these coordinates" is a claim about the app's decision, not about what
+ *       Google rendered</li>
+ * </ul>
+ *
+ * <p>Everything between those edges - the importer, Room, the repositories, the Rx plumbing,
+ * every activity and every hand-off between them - is the shipping code.
+ *
+ * <p><b>One test, on purpose.</b> The point is the continuity: a per-screen split is what the
+ * suite already has, and it is what let two joins go unexamined. It is paced with
+ * {@link TestPace}, so this is the one to run with {@code slowMotion} when somebody wants to
+ * watch the app work rather than read that it does.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class TheWholeAppJourneyTest {
+
+    private static final String EMAIL = "someone@example.com";
+    private static final String PASSWORD = "hunter2";
+    private static final String CODE = "123456";
+    private static final String DEVICE_PASSCODE = "123456";
+
+    /** How many reports the account has for today. Asserted on the history screen, exactly. */
+    private static final int REPORTS_TODAY = 3;
+
+    /** Where the walk starts. Somewhere no other test reports from, so a stale row is obvious. */
+    private static final double LATITUDE = 48.858370;
+    private static final double LONGITUDE = 2.294481;
+
+    /** How far each later report of the day moves on from the one before it. */
+    private static final double STEP_LATITUDE = 0.003;
+    private static final double STEP_LONGITUDE = 0.004;
+
+    /**
+     * Where the newest report of the day is - which is what the map pin shows.
+     *
+     * <p>Derived rather than written out, because it has to follow {@link #REPORTS_TODAY} and the
+     * step. Writing it as a second literal is how this test broke when the reports were first
+     * spread out: the pin moved to the newest report, correctly, and the assertion still named
+     * the oldest.
+     */
+    private static final double LAST_LATITUDE = LATITUDE + ((REPORTS_TODAY - 1) * STEP_LATITUDE);
+    private static final double LAST_LONGITUDE =
+            LONGITUDE + ((REPORTS_TODAY - 1) * STEP_LONGITUDE);
+
+    /** What the fake geocoder calls that spot. Invented, and worded so as not to look real. */
+    private static final String WHERE_THAT_IS = "A made-up street, in a made-up town";
+
+    /**
+     * <b>Granted up front, or the journey stops on the map and never restarts.</b>
+     *
+     * <p>{@code MapsActivity} asks for location the moment it opens. The permission dialog
+     * belongs to the system's permission controller, not to this app, so it takes focus, pauses
+     * the map, and leaves Espresso reporting "no activity currently resumed" - which reads as
+     * the app having died and is the system waiting politely for an answer nothing will give.
+     * Costly to diagnose too: every retry pays the root picker's own thirty-second wait.
+     *
+     * <p>The screen-level map tests never met it because they ask the fake provider what was
+     * drawn rather than asking Espresso for a view, and a dialog in front of the activity does
+     * not change either answer.
+     */
+    @Rule
+    public GrantPermissionRule locationGranted = GrantPermissionRule.grant(
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION);
+
+    private FakeAppleAuthService apple;
+    private FakeICloudService icloud;
+    private FakeMapProvider map;
+    private FakeGeocoder geocoder;
+    private KeychainMembershipRepository memberships;
+    private DeviceStateGuard deviceState;
+    private PyObject appleDouble;
+    private ActivityScenario<?> scenario;
+
+    @Before
+    public void signOutAndReplaceTheOutsideWorld() {
+        final Context context = getInstrumentation().getTargetContext();
+
+        this.deviceState = DeviceStateGuard.capture(context);
+        signEverybodyOut();
+
+        this.memberships = new KeychainMembershipRepository(
+                UserAuthDataStore.getInstance(context), new AppCryptographyUtil());
+        this.memberships.forget().blockingAwait();
+        AccountBeaconsForTests.forgetThemAll();
+
+        this.apple = FakeAppleAuthService.wantsTwoFactor();
+        this.icloud = FakeICloudService.withTags();
+        AppDependencies.replaceAuthService(this.apple);
+        AppDependencies.replaceAnisette(settings -> FakeAnisetteSource.ready());
+        AppDependencies.replaceICloud(() -> this.icloud);
+
+        this.map = new FakeMapProvider();
+        MapProviderFactory.replaceWith(() -> this.map);
+
+        // **So the screens show a place rather than a pair of numbers.** The managed device has
+        // no geocoding backend, and the app's fallback for "no address found" is to print the
+        // coordinates - a correct fallback that makes a missing geocoder indistinguishable from
+        // an honest answer, on screen and in every screenshot.
+        // Registered at the *newest* report, because that is the one the card describes. The
+        // fake matches within about a hundred metres, and the walk moves further than that
+        // between reports - so naming the starting point here would leave the card correctly
+        // showing the fallback for an unregistered spot.
+        this.geocoder = new FakeGeocoder().saying(LAST_LATITUDE, LAST_LONGITUDE, WHERE_THAT_IS);
+        AppDependencies.replaceGeocoder((ctx, locale) -> this.geocoder);
+
+        this.givenTheAccountHasReportedToday();
+
+        // **Otherwise the startup fetch is skipped and no tag is ever located.** RefreshPolicy
+        // is process-wide and survives an activity being rebuilt - deliberately, so a theme
+        // change does not cost a walk of every tag's key history - which also means one test's
+        // fetch suppresses the next test's.
+        RefreshPolicy.resetShared();
+    }
+
+    /**
+     * Put this journey's reports on today, at times the history screen will ask for.
+     *
+     * <p><b>Absolute times, not offsets.</b> The history screen asks for one <i>local</i> day at
+     * a time, so "two hours ago" falls on yesterday for anybody running the suite shortly after
+     * midnight - a test that is green all day and red at 00:30 for reasons that have nothing to
+     * do with the app. The day boundary is computed here the same way the screen computes it.
+     */
+    private void givenTheAccountHasReportedToday() {
+        if (!Python.isStarted()) {
+            Python.start(new AndroidPlatform(getInstrumentation().getTargetContext()));
+        }
+
+        this.appleDouble = Python.getInstance().getModule("apple_test_double");
+        this.appleDouble.callAttr("install");
+        this.appleDouble.callAttr("clearReports");
+
+        final long startOfToday = startOfTodayLocal();
+        for (int i = 0; i < REPORTS_TODAY; i++) {
+            // A minute apart, and only minutes into the day, so every one of them is in the
+            // past however early the suite runs.
+            //
+            // **And each one somewhere slightly different.** All three used to be at the same
+            // spot, which is a fair description of a tag sitting on a shelf and a poor test: a
+            // route through three identical points draws as a dot, so the history screen's line
+            // could have been drawn through any of them, or one of them, and looked the same.
+            // A few hundred metres apart makes the drawing say what it did.
+            this.appleDouble.callAttr("reportAt",
+                    startOfToday + ((i + 1) * 60_000L),
+                    LATITUDE + (i * STEP_LATITUDE), LONGITUDE + (i * STEP_LONGITUDE));
+        }
+    }
+
+    /** Midnight this morning, by the same clock {@code HistoryViewActivity} uses. */
+    private static long startOfTodayLocal() {
+        return Instant.ofEpochMilli(System.currentTimeMillis())
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate()
+                .atStartOfDay(ZoneId.systemDefault())
+                .toInstant()
+                .toEpochMilli();
+    }
+
+    @After
+    public void putEverythingBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        if (this.appleDouble != null) {
+            this.appleDouble.callAttr("uninstall");
+        }
+
+        MapProviderFactory.reset();
+        AppDependencies.reset();
+
+        getInstrumentation().waitForIdleSync();
+        AccountBeaconsForTests.forgetThemAll();
+        this.memberships.forget().blockingAwait();
+        signEverybodyOut();
+        this.deviceState.restore();
+    }
+
+    // ------------------------------------------------------------------ the journey
+
+    @Test
+    public void fromSignedOutToATagsHistoryWithoutSeedingAnything() {
+        this.signIn();
+        this.themapOpensOnAnAccountWithNothingOnItYet();
+        this.readTheAccountFromTheDeviceList();
+        this.thetagsAreDrawnWhereTheAccountSaysTheyAre();
+        this.openTheBikesHistory();
+    }
+
+    // ------------------------------------------------------------------ step by step
+
+    /** Email, password, a code by text - and the map is what a sign-in ends at. */
+    private void signIn() {
+        this.scenario = ActivityScenario.launch(AppleLoginActivity.class);
+        TestPace.afterAStep();
+
+        onView(withId(R.id.email_or_phone_input_field)).perform(replaceText(EMAIL));
+        onView(withId(R.id.password_input_field))
+                .perform(replaceText(PASSWORD), closeSoftKeyboard());
+        TestPace.afterAStep();
+
+        Eventually.perform("the sign in button", () -> this.apple.timesCalled("login") > 0,
+                () -> onView(withId(R.id.login_button_main)).perform(click()));
+        TestPace.afterAStep();
+
+        Eventually.check(() -> onView(withText(
+                getInstrumentation().getTargetContext().getString(
+                        R.string.auth_by_sms_to_x, FakeAppleAuthService.PHONE_ONE)))
+                .perform(click()));
+        TestPace.afterAStep();
+
+        Eventually.check(() -> onView(withId(R.id.twofa_sent_info_text))
+                .check(matches(isDisplayed())));
+        // Pasted rather than typed: the boxes move focus as they fill, so per-character typing
+        // fails the moment the field it started on stops being focused - and pasting is what
+        // people do with a code they were just sent.
+        onView(withId(R.id.twofactorauth_textinput_1)).perform(replaceText(CODE));
+        TestPace.afterAStep();
+    }
+
+    /**
+     * <b>The map, for real, on the far side of a sign-in.</b>
+     *
+     * <p>The join nothing crossed before. The sign-in screen finishes itself and starts this,
+     * which restores the session through Python and draws whatever is stored - and with a fresh
+     * install nothing is, so the assertion is that it got as far as having a map at all.
+     */
+    private void themapOpensOnAnAccountWithNothingOnItYet() {
+        Eventually.check(() -> assertTrue("signing in never reached a working map",
+                this.map.isReady()));
+
+        assertTrue("a fresh install drew a pin for something", this.map.markers().isEmpty());
+        TestPace.afterAStep();
+    }
+
+    /** Map to My Devices to the account, and back with two tags. */
+    private void readTheAccountFromTheDeviceList() {
+        Eventually.check(() -> onView(withId(R.id.button_more_settings))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.button_more_settings)).perform(click());
+        TestPace.afterAStep();
+
+        // Not wrapped in Eventually: a PopupMenu is shown on the main thread inside the click
+        // handler, so it is already up by the time the perform returns - and asking for a
+        // platform-popup root that is not there yet is the expensive question, not the cheap
+        // one. Espresso's root picker retries internally for seconds before admitting it.
+        onView(withText(R.string.my_devices)).inRoot(isPlatformPopup()).perform(click());
+        TestPace.afterAStep();
+
+        // Nothing has ever been imported, so this is the empty state, and its own button is the
+        // way in - the same button a first-run user meets.
+        Eventually.check(() -> onView(withId(R.id.my_devices_empty_fetch_button))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.my_devices_empty_fetch_button)).perform(click());
+        TestPace.afterAStep();
+
+        this.unlockWithADevicePasscode();
+
+        Eventually.check(() -> onView(withId(R.id.icloud_results_container))
+                .check(matches(isDisplayed())));
+        TestPace.afterAStep();
+        onView(withId(R.id.icloud_primary_button)).perform(click());
+
+        // Back on the device list, which rebuilt itself when the fetch reported tags.
+        Eventually.check(() -> onView(withId(R.id.my_devices_list))
+                .check(matches(isDisplayed())));
+        Eventually.check(() -> onView(withId(R.id.my_devices_empty_state))
+                .check(matches(not(isDisplayed()))));
+        TestPace.afterAStep();
+
+        // **Rows, not a screenful.** The list could show what the fetch is still holding in
+        // memory; what has to be true is that it was written down, with the accessory state
+        // that makes a tag locatable rather than merely present.
+        final OpenTagViewerDatabase db = OpenTagViewerDatabase.getInstance(
+                getInstrumentation().getTargetContext());
+        final List<OwnedBeacon> stored = db.ownedBeaconDao().getAll();
+
+        assertEquals("the account's two tags should have been written", 2, stored.size());
+        for (final OwnedBeacon beacon : stored) {
+            assertTrue(beacon.id + " imported with no accessory state, so it looks imported and"
+                    + " can never be located", beacon.accessoryJson != null);
+        }
+    }
+
+    /**
+     * <b>Back on the map, and the tags are on it.</b>
+     *
+     * <p>Which is a fetch, not a redraw: these tags have never been located, so the pin can only
+     * be there if the request crossed the bridge, Python answered, and the repository stored it.
+     * Asked of Python first, because "no marker" and "a marker in the wrong place" have very
+     * different causes and the screen shows neither.
+     */
+    private void thetagsAreDrawnWhereTheAccountSaysTheyAre() {
+        pressBack();
+        TestPace.afterAStep();
+
+        Eventually.check(() -> assertTrue("python was never asked to locate the new tags",
+                this.appleDouble.callAttr("howManyFetches").toInt() > 0));
+
+        Eventually.check(() -> assertEquals("the imported tags were never drawn",
+                2, this.map.markers().size()));
+
+        final FakeMapProvider.PlacedMarker bike = this.markerFor(
+                FakeICloudService.A_BIKE.getBeaconId());
+
+        // **The newest report of the day, not the first.** The tag moved between reports, and
+        // the pin shows where it is now - which is the whole point of the screen.
+        assertEquals("the pin is not on the tag's most recent report",
+                LAST_LATITUDE, bike.marker.getLatitude(), 0.000001);
+        assertEquals(LAST_LONGITUDE, bike.marker.getLongitude(), 0.000001);
+
+        // **And the card says where that is, in words.** Its fallback when no address can be
+        // found is the raw coordinates, which is right - and means that until there was a
+        // geocoder to answer, this assertion could not tell a working lookup from no lookup at
+        // all. It also covers the rounding: the app geocodes a rounded pair, so what is asked
+        // for is never exactly what was reported.
+        Eventually.check(() -> onView(theBikesCard(R.id.device_location))
+                .perform(scrollTo())
+                .check(matches(withText(WHERE_THAT_IS))));
+        TestPace.afterAStep();
+    }
+
+    /**
+     * <b>And its history, which no test could reach before this one.</b>
+     *
+     * <p>{@code HistoryViewActivity} takes its Apple session from
+     * {@code PythonAppleService.getInstance()}, which only the map sets up, so it is only
+     * launchable after a map has run. It also fetches by a different route - {@code getReports}
+     * generates the day's keys itself rather than asking for the latest location - which is a
+     * second bridge path, and the one the user meets when they go looking for a day the app did
+     * not fetch on its own.
+     */
+    private void openTheBikesHistory() {
+        // **Scrolled to first, and it is not a formality.** The tag cards live in a
+        // HorizontalScrollView, and with two tags on the account the one this wants is off the
+        // side of the screen - so `click()` fails its own ninety-percent-visible constraint with
+        // a message about constraints rather than about position, and the screenshot shows a
+        // perfectly healthy map with the *other* tag's card on it.
+        Eventually.check(() -> onView(theBikesCard(R.id.device_history_button_container))
+                .perform(scrollTo()));
+        onView(theBikesCard(R.id.device_history_button_container)).perform(click());
+        TestPace.afterAStep();
+
+        // **Not asserted as displayed, because it correctly is not.** The list lives in a bottom
+        // sheet that opens at its peek height, so the rows sit below the fold until somebody
+        // drags it up - `isDisplayed` is false and Espresso is right to say so. An earlier
+        // version checked exactly that and passed on timing luck for several runs before the
+        // extra work of the merged history fetch shifted it enough to fail honestly.
+        //
+        // What is wanted here is that the rows exist, which the caption below says without
+        // needing anything to be on screen. Dragging the sheet open is covered by
+        // TheHistoryScreenDrawsTheDayTest, where it is the point rather than a step.
+
+        // **Asked out loud, because the screen renders both the same way.** A day that was
+        // searched and came back empty and a day that was never searched at all both arrive as
+        // an empty list, and the second is the bug.
+        Eventually.check(() -> assertTrue("the day was never actually searched",
+                this.appleDouble.callAttr("howManyRangedFetches").toInt() > 0));
+
+        // Exactly, not at least. The day's reports are fetched remotely and merged with what
+        // the map's own fetch already stored, so a broken de-duplication shows up here as
+        // double - which is what the user would see.
+        Eventually.check(() -> onView(withId(R.id.history_datapoints_text))
+                .check(matches(withText(getInstrumentation().getTargetContext()
+                        .getString(R.string.x_data_points, REPORTS_TODAY)))));
+        TestPace.afterAStep();
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    /** A control inside the Bike's card specifically - there are two cards on the screen. */
+    private static org.hamcrest.Matcher<android.view.View> theBikesCard(final int controlId) {
+        return allOf(withId(controlId), isDescendantOfA(allOf(
+                withId(R.id.tag_item_container),
+                hasDescendant(withText(containsString(FakeICloudService.A_BIKE.getName()))))));
+    }
+
+    private FakeMapProvider.PlacedMarker markerFor(final String beaconId) {
+        final List<FakeMapProvider.PlacedMarker> found = this.map.markers().stream()
+                .filter(placed -> beaconId.equals(placed.marker.getId()))
+                .collect(Collectors.toList());
+
+        assertEquals("expected exactly one pin for " + beaconId, 1, found.size());
+        return found.get(0);
+    }
+
+    private void unlockWithADevicePasscode() {
+        Eventually.check(() -> onView(withId(R.id.icloud_device_container))
+                .check(matches(isDisplayed())));
+        TestPace.afterAStep();
+
+        Eventually.check(() -> onView(withText(containsString(
+                FakeICloudService.AN_IPHONE.getSerial()))).perform(click()));
+        TestPace.afterAStep();
+
+        Eventually.check(() -> onView(withId(R.id.icloud_passcode_input))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.icloud_passcode_input)).perform(replaceText(DEVICE_PASSCODE));
+        TestPace.afterAStep();
+
+        Eventually.perform("unlock", () -> this.icloud.timesCalled("unlock") > 0,
+                () -> onView(withId(R.id.icloud_primary_button)).perform(click()));
+        TestPace.afterAStep();
+    }
+
+    /**
+     * Clear any stored session, and wait until it stays cleared.
+     *
+     * <p>The same insistence as {@code AppleLoginFlowTest}: storing a session is the last step of
+     * a sign-in and runs on a background scheduler, so a single look can see an empty store that
+     * is about to be written to.
+     */
+    private static void signEverybodyOut() {
+        final UserAuthRepository auth = new UserAuthRepository(
+                UserAuthDataStore.getInstance(getInstrumentation().getTargetContext()),
+                new AppCryptographyUtil());
+
+        int consecutivelyEmpty = 0;
+
+        for (int attempt = 0; attempt < 40 && consecutivelyEmpty < 3; attempt++) {
+            if (auth.getUserAuth().blockingFirst().isEmpty()) {
+                consecutivelyEmpty++;
+            } else {
+                consecutivelyEmpty = 0;
+                auth.clearUser().blockingAwait();
+            }
+            SystemClock.sleep(50);
+        }
+
+        if (consecutivelyEmpty < 3) {
+            throw new IllegalStateException("a stored session kept coming back");
+        }
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/python/icloud/FakeICloudService.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/python/icloud/FakeICloudService.java
@@ -65,6 +65,17 @@ public final class FakeICloudService implements ICloudService {
     private int refusalsBeforeAccepting = 0;
     private long answerDelayMs = 0;
 
+    /**
+     * How long an unlock attempt hangs before answering.
+     *
+     * <p>Separate from {@link #answerDelayMs}, which only ever applied to
+     * {@code recoveryOptions}. Holding the unlock open is the only way to observe the state
+     * where this screen deliberately refuses to be left - and setting the general delay does
+     * not produce it, because by the time a passcode is being tried the delayed call is long
+     * finished.
+     */
+    private long unlockDelayMs = 0;
+
     private final List<String> calls = new ArrayList<>();
     private final List<String> unlockedWith = new ArrayList<>();
     private String lastPasscode;
@@ -182,6 +193,18 @@ public final class FakeICloudService implements ICloudService {
         return this;
     }
 
+    /**
+     * Hang this long inside an unlock attempt, without slowing anything before it.
+     *
+     * <p>For the one state the screen will not let anybody out of: a passcode already on its
+     * way to Apple. Attempts are probably limited on their end, so abandoning one half way
+     * risks spending it for nothing - which is why back is swallowed there and nowhere else.
+     */
+    public FakeICloudService takingItsTimeToUnlock(final long millis) {
+        this.unlockDelayMs = millis;
+        return this;
+    }
+
     @Override
     public Completable unlock(final String serial, final String passcode) {
         this.calls.add("unlock");
@@ -198,7 +221,10 @@ public final class FakeICloudService implements ICloudService {
                     "That was not accepted. Worth trying the same passcode again."));
         }
 
-        return Completable.complete();
+        return this.unlockDelayMs > 0
+                ? Completable.complete()
+                        .delay(this.unlockDelayMs, java.util.concurrent.TimeUnit.MILLISECONDS)
+                : Completable.complete();
     }
 
     @Override

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/TheInformationPageShowsTheAppMarkTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/TheInformationPageShowsTheAppMarkTest.java
@@ -1,0 +1,164 @@
+package dev.wander.android.opentagviewer.ui;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
+import android.widget.ImageView;
+
+import androidx.appcompat.app.AppCompatDelegate;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import dev.wander.android.opentagviewer.InformationActivity;
+import dev.wander.android.opentagviewer.R;
+
+/**
+ * The app mark on the Information page draws something.
+ *
+ * <p><b>Not "the ImageView is there" - that it puts ink on the screen.</b> The mark is
+ * {@code opentagviewer_icon_themed}, a vector whose fills are <i>theme attributes</i>
+ * ({@code colorPrimary} and {@code colorOnPrimaryFixedVariant}), and a theme attribute cannot be
+ * resolved without a theme. Load it through a context that has none and it draws as nothing at
+ * all: no error, no warning, an empty square where the logo should be.
+ *
+ * <p>That has happened in this app before. The history timeline went blank exactly this way,
+ * and its screenshot test stayed green throughout, because the test passed a theme and the app
+ * did not. Rule 12 in AGENTS.md is written around that incident, and this is the same drawable
+ * risk on a new screen.
+ *
+ * <p><b>So the assertion counts pixels with real opacity</b>, in both themes. A mark that
+ * resolves under one and not the other is precisely the failure this is looking for -
+ * {@code drawable-night} is a separate file picking different tones, so either can break alone.
+ *
+ * <p><b>It runs the real screen rather than inflating the layout</b>, which is forced rather
+ * than preferred: the mark is set with {@code app:srcCompat}, and AppCompat only resolves that
+ * through a view inflater an {@code AppCompatActivity} installs. Inflated against a bare themed
+ * context the view comes out as a plain {@code ImageView} with {@code srcCompat} ignored and no
+ * drawable at all - a failure describing a bug that exists only in the test. Asking the running
+ * screen is the more honest question anyway.
+ */
+@RunWith(AndroidJUnit4.class)
+public class TheInformationPageShowsTheAppMarkTest {
+
+    private int nightModeBefore;
+
+    @Before
+    public void rememberTheDevicesTheme() {
+        this.nightModeBefore = AppCompatDelegate.getDefaultNightMode();
+    }
+
+    /**
+     * Put it back. This flips a process-wide default, and leaving it flipped hands the next
+     * test in the run a device in whichever theme this one finished in.
+     */
+    @After
+    public void restoreTheDevicesTheme() {
+        getInstrumentation().runOnMainSync(
+                () -> AppCompatDelegate.setDefaultNightMode(this.nightModeBefore));
+        getInstrumentation().waitForIdleSync();
+    }
+
+    /**
+     * <b>The mark is on the page at all.</b>
+     *
+     * <p>Thin, and it is the one that fails if somebody removes the view or renames the id -
+     * neither of which stops the app compiling.
+     */
+    @Test
+    public void theappMarkIsOnTheInformationPage() {
+        try (ActivityScenario<InformationActivity> screen = this.openTheInformationPage(false)) {
+            screen.onActivity(activity -> assertNotNull(
+                    "the Information page has no app mark on it",
+                    activity.findViewById(R.id.appLogo)));
+        }
+    }
+
+    /** <b>And it draws ink, in the light theme.</b> */
+    @Test
+    public void themarkDrawsSomethingInTheLightTheme() {
+        this.assertTheMarkIsVisible(false);
+    }
+
+    /**
+     * <b>And in the dark one, which is a different drawable.</b>
+     *
+     * <p>{@code drawable-night} carries its own copy, so this is not the same file being asked
+     * twice - the night version picks different tones so the extruded side stays darker than
+     * the face. Either could be broken on its own.
+     */
+    @Test
+    public void themarkDrawsSomethingInTheDarkTheme() {
+        this.assertTheMarkIsVisible(true);
+    }
+
+    // ------------------------------------------------------------------ the work
+
+    private void assertTheMarkIsVisible(final boolean night) {
+        final int[] inkPixels = {0};
+
+        try (ActivityScenario<InformationActivity> screen = this.openTheInformationPage(night)) {
+            screen.onActivity(activity -> {
+                final ImageView mark = activity.findViewById(R.id.appLogo);
+                assertNotNull("the Information page has no app mark on it", mark);
+
+                final Drawable drawn = mark.getDrawable();
+                assertNotNull("the app mark has no drawable, so nothing will be shown", drawn);
+                assertTrue("the app mark measured " + mark.getWidth() + "x" + mark.getHeight()
+                                + ", so there is nowhere for it to draw",
+                        mark.getWidth() > 0 && mark.getHeight() > 0);
+
+                final Bitmap rendered = Bitmap.createBitmap(
+                        mark.getWidth(), mark.getHeight(), Bitmap.Config.ARGB_8888);
+                drawn.setBounds(0, 0, rendered.getWidth(), rendered.getHeight());
+                drawn.draw(new Canvas(rendered));
+
+                for (int x = 0; x < rendered.getWidth(); x += 2) {
+                    for (int y = 0; y < rendered.getHeight(); y += 2) {
+                        // Any pixel with real opacity. The vector is drawn onto a transparent
+                        // bitmap, so an unresolved attribute and nothing-drawn are both zero.
+                        if (((rendered.getPixel(x, y) >>> 24) & 0xFF) > 0x10) {
+                            inkPixels[0]++;
+                        }
+                    }
+                }
+                rendered.recycle();
+            });
+        }
+
+        assertTrue("the app mark drew " + inkPixels[0] + " pixels in the "
+                        + (night ? "dark" : "light") + " theme, which means its theme-attribute"
+                        + " fills resolved to nothing - the logo is an empty square on screen,"
+                        + " with no error anywhere",
+                inkPixels[0] > 100);
+    }
+
+    /**
+     * The real screen, in the theme asked for.
+     *
+     * <p><b>An activity rather than an inflated layout, and that is not incidental.</b> The mark
+     * is set with {@code app:srcCompat}, which AppCompat resolves through a view inflater that
+     * an {@code AppCompatActivity} installs. Inflate the same layout against a bare themed
+     * context and the {@code ImageView} comes out as a plain one with {@code srcCompat}
+     * ignored - {@code getDrawable()} returns null, and the test fails describing a bug that is
+     * only in the test.
+     *
+     * <p>Which makes this the more honest shape anyway: it asks what the app shows, not what a
+     * layout file could show under ideal conditions.
+     */
+    private ActivityScenario<InformationActivity> openTheInformationPage(final boolean night) {
+        getInstrumentation().runOnMainSync(() -> AppCompatDelegate.setDefaultNightMode(
+                night ? AppCompatDelegate.MODE_NIGHT_YES : AppCompatDelegate.MODE_NIGHT_NO));
+        getInstrumentation().waitForIdleSync();
+
+        return ActivityScenario.launch(InformationActivity.class);
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/history/TheHistoryScreenDrawsTheDayTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/history/TheHistoryScreenDrawsTheDayTest.java
@@ -1,0 +1,718 @@
+package dev.wander.android.opentagviewer.ui.history;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.swipeUp;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition;
+import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.Intent;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+
+import org.hamcrest.Matcher;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+
+import com.chaquo.python.PyObject;
+import com.chaquo.python.Python;
+import com.chaquo.python.android.AndroidPlatform;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.wander.android.opentagviewer.DeviceStateGuard;
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.HistoryViewActivity;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.db.room.OpenTagViewerDatabase;
+import dev.wander.android.opentagviewer.db.room.entity.BeaconNamingRecord;
+import dev.wander.android.opentagviewer.db.room.entity.DailyHistoryFetchRecord;
+import dev.wander.android.opentagviewer.db.room.entity.Import;
+import dev.wander.android.opentagviewer.db.room.entity.LocationReport;
+import dev.wander.android.opentagviewer.db.room.entity.OwnedBeacon;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.python.PythonAppleAccount;
+import dev.wander.android.opentagviewer.python.PythonAppleService;
+import dev.wander.android.opentagviewer.ui.maps.FakeGeocoder;
+import dev.wander.android.opentagviewer.ui.maps.FakeMapProvider;
+import dev.wander.android.opentagviewer.ui.maps.MapPolyline;
+import dev.wander.android.opentagviewer.ui.maps.MapProviderFactory;
+
+/**
+ * What the history screen asks the map to draw for a day.
+ *
+ * <p><b>This screen had no test at all.</b> Not a thin one - none. It takes its Apple session
+ * from {@code PythonAppleService.getInstance()}, a process-wide singleton that only
+ * {@code MapsActivity} ever set up, so nothing could launch it without launching the map first
+ * and nothing did. Every line below it - the day's line, the single-point marker, stepping
+ * between days, what a tap on a row does - was covered by running the app by hand.
+ *
+ * <p><b>The map is the fake here too</b>, which is not extra work: {@code HistoryViewActivity}
+ * goes through {@code MapProviderFactory} like every other screen, so one substitution covers
+ * both. That is rule 7 paying out again.
+ *
+ * <p><b>Most days here are served from the database, deliberately.</b> What is under test is
+ * the drawing, so a day is normally given a {@code DailyHistoryFetchRecord} - the app's own note
+ * that the day is already complete locally - and the Python double reports nothing. The count on
+ * screen is then exactly the count that was seeded, and a failure means the drawing is wrong
+ * rather than that Apple's answer changed. The fetch itself is covered by
+ * {@code TheWholeAppJourneyTest}.
+ *
+ * <p>{@link #reportsAlreadyInTheDatabaseSurviveAnEmptyAnswerFromApple} is the exception and
+ * withholds that record on purpose, because the local-only path would pass it either way.
+ *
+ * <p><b>A beacon id per test, because the screen caches across instances.</b>
+ * {@code MEMORY_REPORTS_CACHE} is static and keyed by day and beacon, so two tests using one
+ * beacon would have the second read the first's answer - passing for the wrong reason, or
+ * failing after an unrelated edit. The name of the running test is the id.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class TheHistoryScreenDrawsTheDayTest {
+
+    private static final String A_TEST_USER = "history-draws@example.com";
+
+    /** Far enough apart to be distinguishable on a line, close enough to be one day's walk. */
+    private static final double[][] A_WALK = {
+            {52.370216, 4.895168},
+            {52.372100, 4.897900},
+            {52.374500, 4.901200},
+            {52.376000, 4.905500},
+    };
+
+    private static final String A_PLIST = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<plist version=\"1.0\"><dict>"
+            + "<key>batteryLevel</key><integer>1</integer>"
+            + "<key>model</key><string></string>"
+            + "<key>pairingDate</key><date>2025-02-27T20:03:32Z</date>"
+            + "<key>privateKey</key><dict><key>key</key><dict>"
+            + "<key>data</key><data>bm90LWEtcmVhbC1rZXk=</data></dict></dict>"
+            + "<key>productId</key><integer>21760</integer>"
+            + "<key>stableIdentifier</key><array><string>2001~#0~#A0</string></array>"
+            + "<key>systemVersion</key><string>2.0.73</string>"
+            + "<key>vendorId</key><integer>76</integer>"
+            + "</dict></plist>";
+
+    @Rule
+    public TestName runningTest = new TestName();
+
+    private OpenTagViewerDatabase db;
+    private DeviceStateGuard guard;
+    private FakeMapProvider map;
+    private PyObject appleDouble;
+    private ActivityScenario<HistoryViewActivity> scenario;
+
+    private String beaconId;
+    private long importId;
+
+    @Before
+    public void substituteTheWorldAndSeedATag() {
+        final Context context = getInstrumentation().getTargetContext();
+
+        this.guard = DeviceStateGuard.capture(context);
+        this.db = OpenTagViewerDatabase.getInstance(context);
+        this.beaconId = "history-" + this.runningTest.getMethodName();
+
+        this.forgetIt();
+
+        this.map = new FakeMapProvider();
+        MapProviderFactory.replaceWith(() -> this.map);
+        AppDependencies.replaceGeocoder((ctx, locale) -> new FakeGeocoder());
+
+        // **Wired straight in, rather than by launching the map first.** The screen only needs
+        // the singleton to exist; going through MapsActivity to create one would make every
+        // test here depend on the map's whole startup, including its fetch.
+        if (!Python.isStarted()) {
+            Python.start(new AndroidPlatform(context));
+        }
+        this.appleDouble = Python.getInstance().getModule("apple_test_double");
+        this.appleDouble.callAttr("installWithNothingToReport");
+        PythonAppleService.setup(new PythonAppleAccount(this.appleDouble.get("theAccount")));
+
+        this.importId = this.db.importDao().insert(Import.builder()
+                .version("0.0.2").importedAt(1_700_000_000_000L).exportedAt(1_699_000_000_000L)
+                .sourceUser(A_TEST_USER).exportedVia("OpenTagViewer.wizard:test").build());
+
+        this.db.ownedBeaconDao().insertAll(OwnedBeacon.builder()
+                .id(this.beaconId).importId(this.importId).content(A_PLIST).version("0.0.2")
+                .fromAccount(false).isRemoved(false)
+                .accessoryJson("{\"type\": \"accessory\", \"id\": \"" + this.beaconId + "\"}")
+                .build());
+
+        this.db.beaconNamingRecordDao().insertAll(BeaconNamingRecord.builder()
+                .id(this.beaconId).importId(this.importId).version("0.0.2").isRemoved(false)
+                .content("<?xml version=\"1.0\" encoding=\"UTF-8\"?><plist version=\"1.0\"><dict>"
+                        + "<key>identifier</key><string>" + this.beaconId + "</string>"
+                        + "<key>name</key><string>Bike</string>"
+                        + "</dict></plist>")
+                .build());
+    }
+
+    @After
+    public void putEverythingBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        if (this.appleDouble != null) {
+            this.appleDouble.callAttr("uninstall");
+        }
+
+        PythonAppleService.INSTANCE = null;
+        MapProviderFactory.reset();
+        AppDependencies.reset();
+
+        this.forgetIt();
+        this.guard.restore();
+    }
+
+    // ------------------------------------------------------------------ the day's line
+
+    /**
+     * <b>Every point of the day is on the line, in order.</b>
+     *
+     * <p>Not "a line was drawn" - the count and the order are the parts that go wrong. A line
+     * built from a filtered or re-sorted list still draws, still looks like a route, and is a
+     * different route.
+     */
+    @Test
+    public void thedaysReportsAreJoinedByALineThroughAllOfThem() {
+        this.givenReportsOn(0, A_WALK);
+        this.openTheHistory();
+
+        Eventually.check(() -> assertTrue("no line was drawn for a day with four reports",
+                !this.map.polylines().isEmpty()));
+
+        final MapPolyline drawn = this.map.polylines().get(0);
+        assertEquals("the line skipped or duplicated a point",
+                A_WALK.length, drawn.getPoints().size());
+
+        for (int i = 0; i < A_WALK.length; i++) {
+            assertEquals("point " + i + " is not where the report was",
+                    A_WALK[i][0], drawn.getPoints().get(i).getLatitude(), 0.000001);
+            assertEquals(A_WALK[i][1], drawn.getPoints().get(i).getLongitude(), 0.000001);
+        }
+    }
+
+    /**
+     * <b>Two lines, not one: the route and the outline under it.</b>
+     *
+     * <p>The outline is what makes the route readable against a busy map. It is drawn first and
+     * wider, so losing it is invisible in code review and obvious only on a dark satellite tile
+     * - which is to say, not on anything CI looks at.
+     */
+    @Test
+    public void thelineIsDrawnOverAnOutlineSoItStaysReadable() {
+        this.givenReportsOn(0, A_WALK);
+        this.openTheHistory();
+
+        Eventually.check(() -> assertEquals("the route should be an outline and a line over it",
+                2, this.map.polylines().size()));
+
+        final MapPolyline outline = this.map.polylines().get(0);
+        final MapPolyline route = this.map.polylines().get(1);
+
+        assertTrue("the outline must be the wider of the two, or it is not an outline",
+                outline.getWidth() > route.getWidth());
+        assertEquals("both should trace the same points",
+                outline.getPoints().size(), route.getPoints().size());
+    }
+
+    /**
+     * <b>One report is a place, not a route.</b>
+     *
+     * <p>A polyline through a single point draws nothing at all on a real map, so this is the
+     * case where "the screen is empty" and "the day had one sighting" look identical.
+     */
+    @Test
+    public void asingleReportGetsAMarkerRatherThanALine() {
+        this.givenReportsOn(0, new double[][] {A_WALK[0]});
+        this.openTheHistory();
+
+        Eventually.check(() -> assertEquals("a single point should be marked, not joined up",
+                1, this.map.markerCount()));
+
+        assertTrue("nothing should be joined up when there is one point",
+                this.map.polylines().isEmpty());
+
+        final FakeMapProvider.PlacedMarker only = this.map.markers().get(0);
+        assertEquals(A_WALK[0][0], only.marker.getLatitude(), 0.000001);
+        assertEquals(A_WALK[0][1], only.marker.getLongitude(), 0.000001);
+    }
+
+    /** And a day nobody was seen on draws neither, rather than a line to nowhere. */
+    @Test
+    public void adayWithNothingOnItDrawsNeither() {
+        this.givenReportsOn(0, new double[][] {});
+        this.openTheHistory();
+
+        // **Waited on the count, not on the list being visible.** An empty map is what this
+        // asserts, and an empty map is also what the screen looks like before the day has
+        // loaded - so without a positive signal that loading finished, this test passes
+        // instantly and would keep passing if the drawing broke entirely. The datapoints
+        // caption is written once the day resolves, whatever the day contained.
+        Eventually.check(() -> assertEquals("the day never finished loading",
+                "0 data points", this.datapointsCaption()));
+
+        assertTrue("a day with no reports drew a line", this.map.polylines().isEmpty());
+        assertTrue("a day with no reports drew a marker", this.map.markers().isEmpty());
+    }
+
+    // ------------------------------------------------------------------ picking one out
+
+    /**
+     * <b>Tapping a report in the list puts a marker on it and goes there.</b>
+     *
+     * <p>The one way to tell which dot on the line is which. It replaces the previous marker
+     * rather than adding to it - the screen keeps a single {@code single_coord_marker} - so a
+     * broken replacement leaves a trail of markers behind the user as they read down the list,
+     * which on a real map looks like the route being drawn twice.
+     */
+    @Test
+    public void tappingAReportMarksItAndMovesTheCameraThere() {
+        this.givenReportsOn(0, A_WALK);
+        this.openTheHistory();
+
+        Eventually.check(() -> assertTrue(this.rowCount() >= A_WALK.length));
+
+        // **The sheet has to be opened, because that is what a person does.** It starts at its
+        // peek height with the list below the fold, so the rows are genuinely not on screen -
+        // Espresso was right to refuse, and the first version of this test read that refusal as
+        // the list being broken.
+        this.expandTheSheet();
+
+        Eventually.check(() -> onView(withId(R.id.recycler_view_history_items))
+                .check(matches(isDisplayed())));
+
+        final int camerasBefore = this.map.cameraMoves().size();
+
+        onView(withId(R.id.recycler_view_history_items))
+                .perform(actionOnItemAtPosition(1, clickTheRowsOwnTarget()));
+
+        Eventually.check(() -> assertEquals("tapping a report should leave exactly one marker",
+                1, this.map.markerCount()));
+
+        final FakeMapProvider.PlacedMarker marked = this.map.markers().get(0);
+        assertEquals("single_coord_marker", marked.id);
+
+        // **On the report that was tapped, not merely somewhere.** Asserting only that a marker
+        // exists would pass with it on any of the four, which is the one thing this control is
+        // for.
+        //
+        // Row order is oldest first - getInTimeRange is `ORDER BY timestamp ASC` - so position 1
+        // is the second point of the walk. Checked rather than assumed: the first version of
+        // this read the list as newest-first and failed pointing at the wrong end of the route.
+        final double[] tapped = A_WALK[1];
+        assertEquals("the marker went on a different report than the one tapped",
+                tapped[0], marked.marker.getLatitude(), 0.000001);
+        assertEquals(tapped[1], marked.marker.getLongitude(), 0.000001);
+
+        Eventually.check(() -> assertTrue("the camera never moved to the tapped report",
+                this.map.cameraMoves().size() > camerasBefore));
+    }
+
+    /**
+     * <b>Tapping a report from a fully open sheet shrinks it to its smaller open state.</b>
+     *
+     * <p>Intended, and easy to lose. At full height the sheet covers the map, so placing a
+     * marker under it and leaving the sheet up would make the tap appear to do nothing - and
+     * showing you where a report was is the control's entire purpose.
+     *
+     * <p><b>Smaller, not gone.</b> It goes to half-expanded rather than all the way down to the
+     * peek height: the list has to stay readable so the next report is one tap away, rather than
+     * making the user re-open the sheet after every single one. Both halves of that are
+     * asserted, because "it shrank" alone would be satisfied by collapsing it entirely.
+     *
+     * <p><b>Only from fully expanded.</b> Tapping from the half-open state leaves the sheet
+     * where it is, because the map is already visible and moving it under the user's thumb would
+     * be the app arguing with them. That case is pinned below.
+     */
+    @Test
+    public void tappingAReportFromAFullyOpenSheetShrinksItToItsSmallerOpenState() {
+        this.givenReportsOn(0, A_WALK);
+        this.openTheHistory();
+
+        Eventually.check(() -> assertTrue(this.rowCount() >= A_WALK.length));
+        this.expandTheSheet();
+        Eventually.check(() -> assertEquals(BottomSheetBehavior.STATE_EXPANDED, this.sheetState()));
+
+        onView(withId(R.id.recycler_view_history_items))
+                .perform(actionOnItemAtPosition(1, clickTheRowsOwnTarget()));
+
+        Eventually.check(() -> assertEquals(
+                "the sheet stayed at full height after a report was tapped, so the marker it"
+                        + " just placed is hidden behind the list",
+                BottomSheetBehavior.STATE_HALF_EXPANDED, this.sheetState()));
+
+        // Said separately, because the assertion above would also be met by a sheet that had
+        // shut entirely - and that would cost the user a re-open for every report they look at.
+        assertTrue("the sheet closed all the way down instead of shrinking, so reading the next"
+                        + " report means opening it again",
+                this.sheetState() != BottomSheetBehavior.STATE_COLLAPSED);
+    }
+
+    /**
+     * <b>And the map is told to keep its content out from under the sheet.</b>
+     *
+     * <p>The other half of the same gesture, and the part that makes it useful. Map padding
+     * shrinks the region the camera centres within, so the screen tracks the sheet with it -
+     * meaning the marker it just placed is framed in the strip still visible above the list
+     * rather than behind it.
+     *
+     * <p>Without this the tap looks broken in a specific, maddening way: the marker <i>is</i>
+     * drawn and the camera <i>does</i> move, both correctly, and the user sees neither because
+     * both are underneath the sheet. Nothing logs anything.
+     *
+     * <p>Asserted as "the bottom is padded and the other three are not", rather than pinning the
+     * exact pixel count - that number is derived from the sheet's height and peek at runtime,
+     * so an exact expectation here would be this test recomputing the app's arithmetic and
+     * agreeing with itself.
+     */
+    @Test
+    public void tappingAReportKeepsTheMapClearOfTheSheet() {
+        this.givenReportsOn(0, A_WALK);
+        this.openTheHistory();
+
+        Eventually.check(() -> assertTrue(this.rowCount() >= A_WALK.length));
+        this.expandTheSheet();
+
+        // The list has to be on screen before a row in it can be acted on - the sheet animates
+        // open, and without this the action lands while it is still on its way up.
+        Eventually.check(() -> onView(withId(R.id.recycler_view_history_items))
+                .check(matches(isDisplayed())));
+
+        onView(withId(R.id.recycler_view_history_items))
+                .perform(actionOnItemAtPosition(1, clickTheRowsOwnTarget()));
+
+        Eventually.check(() -> {
+            final int[] padding = this.map.padding();
+            assertTrue("the map was never told to stay clear of the sheet, so the marker is"
+                    + " centred behind the list", padding != null);
+            assertTrue("the map was given no bottom padding, so its content is framed behind"
+                    + " the sheet", padding[3] > 0);
+        });
+
+        final int[] padding = this.map.padding();
+        assertEquals("padding was applied on a side the sheet is not on", 0, padding[0]);
+        assertEquals("padding was applied on a side the sheet is not on", 0, padding[1]);
+        assertEquals("padding was applied on a side the sheet is not on", 0, padding[2]);
+    }
+
+    /** And from half open it is left where it is, rather than moving under the user's thumb. */
+    @Test
+    public void tappingAReportFromAHalfOpenSheetLeavesItAlone() {
+        this.givenReportsOn(0, A_WALK);
+        this.openTheHistory();
+
+        Eventually.check(() -> assertTrue(this.rowCount() >= A_WALK.length));
+        this.setTheSheetTo(BottomSheetBehavior.STATE_HALF_EXPANDED);
+        Eventually.check(() -> assertEquals(
+                BottomSheetBehavior.STATE_HALF_EXPANDED, this.sheetState()));
+
+        onView(withId(R.id.recycler_view_history_items))
+                .perform(actionOnItemAtPosition(1, clickTheRowsOwnTarget()));
+
+        Eventually.check(() -> assertEquals("tapping a report moved a sheet that was already"
+                        + " showing the map",
+                BottomSheetBehavior.STATE_HALF_EXPANDED, this.sheetState()));
+    }
+
+    /**
+     * <b>The sheet opens by dragging its handle up, which is how a person opens it.</b>
+     *
+     * <p>Every other test here opens the sheet by setting the behaviour's state directly, which
+     * is convenient and skips the only affordance the user has. The list lives below the peek
+     * height, so if the handle stops working there is no way to read the history at all - and
+     * nothing would have noticed, because the tests were reaching past it.
+     *
+     * <p><b>Dragged, not tapped, and the difference is Material's rather than this app's.</b>
+     * {@code BottomSheetDragHandleView} only makes itself <i>clickable</i> when touch
+     * exploration is on - the tap is there for accessibility services, and toggling the sheet
+     * from a click is what a screen reader gets instead of a drag it cannot perform. For
+     * everyone else the handle is a thing to drag, so a tap correctly does nothing, and a test
+     * that tapped was asserting behaviour no sighted user has.
+     */
+    @Test
+    public void thesheetOpensWhenItsHandleIsDraggedUp() {
+        this.givenReportsOn(0, A_WALK);
+        this.openTheHistory();
+
+        Eventually.check(() -> assertTrue(this.rowCount() >= A_WALK.length));
+        Eventually.check(() -> assertEquals("the sheet should start at its peek height",
+                BottomSheetBehavior.STATE_COLLAPSED, this.sheetState()));
+
+        onView(withId(R.id.drag_handle)).perform(swipeUp());
+
+        Eventually.check(() -> assertTrue(
+                "dragging the handle up left the sheet in state " + this.sheetState()
+                        + " (collapsed is " + BottomSheetBehavior.STATE_COLLAPSED + "), so the"
+                        + " history list cannot be reached at all",
+                this.sheetState() != BottomSheetBehavior.STATE_COLLAPSED));
+
+        Eventually.check(() -> onView(withId(R.id.recycler_view_history_items))
+                .check(matches(isDisplayed())));
+    }
+
+    // ------------------------------------------------------------------ moving between days
+
+    /** <b>Stepping back a day draws that day instead.</b> */
+    @Test
+    public void steppingBackADayDrawsThatDayInstead() {
+        this.givenReportsOn(0, new double[][] {A_WALK[0]});
+        this.givenReportsOn(1, A_WALK);
+        this.openTheHistory();
+
+        Eventually.check(() -> assertEquals("today has one report, so it is a marker",
+                1, this.map.markerCount()));
+
+        onView(withId(R.id.history_move_left_button)).perform(click());
+
+        Eventually.check(() -> assertEquals("yesterday's four reports were not joined up",
+                A_WALK.length, this.map.polylines().get(0).getPoints().size()));
+    }
+
+    /**
+     * <b>And there is no stepping forward from today.</b>
+     *
+     * <p>Disabled rather than absent, so the control does not move around under the thumb as the
+     * user walks back through the week.
+     */
+    @Test
+    public void thereIsNoSteppingForwardFromToday() {
+        this.givenReportsOn(0, A_WALK);
+        this.openTheHistory();
+
+        Eventually.check(() -> onView(withId(R.id.history_move_right_button))
+                .check(matches(not(isEnabled()))));
+
+        onView(withId(R.id.history_move_left_button)).perform(click());
+
+        Eventually.check(() -> onView(withId(R.id.history_move_right_button))
+                .check(matches(isEnabled())));
+    }
+
+    // ------------------------------------------------------------------ the fixture
+
+    /**
+     * Put reports on a day, and record that day as already fetched.
+     *
+     * <p>The record is what keeps this deterministic: without it the screen merges a remote
+     * fetch into the answer, and the count on screen stops being the count that was seeded.
+     */
+    private void givenReportsOn(final int daysBack, final double[][] positions) {
+        this.givenReportsOn(daysBack, positions, true);
+    }
+
+    private void givenReportsOn(final int daysBack, final double[][] positions,
+                                final boolean markTheDayAsAlreadyFetched) {
+        final long dayStart = startOfDayLocal(daysBack);
+
+        final List<LocationReport> reports = new ArrayList<>();
+        for (int i = 0; i < positions.length; i++) {
+            // Spread through the middle of the day, so none of them can fall outside it however
+            // early or late the suite runs.
+            final long at = dayStart + (10 * 60 * 60 * 1000L) + (i * 60_000L);
+
+            reports.add(LocationReport.builder()
+                    .hashId(this.beaconId + "-" + daysBack + "-" + i)
+                    .beaconId(this.beaconId)
+                    .publishedAt(at)
+                    .description("Wi-Fi")
+                    .timestamp(at)
+                    .confidence(2)
+                    .latitude(positions[i][0])
+                    .longitude(positions[i][1])
+                    .horizontalAccuracy(83)
+                    .status(144)
+                    .lastUpdate(at)
+                    .build());
+        }
+
+        if (!reports.isEmpty()) {
+            this.db.locationReportDao().insertAll(reports.toArray(new LocationReport[0]));
+        }
+
+        if (markTheDayAsAlreadyFetched) {
+            this.db.dailyHistoryFetchRecordDao().insertAll(DailyHistoryFetchRecord.builder()
+                    .beaconId(this.beaconId)
+                    .dayStartTime(dayStart)
+                    .lastUpdate(System.currentTimeMillis())
+                    .build());
+        }
+    }
+
+    /** Midnight local, {@code daysBack} days ago - the boundary the screen itself uses. */
+    private static long startOfDayLocal(final int daysBack) {
+        final long then = System.currentTimeMillis() - (daysBack * 24L * 60 * 60 * 1000);
+
+        return Instant.ofEpochMilli(then)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate()
+                .atStartOfDay(ZoneId.systemDefault())
+                .toInstant()
+                .toEpochMilli();
+    }
+
+    private void openTheHistory() {
+        final Intent intent = new Intent(
+                getInstrumentation().getTargetContext(), HistoryViewActivity.class);
+        intent.putExtra("beaconId", this.beaconId);
+
+        this.scenario = ActivityScenario.launch(intent);
+    }
+
+    /**
+     * Tap the thing in a history row that actually listens.
+     *
+     * <p><b>The row's root is not clickable</b> - {@code HistoryItemsAdapter} hangs the listener
+     * on {@code history_item_clickable_container} inside it. A plain {@code click()} on the row
+     * therefore lands, dispatches, and is handled by nothing at all, which surfaces as the
+     * assertion about markers failing rather than as anything about the click. Naming the child
+     * removes the ambiguity.
+     *
+     * <p>It calls {@code performClick} rather than injecting a tap, so it proves the wiring from
+     * this control to the map and <b>not</b> that the control is reachable by a finger. Size and
+     * overlap are the layout tests' job.
+     */
+    private static ViewAction clickTheRowsOwnTarget() {
+        return new ViewAction() {
+            @Override
+            public Matcher<View> getConstraints() {
+                return isAssignableFrom(View.class);
+            }
+
+            @Override
+            public String getDescription() {
+                return "click the row's clickable container";
+            }
+
+            @Override
+            public void perform(final UiController uiController, final View view) {
+                final View target = view.findViewById(R.id.history_item_clickable_container);
+                if (target == null) {
+                    throw new AssertionError("a history row has no clickable container in it");
+                }
+                target.performClick();
+                uiController.loopMainThreadUntilIdle();
+            }
+        };
+    }
+
+    /** What the bottom sheet is currently doing, read off its behaviour. */
+    private int sheetState() {
+        final int[] state = {-1};
+        this.scenario.onActivity(activity -> state[0] = BottomSheetBehavior
+                .from(activity.findViewById(R.id.view_history_bottom_sheet_layout))
+                .getState());
+        return state[0];
+    }
+
+    /** Drag the sheet all the way up, as a reader of the list would. */
+    private void expandTheSheet() {
+        this.setTheSheetTo(BottomSheetBehavior.STATE_EXPANDED);
+    }
+
+    /**
+     * Put the sheet in a given state directly.
+     *
+     * <p>Used to <i>arrange</i> a starting point, never to assert one - the tap that opens it is
+     * covered by {@link #thesheetOpensWhenItsHandleIsTapped}, which uses the handle a person
+     * actually touches.
+     */
+    private void setTheSheetTo(final int state) {
+        getInstrumentation().runOnMainSync(() -> this.scenario.onActivity(activity ->
+                BottomSheetBehavior
+                        .from(activity.findViewById(R.id.view_history_bottom_sheet_layout))
+                        .setState(state)));
+        getInstrumentation().waitForIdleSync();
+    }
+
+    /** The "N data points" caption, read directly - it is written once the day resolves. */
+    private String datapointsCaption() {
+        final String[] found = {null};
+        this.scenario.onActivity(activity -> {
+            final TextView caption = activity.findViewById(R.id.history_datapoints_text);
+            found[0] = caption == null || caption.getText() == null
+                    ? null : caption.getText().toString();
+        });
+        return found[0];
+    }
+
+    private int rowCount() {
+        final int[] found = {0};
+        this.scenario.onActivity(activity -> {
+            final RecyclerView list = activity.findViewById(R.id.recycler_view_history_items);
+            found[0] = list == null || list.getAdapter() == null
+                    ? 0 : list.getAdapter().getItemCount();
+        });
+        return found[0];
+    }
+
+    private void forgetIt() {
+        // The reports go with it: LocationReport is keyed to the beacon and cascades on delete,
+        // which is the same mechanism that made INSERT OR REPLACE destroy history elsewhere in
+        // this app. Here it is the wanted behaviour, and there is no delete-by-beacon query.
+        this.db.ownedBeaconDao().delete(OwnedBeacon.builder().id(this.beaconId).build());
+        this.db.beaconNamingRecordDao().delete(
+                BeaconNamingRecord.builder().id(this.beaconId).build());
+
+        for (final Import stale : this.db.importDao().getImportsFromUser(A_TEST_USER)) {
+            this.db.importDao().delete(stale);
+        }
+    }
+
+    // --- what is already known is not thrown away --------------------------------------------
+
+    /**
+     * <b>Reports the app already holds are shown, even when Apple answers with nothing.</b>
+     *
+     * <p><b>The bug this exists for was reported from the app.</b> Inside the last seven days
+     * the screen used to take the remote answer alone and discard everything in the database;
+     * the local copy was merged in only for days <i>older</i> than a week, on the reasoning that
+     * Apple stops serving history beyond that. So a tag the map had located minutes earlier
+     * showed an empty history, and stepping back a day and returning made reports appear.
+     *
+     * <p>Apple returning nothing for a window is entirely ordinary - reports age out, and a
+     * narrow key window covers less than the day asked for - so this was not a rare state.
+     *
+     * <p><b>No {@code DailyHistoryFetchRecord} here, deliberately.</b> That record is what sends
+     * the screen down the local-only path, which would pass this test without the fix. Without
+     * it the screen goes remote, and the double answers with nothing at all - so anything on
+     * screen can only have come from the database.
+     */
+    @Test
+    public void reportsAlreadyInTheDatabaseSurviveAnEmptyAnswerFromApple() {
+        this.givenReportsOn(0, A_WALK, false);
+        this.openTheHistory();
+
+        Eventually.check(() -> assertEquals(
+                "Apple answered with nothing and the day came back empty, so the reports this"
+                        + " app had already stored were thrown away",
+                A_WALK.length, this.map.polylines().get(0).getPoints().size()));
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/importing/ImportingAZipPutsTagsOnTheMapTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/importing/ImportingAZipPutsTagsOnTheMapTest.java
@@ -1,0 +1,313 @@
+package dev.wander.android.opentagviewer.ui.importing;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
+import static androidx.test.espresso.matcher.RootMatchers.isPlatformPopup;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import android.app.Instrumentation.ActivityResult;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import com.chaquo.python.Python;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.db.room.OpenTagViewerDatabase;
+import dev.wander.android.opentagviewer.db.room.entity.OwnedBeacon;
+import dev.wander.android.opentagviewer.ui.maps.AMapWithTagsOnIt;
+
+/**
+ * A zip, chosen from the file picker, ends up as tags on the map.
+ *
+ * <p><b>The route every existing user depends on, and it had no coverage above the parser.</b>
+ * {@code AppleZipImporterUtilTest} and its neighbours take a bundle apart thoroughly - but they
+ * call {@code extractZip} directly. Nothing drove the picker, handed the result to the screen
+ * and watched a pin appear, so the whole span between "the user chose a file" and "the tag is on
+ * the map" was covered by running the app by hand.
+ *
+ * <p>It matters more than the account route it sits beside. Reading tags out of an Apple account
+ * is new; importing a zip made on a Mac is how <i>everybody</i> got their tags in until now, and
+ * how anybody given tags by somebody else still does.
+ *
+ * <p><b>The zip is real and built here</b> - the metadata file, an {@code OwnedBeacons} plist and
+ * a {@code BeaconNamingRecord} per tag, in the layout the exporter writes - so the actual
+ * importer runs. Only the picker is faked, because a system file chooser cannot be driven from a
+ * test.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class ImportingAZipPutsTagsOnTheMapTest {
+
+    private static final String BEACON_A = "1A2B3C4D-1111-4222-8333-444455556666";
+    private static final String BEACON_B = "9F8E7D6C-2222-4333-8444-555566667777";
+    private static final String RECORD_ID = "0A1B2C3D-3333-4444-8555-666677778888";
+
+    private static final String IMPORTED_FROM = "somebody-elses-mac@example.com";
+
+    /** Where the double says both tags are, once the map asks. */
+    private static final double LATITUDE = 51.500729;
+    private static final double LONGITUDE = -0.124625;
+
+    /**
+     * The metadata file, in the exporter's own field names.
+     *
+     * <p><b>{@code exportTimestamp}, not {@code exportedAt}.</b> The second is what the Room
+     * entity calls the same value, and using it here produces a bundle the importer refuses
+     * outright - before it looks at a single tag. Which is the right behaviour, and was how
+     * this test first found out it had invented a field name.
+     */
+    private static final String BUNDLE_METADATA =
+            "version: 0.0.2\n"
+                    + "exportTimestamp: 1699000000000\n"
+                    + "via: OpenTagViewer.wizard:test\n"
+                    + "sourceUser: " + IMPORTED_FROM + "\n";
+
+    private final AMapWithTagsOnIt theMap = new AMapWithTagsOnIt();
+
+    private Context context;
+    private OpenTagViewerDatabase db;
+    private File zipFile;
+
+    @Before
+    public void openAMapWithNothingOnItYet() {
+        this.context = getInstrumentation().getTargetContext();
+        this.db = OpenTagViewerDatabase.getInstance(this.context);
+
+        this.forgetTheImportedTags();
+
+        Intents.init();
+
+        // Seeded with no tags at all: somebody signed in with nothing yet, which is exactly who
+        // reaches for Import.
+        this.theMap.seed();
+
+        // The fixture installs the double with nothing to report, which is right for a map whose
+        // pins come from the database. Here the tags arrive with no locations at all, so a pin
+        // can only appear if the fetch that follows the import returns one.
+        Python.getInstance().getModule("apple_test_double")
+                .callAttr("install", LATITUDE, LONGITUDE, 2.0);
+
+        this.theMap.open();
+
+        Eventually.check(() -> assertTrue("the map never became ready",
+                this.theMap.map().isReady()));
+    }
+
+    @After
+    public void putEverythingBack() {
+        Intents.release();
+        this.theMap.putItBack();
+        this.forgetTheImportedTags();
+
+        if (this.zipFile != null && this.zipFile.exists() && !this.zipFile.delete()) {
+            this.zipFile.deleteOnExit();
+        }
+    }
+
+    /**
+     * <b>Both tags in the bundle are written down, with the state that makes them locatable.</b>
+     *
+     * <p>{@code accessory_json} is asserted for the same reason it is in the account journey: a
+     * missing one is backfilled on first fetch rather than being fatal, so a tag that imported
+     * and can never be located looks exactly like a tag that imported.
+     */
+    @Test
+    public void thetagsInTheZipAreImportedAndAreLocatable() {
+        this.chooseTheZipFromTheImportMenu();
+
+        Eventually.check(() -> assertEquals("the bundle's two tags were not both imported",
+                2, this.importedTags().size()));
+
+        for (final OwnedBeacon imported : this.importedTags()) {
+            assertNotNull(imported.id + " imported with no accessory state, so it looks"
+                    + " imported and can never be located", imported.accessoryJson);
+            assertNotNull(imported.id + " imported with no plist", imported.content);
+        }
+    }
+
+    /**
+     * <b>And they arrive on the map, without the user going anywhere.</b>
+     *
+     * <p>The hand-off that had nothing on it. The screen takes a {@code Uri} from an activity
+     * result, imports it, fetches for what arrived and redraws - and a break anywhere along
+     * that leaves a user who picked the right file staring at an unchanged map, with the tags
+     * sitting in the database where only My Devices would show them.
+     */
+    @Test
+    public void andappearOnTheMapWithoutLeavingTheScreen() {
+        this.chooseTheZipFromTheImportMenu();
+
+        Eventually.check(() -> assertEquals("the imported tags never reached the map",
+                2, this.theMap.map().markerCount()));
+
+        for (final String beaconId : List.of(BEACON_A, BEACON_B)) {
+            final List<dev.wander.android.opentagviewer.ui.maps.FakeMapProvider.PlacedMarker> pins =
+                    this.theMap.map().markers().stream()
+                            .filter(placed -> beaconId.equals(placed.marker.getId()))
+                            .collect(Collectors.toList());
+
+            assertEquals("no pin was drawn for " + beaconId, 1, pins.size());
+            assertEquals(LATITUDE, pins.get(0).marker.getLatitude(), 0.000001);
+            assertEquals(LONGITUDE, pins.get(0).marker.getLongitude(), 0.000001);
+        }
+    }
+
+    /** And the tag cards are built for them too, not only the pins. */
+    @Test
+    public void andgetTagCardsOfTheirOwn() {
+        this.chooseTheZipFromTheImportMenu();
+
+        Eventually.check(() -> assertTrue("no tag cards were built for the imported tags",
+                this.theMap.cards().size() >= 2));
+    }
+
+    // ------------------------------------------------------------------ the picker
+
+    /**
+     * Open the overflow, choose Import, and answer the picker with our zip.
+     *
+     * <p>The stub is registered before the menu is touched, because the launcher fires the
+     * moment the item is chosen and an intent that goes out unstubbed reaches the real system
+     * file chooser - which no test can answer.
+     */
+    private void chooseTheZipFromTheImportMenu() {
+        final Uri bundle = this.writeAZipWithTwoTagsInIt();
+
+        final Intent chosen = new Intent();
+        chosen.setData(bundle);
+        intending(hasAction(Intent.ACTION_GET_CONTENT))
+                .respondWith(new ActivityResult(Activity.RESULT_OK, chosen));
+
+        Eventually.check(() -> onView(withId(R.id.button_more_settings))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.button_more_settings)).perform(click());
+
+        // Not wrapped in Eventually: a PopupMenu is up by the time the click returns, and asking
+        // for a platform-popup root that is not there yet is the slow question, not the quick
+        // one.
+        onView(androidx.test.espresso.matcher.ViewMatchers.withText(R.string.do_import))
+                .inRoot(isPlatformPopup()).perform(click());
+    }
+
+    // ------------------------------------------------------------------ the bundle
+
+    /**
+     * A bundle on disk, in the layout the exporter produces.
+     *
+     * <p>Written to the app's own cache so a {@code file://} Uri is readable without a provider.
+     * That is safe here and would not be in the app: nothing leaves the process, because the
+     * picker is stubbed and the result is handed straight back.
+     */
+    private Uri writeAZipWithTwoTagsInIt() {
+        final Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("OPENTAGVIEWER.yml", BUNDLE_METADATA);
+        entries.put("OwnedBeacons/" + BEACON_A + ".plist", ownedBeaconPlist(BEACON_A));
+        entries.put("BeaconNamingRecord/" + BEACON_A + "/" + RECORD_ID + ".plist",
+                namingRecordPlist(BEACON_A, "Borrowed Bike"));
+        entries.put("OwnedBeacons/" + BEACON_B + ".plist", ownedBeaconPlist(BEACON_B));
+        entries.put("BeaconNamingRecord/" + BEACON_B + "/" + RECORD_ID + ".plist",
+                namingRecordPlist(BEACON_B, "Borrowed Keys"));
+
+        try {
+            this.zipFile = File.createTempFile(
+                    "otv-import-journey", ".zip", this.context.getCacheDir());
+
+            try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(this.zipFile))) {
+                for (final Map.Entry<String, String> entry : entries.entrySet()) {
+                    out.putNextEntry(new ZipEntry(entry.getKey()));
+                    out.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
+                    out.closeEntry();
+                }
+            }
+        } catch (final IOException cannotWrite) {
+            throw new AssertionError("could not build a bundle to import", cannotWrite);
+        }
+
+        return Uri.fromFile(this.zipFile);
+    }
+
+    /**
+     * An {@code OwnedBeacons} plist the real converter can actually convert.
+     *
+     * <p><b>The key material has to be real in shape, and a made-up string will not do.</b> The
+     * importer hands each plist to Python's {@code convertPlistToJson}, which builds a
+     * {@code FindMyAccessory} - and that reaches for a 28-byte master key and two 32-byte shared
+     * secrets. A short placeholder is refused there.
+     *
+     * <p>Refused <b>quietly</b>, which is what made this worth a comment: a missing accessory
+     * state is not fatal by design, because it is backfilled on the first fetch. So the first
+     * version of this test imported two tags perfectly happily and neither could ever be
+     * located - the same trap {@code FakeICloudService.AN_OWNED_BEACON_PLIST} was written to
+     * escape, and this borrows its key material for the same reason. It is real in shape and
+     * secret in no sense whatsoever.
+     */
+    private static String ownedBeaconPlist(final String beaconId) {
+        return dev.wander.android.opentagviewer.python.icloud.FakeICloudService
+                .AN_OWNED_BEACON_PLIST
+                // The fixture names one identifier; a bundle with two tags needs two. The
+                // importer takes the beacon id from the file name, so this only keeps the
+                // document internally consistent.
+                .replace("F612A183-492B-45A8-A5A2-233CA9062A94", beaconId);
+    }
+
+    private static String namingRecordPlist(final String beaconId, final String name) {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<plist version=\"1.0\"><dict>"
+                + "<key>identifier</key><string>" + beaconId + "</string>"
+                + "<key>associatedBeacon</key><string>" + beaconId + "</string>"
+                + "<key>name</key><string>" + name + "</string>"
+                + "</dict></plist>";
+    }
+
+    // ------------------------------------------------------------------ housekeeping
+
+    private List<OwnedBeacon> importedTags() {
+        return this.db.ownedBeaconDao().getAll().stream()
+                .filter(beacon -> BEACON_A.equals(beacon.id) || BEACON_B.equals(beacon.id))
+                .collect(Collectors.toList());
+    }
+
+    private void forgetTheImportedTags() {
+        for (final String beaconId : List.of(BEACON_A, BEACON_B)) {
+            this.db.ownedBeaconDao().delete(OwnedBeacon.builder().id(beaconId).build());
+            this.db.beaconNamingRecordDao().delete(
+                    dev.wander.android.opentagviewer.db.room.entity.BeaconNamingRecord.builder()
+                            .id(beaconId).build());
+        }
+
+        for (final var stale : this.db.importDao().getImportsFromUser(IMPORTED_FROM)) {
+            this.db.importDao().delete(stale);
+        }
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/AMapWithTagsOnIt.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/AMapWithTagsOnIt.java
@@ -1,0 +1,334 @@
+package dev.wander.android.opentagviewer.ui.maps;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
+import android.content.Context;
+import android.content.Intent;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.test.core.app.ActivityScenario;
+
+import com.chaquo.python.PyObject;
+import com.chaquo.python.Python;
+import com.chaquo.python.android.AndroidPlatform;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.wander.android.opentagviewer.DeviceStateGuard;
+import dev.wander.android.opentagviewer.MapsActivity;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
+import dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStore;
+import dev.wander.android.opentagviewer.db.repo.UserAuthRepository;
+import dev.wander.android.opentagviewer.db.repo.UserSettingsRepository;
+import dev.wander.android.opentagviewer.db.repo.model.UserSettings;
+import dev.wander.android.opentagviewer.db.room.OpenTagViewerDatabase;
+import dev.wander.android.opentagviewer.db.room.entity.BeaconNamingRecord;
+import dev.wander.android.opentagviewer.db.room.entity.Import;
+import dev.wander.android.opentagviewer.db.room.entity.LocationReport;
+import dev.wander.android.opentagviewer.db.room.entity.OwnedBeacon;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
+import dev.wander.android.opentagviewer.util.rx.RefreshPolicy;
+
+/**
+ * The map, open, with tags on it - the starting point seven tests need and none of them own.
+ *
+ * <p><b>Written once because it is the same eight-step arrangement every time.</b> Reaching a
+ * drawn map means a stored session, a Python double that will restore it, a substituted map
+ * provider, a geocoder that answers, beacons with usable accessory state, locations for them to
+ * be drawn at, and the shared refresh policy reset so the startup fetch is not skipped. Copying
+ * that into each test is how they drift: one forgets {@code RefreshPolicy.resetShared} and
+ * passes for a year because the fetch it meant to observe never ran.
+ *
+ * <p><b>It is a fixture, not a base class.</b> Tests hold one and call {@link #open}; they do not
+ * extend it. Inheritance would put the seeding out of sight of the test that depends on it, and
+ * the seeding is exactly what a reader needs to see to know what an assertion means.
+ *
+ * <p>Everything it leaves behind is undone by {@link #putItBack}, which belongs in an
+ * {@code @After} - including the device's own settings, which this overwrites.
+ */
+public final class AMapWithTagsOnIt {
+
+    /** Somewhere no other test reports from, so a stale row cannot be mistaken for this one. */
+    public static final double LATITUDE = 48.858370;
+    public static final double LONGITUDE = 2.294481;
+
+    public static final String WHERE_THAT_IS = "A made-up street, in a made-up town";
+
+    private static final String A_TEST_USER = "map-fixture@example.com";
+
+    private static final String A_PLIST = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<plist version=\"1.0\"><dict>"
+            + "<key>batteryLevel</key><integer>1</integer>"
+            + "<key>model</key><string></string>"
+            + "<key>pairingDate</key><date>2025-02-27T20:03:32Z</date>"
+            + "<key>privateKey</key><dict><key>key</key><dict>"
+            + "<key>data</key><data>bm90LWEtcmVhbC1rZXk=</data></dict></dict>"
+            + "<key>productId</key><integer>21760</integer>"
+            + "<key>stableIdentifier</key><array><string>2001~#0~#A0</string></array>"
+            + "<key>systemVersion</key><string>2.0.73</string>"
+            + "<key>vendorId</key><integer>76</integer>"
+            + "</dict></plist>";
+
+    private final Context context = getInstrumentation().getTargetContext();
+    private final OpenTagViewerDatabase db = OpenTagViewerDatabase.getInstance(this.context);
+
+    private final List<String> beaconIds = new ArrayList<>();
+
+    private DeviceStateGuard guard;
+    private FakeMapProvider map;
+    private FakeGeocoder geocoder;
+    private PyObject appleDouble;
+    private ActivityScenario<MapsActivity> scenario;
+
+    // ------------------------------------------------------------------ what a test reads
+
+    public FakeMapProvider map() {
+        return this.map;
+    }
+
+    public FakeGeocoder geocoder() {
+        return this.geocoder;
+    }
+
+    public ActivityScenario<MapsActivity> scenario() {
+        return this.scenario;
+    }
+
+    /** The ids of the tags that were seeded, in the order they were named. */
+    public List<String> tagIds() {
+        return new ArrayList<>(this.beaconIds);
+    }
+
+    // ------------------------------------------------------------------ arranging it
+
+    /**
+     * Seed a tag per name, each with a location, and put the fakes in place.
+     *
+     * <p>Every tag is given a location on purpose. A tag without one gets no card and no pin -
+     * intended behaviour, and the reason a fixture that quietly seeded one would make a test
+     * about cards fail for a reason nowhere near the card.
+     */
+    public AMapWithTagsOnIt seed(final String... names) {
+        this.guard = DeviceStateGuard.capture(this.context);
+        this.grantLocationUpFront();
+        this.forgetThem();
+
+        // Enough of a session to get past the door. What is in it does not matter, because
+        // apple_test_double replaces the function that would read it.
+        new UserAuthRepository(
+                UserAuthDataStore.getInstance(this.context), new AppCryptographyUtil())
+                .storeUserAuth("{\"not\":\"a restorable account\"}".getBytes(StandardCharsets.UTF_8))
+                .blockingAwait();
+
+        // **Otherwise a dialog opens on top of the map and every assertion looks at that.**
+        // MapsActivity offers the move to local Anisette to anybody who is signed in and has
+        // never chosen a mode - which is exactly what writing a session by hand produces. The
+        // offer is correct behaviour; it is just not what these tests are about, and Espresso's
+        // default root becomes the dialog, so the map's own controls are "not in the hierarchy".
+        //
+        // Recorded as already offered rather than answered, because answering it writes an
+        // Anisette mode and that is a different thing to be asserting about by accident.
+        final UserSettingsRepository settingsRepo = new UserSettingsRepository(
+                UserSettingsDataStore.getInstance(this.context));
+        final UserSettings settings = settingsRepo.getUserSettings();
+        settings.setAnisetteUpgradeOffered(true);
+        settingsRepo.storeUserSettings(settings).blockingAwait();
+
+        final long importId = this.db.importDao().insert(Import.builder()
+                .version("0.0.2").importedAt(1_700_000_000_000L).exportedAt(1_699_000_000_000L)
+                .sourceUser(A_TEST_USER).exportedVia("OpenTagViewer.wizard:test").build());
+
+        for (int i = 0; i < names.length; i++) {
+            final String beaconId = "fixture-tag-" + i;
+            this.beaconIds.add(beaconId);
+
+            this.db.ownedBeaconDao().insertAll(OwnedBeacon.builder()
+                    .id(beaconId).importId(importId).content(A_PLIST).version("0.0.2")
+                    .fromAccount(false).isRemoved(false)
+                    // Stored, so nothing tries to derive it from the plist above - that key is
+                    // eighteen bytes where a real one is twenty-eight, so FindMy.py refuses it
+                    // and the fetch silently never happens.
+                    .accessoryJson("{\"type\": \"accessory\", \"id\": \"" + beaconId + "\"}")
+                    .build());
+
+            this.db.beaconNamingRecordDao().insertAll(BeaconNamingRecord.builder()
+                    .id(beaconId).importId(importId).version("0.0.2").isRemoved(false)
+                    .content("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                            + "<plist version=\"1.0\"><dict>"
+                            + "<key>identifier</key><string>" + beaconId + "</string>"
+                            + "<key>name</key><string>" + names[i] + "</string>"
+                            + "</dict></plist>")
+                    .build());
+
+            // **Reported a couple of hours ago, not on a fixed date in 2023.** The timestamp
+            // decides which day the report belongs to, and the history screen asks for one
+            // local day at a time - so a fixed past date gives every screen built on this
+            // fixture an empty "today", which reads as the history being broken.
+            //
+            // Two hours rather than minutes, so it is comfortably inside today whatever hour
+            // the suite runs at, and inside every window the app asks for.
+            final long reportedAt = System.currentTimeMillis() - (2L * 60 * 60 * 1000);
+
+            // Spread apart, so "which card is centred" has a different answer per tag.
+            this.db.locationReportDao().insertAll(LocationReport.builder()
+                    .hashId(beaconId + "-seeded")
+                    .beaconId(beaconId)
+                    .publishedAt(reportedAt)
+                    .description("Wi-Fi")
+                    .timestamp(reportedAt)
+                    .confidence(2)
+                    .latitude(LATITUDE + (i * 0.001))
+                    .longitude(LONGITUDE + (i * 0.001))
+                    .horizontalAccuracy(83)
+                    .status(144)
+                    .lastUpdate(reportedAt)
+                    .build());
+        }
+
+        this.map = new FakeMapProvider();
+        MapProviderFactory.replaceWith(() -> this.map);
+
+        this.geocoder = new FakeGeocoder().saying(LATITUDE, LONGITUDE, WHERE_THAT_IS);
+        AppDependencies.replaceGeocoder((ctx, locale) -> this.geocoder);
+
+        if (!Python.isStarted()) {
+            Python.start(new AndroidPlatform(this.context));
+        }
+        this.appleDouble = Python.getInstance().getModule("apple_test_double");
+        // Nothing to report: the cached locations above are what gets drawn, and a fetch that
+        // moved every pin would make "where is this tag drawn" depend on the double instead of
+        // on the seed. TheWholeAppJourneyTest is where the fetch itself is exercised.
+        this.appleDouble.callAttr("installWithNothingToReport");
+
+        // Otherwise a previous test's fetch suppresses this one's: the policy is process-wide
+        // and outlives any activity, deliberately.
+        RefreshPolicy.resetShared();
+
+        return this;
+    }
+
+    /**
+     * <b>Granted before the map opens, or nothing after this works.</b>
+     *
+     * <p>{@code MapsActivity} asks for location the moment it starts. The dialog belongs to the
+     * system permission controller, not to this app, so it takes focus, pauses the map, and
+     * leaves Espresso reporting "no activity currently resumed" - which reads as the app having
+     * crashed. It is expensive to diagnose, too: the root picker waits thirty seconds per retry,
+     * so one affected test ran for six minutes before saying anything.
+     *
+     * <p>Done here rather than with a {@code GrantPermissionRule} in each test, because a rule
+     * is per-class and this is a property of arranging the map at all - a new test that used the
+     * fixture and forgot the rule would hit the same six-minute wall.
+     */
+    private void grantLocationUpFront() {
+        final String packageName = this.context.getPackageName();
+
+        for (final String permission : new String[] {
+                android.Manifest.permission.ACCESS_FINE_LOCATION,
+                android.Manifest.permission.ACCESS_COARSE_LOCATION}) {
+            try {
+                getInstrumentation().getUiAutomation()
+                        .grantRuntimePermission(packageName, permission);
+            } catch (final RuntimeException alreadyGrantedOrNotGrantable) {
+                // Already held, which is the usual case after the first test in a run.
+            }
+        }
+    }
+
+    /** Launch the map and hand back the scenario. */
+    public ActivityScenario<MapsActivity> open() {
+        this.scenario = ActivityScenario.launch(new Intent(this.context, MapsActivity.class));
+        return this.scenario;
+    }
+
+    // ------------------------------------------------------------------ asking about cards
+
+    /** The tag cards currently on screen, left to right, as the row holds them. */
+    public List<View> cards() {
+        final List<View> found = new ArrayList<>();
+
+        this.scenario.onActivity(activity -> {
+            final ViewGroup row = activity.findViewById(R.id.tags_scroll_container);
+            if (row == null) {
+                return;
+            }
+            for (int i = 0; i < row.getChildCount(); i++) {
+                found.add(row.getChildAt(i));
+            }
+        });
+
+        return found;
+    }
+
+    /**
+     * How far the nearest card's centre is from the middle of the row, in pixels.
+     *
+     * <p>The number the carousel's settling is judged by: whatever a gesture did, it has to end
+     * with one card centred rather than two half-shown.
+     */
+    public int howFarOffCentreTheNearestCardIs() {
+        final int[] answer = {Integer.MAX_VALUE};
+
+        this.scenario.onActivity(activity -> {
+            final View area = activity.findViewById(R.id.tags_scrollable_area);
+            final ViewGroup row = activity.findViewById(R.id.tags_scroll_container);
+            if (area == null || row == null || row.getChildCount() == 0) {
+                return;
+            }
+
+            final int[] areaAt = new int[2];
+            area.getLocationOnScreen(areaAt);
+            final int rowMiddle = areaAt[0] + (area.getWidth() / 2);
+
+            final int[] cardAt = new int[2];
+            for (int i = 0; i < row.getChildCount(); i++) {
+                final View card = row.getChildAt(i);
+                card.getLocationOnScreen(cardAt);
+
+                final int cardMiddle = cardAt[0] + (card.getWidth() / 2);
+                answer[0] = Math.min(answer[0], Math.abs(rowMiddle - cardMiddle));
+            }
+        });
+
+        return answer[0];
+    }
+
+    // ------------------------------------------------------------------ putting it back
+
+    /** Call from {@code @After}, always - this overwrote the device's own settings. */
+    public void putItBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        if (this.appleDouble != null) {
+            this.appleDouble.callAttr("uninstall");
+        }
+
+        MapProviderFactory.reset();
+        AppDependencies.reset();
+
+        this.forgetThem();
+
+        if (this.guard != null) {
+            this.guard.restore();
+        }
+    }
+
+    private void forgetThem() {
+        for (final String beaconId : this.beaconIds) {
+            // Reports go with it: LocationReport cascades on the beacon being deleted.
+            this.db.ownedBeaconDao().delete(OwnedBeacon.builder().id(beaconId).build());
+            this.db.beaconNamingRecordDao().delete(
+                    BeaconNamingRecord.builder().id(beaconId).build());
+        }
+
+        for (final Import stale : this.db.importDao().getImportsFromUser(A_TEST_USER)) {
+            this.db.importDao().delete(stale);
+        }
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/EveryButtonOnTheMapGoesSomewhereTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/EveryButtonOnTheMapGoesSomewhereTest.java
@@ -1,0 +1,236 @@
+package dev.wander.android.opentagviewer.ui.maps;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasDataString;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasType;
+import static androidx.test.espresso.matcher.RootMatchers.isPlatformPopup;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import android.app.Instrumentation.ActivityResult;
+import android.content.Intent;
+
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import dev.wander.android.opentagviewer.DeviceInfoActivity;
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.HistoryViewActivity;
+import dev.wander.android.opentagviewer.InformationActivity;
+import dev.wander.android.opentagviewer.MapsActivity;
+import dev.wander.android.opentagviewer.MyDevicesListActivity;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.SettingsActivity;
+
+/**
+ * Every control on the map goes where it says it goes.
+ *
+ * <p><b>The cheapest useful test in this suite, and the one with no equivalent before it.</b>
+ * Nothing here checks that a destination screen is correct - each has its own tests. What it
+ * checks is that the wire between the control and the destination still exists, which is the
+ * thing that breaks silently: a renamed id, a listener attached to the wrong view, an
+ * {@code android:onClick} pointing at a method somebody moved. None of those fail to compile,
+ * and all of them present as a button that does nothing.
+ *
+ * <p><b>Intents are stubbed at the door.</b> Each destination is answered rather than started,
+ * so this stays a test of the map and does not become a slow tour of the whole app - and the
+ * external maps application, which would otherwise really open, never does.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class EveryButtonOnTheMapGoesSomewhereTest {
+
+    private final AMapWithTagsOnIt theMap = new AMapWithTagsOnIt();
+
+    @Before
+    public void openTheMapWithTwoTagsOnIt() {
+        // Before the activity starts, or the first intents it sends are missed.
+        Intents.init();
+
+        // **Everything except the map itself.** `anyIntent()` reads like the obvious way to say
+        // "do not really navigate anywhere", and it also stubs the intent
+        // `ActivityScenario.launch` uses to start MapsActivity - so the map is answered at the
+        // door, never runs, and every test here waits for a screen that was never allowed to
+        // exist. It presents as a hang rather than a failure: six minutes per test, with
+        // `Stubbing intent ... MapsActivity` as the only clue in the log.
+        intending(not(hasComponent(MapsActivity.class.getName())))
+                .respondWith(new ActivityResult(Activity.RESULT_OK, null));
+
+        this.theMap.seed("Bike", "Keys").open();
+
+        Eventually.check(() -> assertTrue("the map never became ready",
+                this.theMap.map().isReady()));
+    }
+
+    @After
+    public void putEverythingBack() {
+        this.theMap.putItBack();
+        Intents.release();
+    }
+
+    // ------------------------------------------------------------------ the overflow menu
+
+    @Test
+    public void themenuOpensMyDevices() {
+        this.pickFromTheOverflow(R.string.my_devices);
+
+        Eventually.check(() -> intended(hasComponent(MyDevicesListActivity.class.getName())));
+    }
+
+    @Test
+    public void themenuOpensSettings() {
+        this.pickFromTheOverflow(R.string.settings);
+
+        Eventually.check(() -> intended(hasComponent(SettingsActivity.class.getName())));
+    }
+
+    @Test
+    public void themenuOpensTheInformationPage() {
+        this.pickFromTheOverflow(R.string.information);
+
+        Eventually.check(() -> intended(hasComponent(InformationActivity.class.getName())));
+    }
+
+    /**
+     * Import opens the system file picker, not a screen of this app's own.
+     *
+     * <p>Asserted on the action rather than a component for that reason: which application
+     * answers it is the platform's business and differs by device.
+     *
+     * <p><b>{@code GET_CONTENT}, not {@code OPEN_DOCUMENT}</b>, which is worth stating because
+     * the two look interchangeable and are not. {@code GET_CONTENT} asks for a copy of a file
+     * and is right here - the zip is read once at import and never again - while
+     * {@code OPEN_DOCUMENT} asks for a lasting handle to the original, which this app has no use
+     * for and would be asking the user to grant more than it needs. The log export next door
+     * uses {@code CREATE_DOCUMENT} for the same sort of reason, in the other direction.
+     */
+    @Test
+    public void themenuOpensTheFilePickerToImportAZip() {
+        this.pickFromTheOverflow(R.string.do_import);
+
+        Eventually.check(() -> intended(allOf(
+                hasAction(Intent.ACTION_GET_CONTENT),
+                hasType("application/zip"))));
+    }
+
+    // ------------------------------------------------------------------ the tag card
+
+    @Test
+    public void thehistoryButtonOnACardOpensThatTagsHistory() {
+        this.waitForTheCards();
+        onView(theFirstCard(R.id.device_history_button_container)).perform(scrollTo(), click());
+
+        Eventually.check(() -> intended(hasComponent(HistoryViewActivity.class.getName())));
+    }
+
+    @Test
+    public void themoreButtonOnACardOpensThatTagsPage() {
+        this.waitForTheCards();
+        onView(theFirstCard(R.id.device_more_button_container)).perform(scrollTo(), click());
+
+        Eventually.check(() -> intended(hasComponent(DeviceInfoActivity.class.getName())));
+    }
+
+    /**
+     * <b>Navigate-to hands the tag's position to whatever opens maps.</b>
+     *
+     * <p>This is the control that was dead on every current device. It named
+     * {@code com.google.android.apps.maps} explicitly, and from Android 11 an application cannot
+     * see a package it has not declared in {@code <queries>} - so {@code resolveActivity}
+     * returned null whether or not Google Maps was installed, and the button logged and did
+     * nothing.
+     *
+     * <p>Two things are asserted, and the second is the point: that an intent goes out at all,
+     * and that it names <b>no package</b>. Pinning the absence is what stops the hard-coding
+     * coming back - it reads like a reasonable thing to add, and it would send everyone who
+     * chose a different maps application into a dead end again.
+     */
+    @Test
+    public void navigateToOpensWhicheverMapsApplicationTheUserHas() {
+        // **Waited on for a reason that is not obvious from the button.** It is on screen from
+        // the moment the map opens, but onClickNavigateTo returns early when there are no tag
+        // cards yet - so pressing it too soon does nothing at all, and the failure is "no intent
+        // was sent", which reads as the navigation being broken rather than as being early.
+        this.waitForTheCards();
+
+        Eventually.check(() -> onView(withId(R.id.button_navigate_to))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.button_navigate_to)).perform(click());
+
+        Eventually.check(() -> intended(allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasDataString(startsWith("geo:")))));
+
+        assertTrue("navigate-to named a package again, so every maps application except that"
+                        + " one is shut out - and on Android 11 and up package visibility hides"
+                        + " the named one too, which makes the button do nothing at all",
+                this.theOutgoingMapsIntentNamesNoPackage());
+    }
+
+    private boolean theOutgoingMapsIntentNamesNoPackage() {
+        return Intents.getIntents().stream()
+                .filter(sent -> sent.getData() != null
+                        && String.valueOf(sent.getData()).startsWith("geo:"))
+                .allMatch(sent -> sent.getPackage() == null);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    /**
+     * Wait until the tag cards exist.
+     *
+     * <p><b>The overflow button is there the instant the map opens; the cards are not.</b> They
+     * are built after the beacons are read, parsed and drawn, so reaching for one straight away
+     * races that - and Espresso reports it as "no views in hierarchy matching", which reads as
+     * the card being gone rather than as not having arrived yet.
+     */
+    private void waitForTheCards() {
+        Eventually.check(() -> assertTrue("the tag cards were never built",
+                this.theMap.cards().size() >= 2));
+    }
+
+    /** A control inside the first tag's card - there is more than one card on screen. */
+    private static org.hamcrest.Matcher<android.view.View> theFirstCard(final int controlId) {
+        return allOf(withId(controlId), androidx.test.espresso.matcher.ViewMatchers
+                .isDescendantOfA(allOf(withId(R.id.tag_item_container),
+                        androidx.test.espresso.matcher.ViewMatchers
+                                .hasDescendant(withText("Bike")))));
+    }
+
+    /**
+     * Open the overflow and choose an item by its label.
+     *
+     * <p>Not wrapped in {@code Eventually}: a {@code PopupMenu} is shown on the main thread
+     * inside the click handler, so it is already up when the click returns. Asking for a
+     * platform-popup root that is not there yet is the <i>expensive</i> question - Espresso's
+     * root picker retries internally for seconds before admitting it - so a retry loop here
+     * makes the cheap case the slow one.
+     */
+    private void pickFromTheOverflow(final int label) {
+        Eventually.check(() -> onView(withId(R.id.button_more_settings))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.button_more_settings)).perform(click());
+
+        onView(withText(label)).inRoot(isPlatformPopup()).perform(click());
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/FakeGeocoder.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/FakeGeocoder.java
@@ -1,0 +1,94 @@
+package dev.wander.android.opentagviewer.ui.maps;
+
+import android.location.Address;
+
+import dev.wander.android.opentagviewer.util.android.AddressLookup;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Street names for coordinates, invented and stable.
+ *
+ * <p><b>The managed device has no geocoder at all.</b> {@code aosp-atd} carries no backend, so
+ * the platform's {@code getFromLocation} returns an empty list for every point on earth. Nothing
+ * fails: the tag card and the history rows both fall back to printing the raw latitude and
+ * longitude, which is exactly what they are supposed to do when an address genuinely cannot be
+ * found. So the absence looks like correct behaviour, and every screenshot of either screen
+ * shows numbers where a real phone shows a place.
+ *
+ * <p><b>Which means the geocoding path was covered by nothing.</b> There is real behaviour in
+ * it - coordinates are rounded before lookup so that a tag jittering by metres does not
+ * re-geocode, and results are cached per rounded pair across screens - and none of it could be
+ * observed, because the answer was empty either way.
+ *
+ * <p><b>Deliberately not plausible.</b> The addresses are invented and say so, because a
+ * screenshot of a test is a thing people read later, and one carrying a real-looking address
+ * next to a real-looking coordinate invites somebody to believe a location was actually looked
+ * up. Anything not explicitly registered gets a name derived from its coordinates rather than
+ * nothing, so an unexpected point is visible as an unexpected point.
+ */
+public final class FakeGeocoder implements AddressLookup {
+
+    /** Registered points, in insertion order, keyed as they will be compared. */
+    private final Map<String, String> byRoundedPosition = new LinkedHashMap<>();
+
+    /**
+     * How close a lookup has to be to a registered point to get its name.
+     *
+     * <p>Roughly a hundred metres. The app rounds coordinates before asking - to four decimal
+     * places, as {@code HistoryItemsAdapter}'s own log line shows - so a test that registers the
+     * exact coordinates it reported cannot rely on getting the exact coordinates back.
+     */
+    private static final double NEAR_ENOUGH = 0.001;
+
+    private final List<double[]> asked = new ArrayList<>();
+
+    /** Give a point a name. Anything within about a hundred metres of it answers with this. */
+    public FakeGeocoder saying(final double latitude, final double longitude, final String name) {
+        this.byRoundedPosition.put(key(latitude, longitude), name);
+        return this;
+    }
+
+    /** Every coordinate pair this was asked about, so a test can assert it was asked at all. */
+    public List<double[]> asked() {
+        return new ArrayList<>(this.asked);
+    }
+
+    @Override
+    public List<Address> getFromLocation(
+            final double latitude, final double longitude, final int maxResults) {
+
+        this.asked.add(new double[] {latitude, longitude});
+
+        final Address address = new Address(Locale.UK);
+        address.setLatitude(latitude);
+        address.setLongitude(longitude);
+        address.setAddressLine(0, this.nameFor(latitude, longitude));
+
+        return List.of(address);
+    }
+
+    private String nameFor(final double latitude, final double longitude) {
+        for (final Map.Entry<String, String> registered : this.byRoundedPosition.entrySet()) {
+            final String[] parts = registered.getKey().split(",");
+            if (Math.abs(Double.parseDouble(parts[0]) - latitude) < NEAR_ENOUGH
+                    && Math.abs(Double.parseDouble(parts[1]) - longitude) < NEAR_ENOUGH) {
+                return registered.getValue();
+            }
+        }
+
+        // Not registered, and named rather than dropped - an empty answer would be
+        // indistinguishable from the device having no geocoder, which is the whole problem this
+        // exists to remove.
+        return String.format(Locale.ROOT, "Nowhere in particular (%.4f, %.4f)",
+                latitude, longitude);
+    }
+
+    private static String key(final double latitude, final double longitude) {
+        return latitude + "," + longitude;
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/FakeMapProvider.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/FakeMapProvider.java
@@ -2,8 +2,10 @@ package dev.wander.android.opentagviewer.ui.maps;
 
 import android.app.Activity;
 import android.view.View;
+import android.view.ViewGroup;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +44,12 @@ public class FakeMapProvider implements IMapProvider {
     private final Map<String, MapPolyline> polylines = new LinkedHashMap<>();
     private final List<CameraPosition> cameraMoves = new ArrayList<>();
 
+    /** Z-index per marker, as {@link #setMarkerZIndex} was told. Decides draw order. */
+    private final Map<String, Float> raised = new LinkedHashMap<>();
+
+    /** The last padding asked for - see {@link #setPadding}. Null until something asks. */
+    private int[] padding;
+
     private View mapView;
     private MapStyle style;
     private int nextId = 0;
@@ -78,16 +86,45 @@ public class FakeMapProvider implements IMapProvider {
     // ------------------------------------------------------------------ IMapProvider
 
     /**
-     * Ready immediately, on the caller's thread.
+     * Ready immediately, on the caller's thread, with a view that actually draws.
      *
      * <p>A real provider calls back asynchronously once the map surface exists. Doing it
      * synchronously here removes a wait the test would otherwise have to guess at, and the
      * screen's own code path is identical either way - it only ever reacts to the callback.
+     *
+     * <p><b>The view is added to the container, as the real providers do.</b> Google's replaces
+     * that container with a {@code SupportMapFragment}; this puts a {@link FakeMapView} in it.
+     * Both container ids in this app - {@code R.id.map} and {@code R.id.history_map} - are
+     * {@code FrameLayout}s, so there is somewhere to put it. If there is not, nothing is added
+     * and everything else here still works: recording never depended on being on screen.
      */
     @Override
     public void initialize(
             final Activity activity, final int containerViewId, final OnMapReadyCallback callback) {
-        this.mapView = new View(activity);
+
+        // **A map starts empty, and this one has to as well.** The real factory builds a fresh
+        // provider for every screen, so nothing one screen drew can appear on the next. A test
+        // hands out a single instance instead - which is what lets it be asked what was drawn -
+        // and without this that instance carries its markers from screen to screen.
+        //
+        // It showed up as the tag pin from the map still sitting on the history screen,
+        // underneath that screen's own route. Nothing asserted on it, so nothing failed; it was
+        // visible only because the fake draws now. That is the same way a fake stops being
+        // useful as inventing marker ids was: plausible, quiet, and not what the app does.
+        this.markers.clear();
+        this.polylines.clear();
+        this.raised.clear();
+        this.cameraMoves.clear();
+
+        final FakeMapView drawn = new FakeMapView(activity, this);
+        this.mapView = drawn;
+
+        final View container = activity.findViewById(containerViewId);
+        if (container instanceof ViewGroup) {
+            ((ViewGroup) container).addView(drawn, new ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+        }
+
         this.ready = true;
 
         if (callback != null) {
@@ -95,9 +132,18 @@ public class FakeMapProvider implements IMapProvider {
         }
     }
 
+    /** Ask the drawn view to repaint, from whichever thread just changed something. */
+    private void redraw() {
+        final View drawn = this.mapView;
+        if (drawn != null) {
+            drawn.postInvalidateOnAnimation();
+        }
+    }
+
     @Override
     public void setMapStyle(final MapStyle mapStyle) {
         this.style = mapStyle;
+        this.redraw();
     }
 
     /**
@@ -120,45 +166,64 @@ public class FakeMapProvider implements IMapProvider {
                 : "unidentified-" + (this.nextId++);
 
         this.markers.put(id, new PlacedMarker(id, marker));
+        this.redraw();
         return id;
     }
 
     @Override
     public void removeMarker(final String markerId) {
         this.markers.remove(markerId);
+        this.raised.remove(markerId);
+        this.redraw();
     }
 
+    /**
+     * <b>Recorded, now that something draws.</b>
+     *
+     * <p>This used to do nothing, on the reasoning that nothing asserted stacking order and a
+     * fake with opinions is worse than a fake without. That held while the view was blank. It
+     * does not now: tags in one building overlap completely at anything but the closest zoom,
+     * which is exactly why the screen raises the selected one, and a fake that ignored it would
+     * draw the selected pin underneath whichever tag happened to be added last - and the
+     * screenshot would show the app failing to do the thing it does.
+     */
     @Override
     public void setMarkerZIndex(final String markerId, final float zIndex) {
-        // Recorded nowhere: nothing asserts stacking order, and pretending to model it would be
-        // a fake with opinions of its own.
+        this.raised.put(markerId, zIndex);
+        this.redraw();
     }
 
     @Override
     public void clearMarkers() {
         this.markers.clear();
+        this.raised.clear();
+        this.redraw();
     }
 
     @Override
     public String addPolyline(final MapPolyline polyline) {
         final String id = "polyline-" + (this.nextId++);
         this.polylines.put(id, polyline);
+        this.redraw();
         return id;
     }
 
     @Override
     public void removePolyline(final String polylineId) {
         this.polylines.remove(polylineId);
+        this.redraw();
     }
 
     @Override
     public void clearPolylines() {
         this.polylines.clear();
+        this.redraw();
     }
 
     @Override
     public void moveCamera(final double latitude, final double longitude, final float zoom) {
         this.cameraMoves.add(new CameraPosition(latitude, longitude, zoom));
+        this.redraw();
     }
 
     @Override
@@ -166,6 +231,7 @@ public class FakeMapProvider implements IMapProvider {
             final double latitude, final double longitude, final float zoom,
             final Runnable callback) {
         this.cameraMoves.add(new CameraPosition(latitude, longitude, zoom));
+        this.redraw();
         if (callback != null) {
             callback.run();
         }
@@ -179,8 +245,23 @@ public class FakeMapProvider implements IMapProvider {
     public void setOnMarkerClickListener(final OnMarkerClickListener listener) {
     }
 
+    /**
+     * <b>Recorded, because it is how the map keeps its content out from under the sheet.</b>
+     *
+     * <p>This used to be ignored. On a real map, padding shrinks the region the camera centres
+     * within - so the history screen tracks the bottom sheet with it, and a route or a marker
+     * is framed in the strip that is still visible rather than behind the list. Drop the
+     * padding and everything still draws; it just draws underneath the sheet, where the user
+     * cannot see it, and nothing anywhere reports a problem.
+     */
     @Override
     public void setPadding(final int left, final int top, final int right, final int bottom) {
+        this.padding = new int[] {left, top, right, bottom};
+    }
+
+    /** The last padding the screen asked for, as {left, top, right, bottom}. */
+    public int[] padding() {
+        return this.padding == null ? null : this.padding.clone();
     }
 
     @Override
@@ -210,10 +291,31 @@ public class FakeMapProvider implements IMapProvider {
     public void clear() {
         this.markers.clear();
         this.polylines.clear();
+        this.raised.clear();
+        this.redraw();
     }
 
     @Override
     public View getMapView() {
         return this.mapView;
+    }
+
+    // ------------------------------------------------------------------ what the eye sees
+
+    /** Markers in the order they should be painted: lowest z-index first, ties in add order. */
+    List<PlacedMarker> inDrawOrder() {
+        final List<PlacedMarker> ordered = new ArrayList<>(this.markers.values());
+        ordered.sort(Comparator.comparingDouble(
+                placed -> this.raised.getOrDefault(placed.id, placed.marker.getZIndex())));
+        return ordered;
+    }
+
+    /** Where the camera is, or a default nobody set - the same answer as an untouched map. */
+    CameraPosition whereTheCameraIs() {
+        return this.getCameraPosition();
+    }
+
+    List<MapPolyline> linesToDraw() {
+        return new ArrayList<>(this.polylines.values());
     }
 }

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/FakeMapView.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/FakeMapView.java
@@ -1,0 +1,235 @@
+package dev.wander.android.opentagviewer.ui.maps;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.util.TypedValue;
+import android.view.View;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Draws what {@link FakeMapProvider} was asked to place, so a screenshot shows something.
+ *
+ * <p><b>Why this exists.</b> The fake recorded markers and drew nothing, which is right for an
+ * assertion and useless for an eye. Every screenshot of the map screen was a white rectangle
+ * with the tag cards floating over it, and a run in slow motion - the thing somebody watches
+ * when they want to see the app work - showed cards sliding across a void. The pin is the whole
+ * point of that screen and it was the one thing not on it.
+ *
+ * <p><b>It is not a map, and it says so.</b> There is no tile source and there never will be:
+ * the managed device has no network worth relying on and no Play Services, and a fake that
+ * looked convincing would be worse than one that does not - somebody would eventually read a
+ * screenshot from a test as evidence about a real place. So: flat ground, a graticule, and a
+ * caption naming it as a fake along with the camera it was drawn from. A reader can tell at a
+ * glance both that this is synthetic and where the app thought it was looking.
+ *
+ * <p><b>The projection is honest about being crude.</b> Equirectangular around the camera,
+ * scaled the way web maps scale - 256 pixels per tile, doubling per zoom level. It is wrong in
+ * the way every flat projection is wrong, and at the zooms this app uses the error is far below
+ * a pixel. What it gets right is the part that matters here: two reports a hundred metres apart
+ * are drawn a hundred metres apart, so a pin in the wrong place looks wrong.
+ *
+ * <p><b>Nothing asserts on what this paints.</b> It is decoration for the human, and the
+ * assertions still read {@link FakeMapProvider#markers()}. That separation is deliberate - see
+ * the note in {@code AGENTS.md} about a screenshot not being an assertion - and it is why this
+ * class can be as rough as it likes without any test becoming a test of the fake.
+ */
+final class FakeMapView extends View {
+
+    /** Web-map convention: one 256px tile spans the world at zoom 0. */
+    private static final double TILE_SIZE = 256.0;
+
+    private static final float GRID_SPACING_DP = 48f;
+
+    private final FakeMapProvider provider;
+
+    private final Paint ground = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint grid = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint line = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint defaultPin = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint caption = new Paint(Paint.ANTI_ALIAS_FLAG);
+
+    FakeMapView(final Context context, final FakeMapProvider provider) {
+        super(context);
+        this.provider = provider;
+
+        // Resolved from the drawing context, not from fixed colours, so this follows the theme
+        // into dark mode and into a dynamic-colour scheme exactly as the pins themselves do.
+        final int ink = MarkerPalette.icon(context);
+
+        this.ground.setColor(MarkerPalette.fill(context));
+        this.ground.setStyle(Paint.Style.FILL);
+
+        this.grid.setColor(withAlpha(ink, 0x22));
+        this.grid.setStrokeWidth(dp(1));
+        this.grid.setStyle(Paint.Style.STROKE);
+
+        this.line.setStyle(Paint.Style.STROKE);
+        this.line.setStrokeCap(Paint.Cap.ROUND);
+        this.line.setStrokeJoin(Paint.Join.ROUND);
+
+        // The on-surface colour, which Material guarantees contrasts with the ground this is
+        // painted on - in either theme. The marker's own colour is deliberately not consulted.
+        this.defaultPin.setColor(ink);
+        this.defaultPin.setStyle(Paint.Style.FILL);
+
+        this.caption.setColor(withAlpha(ink, 0x99));
+        this.caption.setTextSize(dp(11));
+    }
+
+    @Override
+    protected void onDraw(final Canvas canvas) {
+        super.onDraw(canvas);
+
+        final IMapProvider.CameraPosition camera = this.provider.whereTheCameraIs();
+        final double pixelsPerDegree = TILE_SIZE * Math.pow(2, camera.getZoom()) / 360.0;
+
+        final float centreX = this.getWidth() / 2f;
+        final float centreY = this.getHeight() / 2f;
+
+        canvas.drawRect(0, 0, this.getWidth(), this.getHeight(), this.ground);
+        this.drawGraticule(canvas);
+        this.drawLines(canvas, camera, pixelsPerDegree, centreX, centreY);
+        this.drawPins(canvas, camera, pixelsPerDegree, centreX, centreY);
+        this.drawCaption(canvas, camera);
+    }
+
+    private void drawGraticule(final Canvas canvas) {
+        final float step = dp(GRID_SPACING_DP);
+
+        for (float x = 0; x < this.getWidth(); x += step) {
+            canvas.drawLine(x, 0, x, this.getHeight(), this.grid);
+        }
+        for (float y = 0; y < this.getHeight(); y += step) {
+            canvas.drawLine(0, y, this.getWidth(), y, this.grid);
+        }
+    }
+
+    private void drawLines(
+            final Canvas canvas, final IMapProvider.CameraPosition camera,
+            final double pixelsPerDegree, final float centreX, final float centreY) {
+
+        for (final MapPolyline polyline : this.provider.linesToDraw()) {
+            final List<MapPolyline.LatLng> points = polyline.getPoints();
+            if (points == null || points.size() < 2) {
+                continue;
+            }
+
+            this.line.setColor(polyline.getColor());
+            this.line.setStrokeWidth(Math.max(dp(2), polyline.getWidth()));
+
+            final Path path = new Path();
+            for (int i = 0; i < points.size(); i++) {
+                final float x = x(points.get(i).getLongitude(), camera, pixelsPerDegree, centreX);
+                final float y = y(points.get(i).getLatitude(), camera, pixelsPerDegree, centreY);
+
+                if (i == 0) {
+                    path.moveTo(x, y);
+                } else {
+                    path.lineTo(x, y);
+                }
+            }
+            canvas.drawPath(path, this.line);
+        }
+    }
+
+    private void drawPins(
+            final Canvas canvas, final IMapProvider.CameraPosition camera,
+            final double pixelsPerDegree, final float centreX, final float centreY) {
+
+        // Lowest first, so a raised marker lands on top - which is what the screen raises it for.
+        for (final FakeMapProvider.PlacedMarker placed : this.provider.inDrawOrder()) {
+            final MapMarker marker = placed.marker;
+            if (!marker.isVisible()) {
+                continue;
+            }
+
+            final float x = x(marker.getLongitude(), camera, pixelsPerDegree, centreX);
+            final float y = y(marker.getLatitude(), camera, pixelsPerDegree, centreY);
+
+            final Bitmap icon = marker.getIconBitmap();
+            if (icon != null) {
+                // Bottom-centre anchored, which is where a pin's point is - the same anchor the
+                // real providers use, so a pin drawn here sits over the same spot.
+                canvas.drawBitmap(icon, x - icon.getWidth() / 2f, y - icon.getHeight(), null);
+            } else {
+                this.drawDefaultPin(canvas, x, y);
+            }
+        }
+    }
+
+    /**
+     * A pin for a marker that brought no bitmap of its own.
+     *
+     * <p><b>Drawn as a pin rather than a dot, and never in the marker's own colour.</b> This used
+     * to be {@code drawCircle} in {@code marker.getMarkerColor()}, which reads as reasonable and
+     * is wrong twice over.
+     *
+     * <p>Wrong in shape: the app builds these with {@code useDefaultIcon(true)} - the history
+     * screen's {@code single_coord_marker} is the only one - and both real providers answer that
+     * with their own teardrop pin. A flat dot is not what the user sees, so a screenshot showing
+     * one is a screenshot of the fake rather than of the app.
+     *
+     * <p>And wrong in colour: {@code MapMarker}'s default {@code markerColor} is opaque black,
+     * which nothing ever sets for these markers, so every default pin came out black - on a dark
+     * theme, a black dot on a near-black ground. Present, correct, invisible, which is the exact
+     * failure mode {@code AGENTS.md} rule 12 lists.
+     */
+    private void drawDefaultPin(final Canvas canvas, final float x, final float y) {
+        final float radius = dp(7);
+        final float height = dp(22);
+
+        // A teardrop: a circle at the top, tapering to the point that sits on the coordinate.
+        final Path pin = new Path();
+        pin.addCircle(x, y - height + radius, radius, Path.Direction.CW);
+        pin.moveTo(x - radius * 0.8f, y - height + radius * 1.5f);
+        pin.lineTo(x, y);
+        pin.lineTo(x + radius * 0.8f, y - height + radius * 1.5f);
+        pin.close();
+
+        canvas.drawPath(pin, this.defaultPin);
+    }
+
+    /**
+     * Says what this is and where it is pointed.
+     *
+     * <p>Both halves earn their place. The first stops a screenshot being mistaken for evidence
+     * about a real location; the second is the thing that is otherwise invisible - a pin missing
+     * because the camera is over the wrong continent looks exactly like a pin that was never
+     * drawn, and this is the difference.
+     */
+    private void drawCaption(final Canvas canvas, final IMapProvider.CameraPosition camera) {
+        final float pad = dp(8);
+
+        canvas.drawText("FAKE MAP - nothing here is a real place", pad,
+                this.getHeight() - pad - this.caption.getTextSize() * 1.4f, this.caption);
+        canvas.drawText(String.format(Locale.ROOT, "camera %.5f, %.5f  z%.1f",
+                        camera.getLatitude(), camera.getLongitude(), camera.getZoom()),
+                pad, this.getHeight() - pad, this.caption);
+    }
+
+    private static float x(final double longitude, final IMapProvider.CameraPosition camera,
+                           final double pixelsPerDegree, final float centreX) {
+        return (float) (centreX + (longitude - camera.getLongitude()) * pixelsPerDegree);
+    }
+
+    private static float y(final double latitude, final IMapProvider.CameraPosition camera,
+                           final double pixelsPerDegree, final float centreY) {
+        // Minus, because latitude grows northward and screen y grows downward.
+        return (float) (centreY - (latitude - camera.getLatitude()) * pixelsPerDegree);
+    }
+
+    private static int withAlpha(final int colour, final int alpha) {
+        return Color.argb(alpha, Color.red(colour), Color.green(colour), Color.blue(colour));
+    }
+
+    private float dp(final float value) {
+        return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value,
+                this.getResources().getDisplayMetrics());
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/TagCardLayoutTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/TagCardLayoutTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -56,6 +57,21 @@ public class TagCardLayoutTest {
     private static final String SHORT_ADDRESS = "Amsterdam, Netherlands";
     private static final String LONG_ADDRESS =
             "Nieuwezijds Voorburgwal 147, 1012 RJ Amsterdam, Noord-Holland, Netherlands";
+
+    /**
+     * A real place, and about as long as a geocoded address gets.
+     *
+     * <p>Llanfairpwllgwyngyll's full name is the usual example and it is not a joke input: the
+     * address on a card comes from a geocoder, so its length is decided by where the tag is
+     * rather than by anything this app or its user chose. Somebody's card looks like this.
+     */
+    private static final String A_RIDICULOUS_ADDRESS =
+            "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch, "
+                    + "Ynys Môn, Wales, LL61 5UJ, United Kingdom";
+
+    /** And a name the user typed themselves, with no length limit on the field. */
+    private static final String A_RIDICULOUS_NAME =
+            "My absolutely enormous and unreasonably descriptive spare bicycle key tag";
 
     private Context context;
 
@@ -210,5 +226,321 @@ public class TagCardLayoutTest {
         assertFalse("tags_scroll_container must not clip to padding", rowClipsToPadding.get());
         assertFalse("tags_scrollable_area must not clip its children", areaClipsChildren.get());
         assertFalse("tags_scrollable_area must not clip to padding", areaClipsToPadding.get());
+    }
+
+    /**
+     * <b>The card is elevated, so something has to make room for its shadow.</b>
+     *
+     * <p>Only half the story is checkable here, and it is worth being explicit about which half.
+     * The elevation is in the layout; the room below it is <b>not</b> - {@code MapsActivity}
+     * calls {@code WindowPaddingUtil.insertUIBottomPadding} at runtime and the space comes from
+     * the navigation-bar inset. A freshly inflated layout therefore has zero bottom padding and
+     * always will, so asserting on it here fails for a reason that has nothing to do with the
+     * app. This test says the elevation exists and leaves the measurement to a test that has an
+     * activity to measure.
+     */
+    @Test
+    public void theCardIsElevatedSoItsShadowNeedsRoomBelow() {
+        final int[] elevation = {0};
+
+        getInstrumentation().runOnMainSync(() -> {
+            final FrameLayout card = (FrameLayout) LayoutInflater.from(this.context)
+                    .inflate(R.layout.maps_tag_card, null);
+            elevation[0] = Math.round(card.findViewById(R.id.tag_item_container).getElevation());
+        });
+
+        assertTrue("the card is no longer elevated, so the row's bottom inset and its"
+                + " clipToPadding settings are now protecting nothing", elevation[0] > 0);
+    }
+
+    // --- the width of a card, and the one behind it ----------------------------------------
+
+    /** The width {@code MapsActivity.updateBeaconCards} gives every card, in pixels. */
+    private static int cardWidthFor(final int screenWidth) {
+        return screenWidth - 80;
+    }
+
+    /**
+     * Lay out a row of cards the size the app makes them, and return each card's left edge.
+     *
+     * <p>Sized by the app's own rule rather than by a number chosen here, so this measures
+     * {@code updateBeaconCards} and not the test's opinion of it.
+     */
+    private List<Integer> measureLeftEdges(final CardSpec... specs) {
+        final List<Integer> edges = new ArrayList<>();
+
+        getInstrumentation().runOnMainSync(() -> {
+            final View activityMaps = LayoutInflater.from(this.context)
+                    .inflate(R.layout.activity_maps, null);
+            final ViewGroup row = activityMaps.findViewById(R.id.tags_scroll_container);
+
+            for (final CardSpec spec : specs) {
+                final FrameLayout card = (FrameLayout) LayoutInflater.from(this.context)
+                        .inflate(R.layout.maps_tag_card, null);
+                row.addView(card);
+
+                final ViewGroup.LayoutParams params = card.getLayoutParams();
+                params.width = cardWidthFor(SCREEN_WIDTH_PX);
+                params.height = spec.height;
+                card.setLayoutParams(params);
+
+                ((TextView) card.findViewById(R.id.device_name)).setText(spec.name);
+                ((TextView) card.findViewById(R.id.device_location)).setText(spec.address);
+                ((TextView) card.findViewById(R.id.device_last_update))
+                        .setText("Last Updated: 2 minutes ago");
+            }
+
+            activityMaps.measure(
+                    View.MeasureSpec.makeMeasureSpec(SCREEN_WIDTH_PX, View.MeasureSpec.EXACTLY),
+                    View.MeasureSpec.makeMeasureSpec(2400, View.MeasureSpec.EXACTLY));
+            activityMaps.layout(0, 0, SCREEN_WIDTH_PX, 2400);
+
+            // **Asked of the view, not reconstructed from offsets.** Adding the row's own
+            // padding to a child's getLeft() double-counts it - layout has already applied it -
+            // which put the second card 42px further right than it is and turned a passing
+            // layout into a failing assertion about the app.
+            final int[] atScreen = new int[2];
+            for (int i = 0; i < row.getChildCount(); i++) {
+                row.getChildAt(i).getLocationInWindow(atScreen);
+                edges.add(atScreen[0]);
+            }
+        });
+
+        return edges;
+    }
+
+    /**
+     * <b>The next card peeks, which is the only sign the row scrolls at all.</b>
+     *
+     * <p>There is no scrollbar and no arrow - {@code scrollbars="none"} - so a sliver of the
+     * card behind is the entire affordance. A card sized to the full width hides it, and a user
+     * with four tags sees one and no reason to think there are more.
+     */
+    @Test
+    public void thenextCardPeeksSoTheRowLooksScrollable() {
+        final List<Integer> edges = this.measureLeftEdges(
+                new CardSpec("Keys", SHORT_ADDRESS),
+                new CardSpec("Bike", SHORT_ADDRESS));
+
+        final int secondCardStartsAt = edges.get(1);
+        final int visible = SCREEN_WIDTH_PX - secondCardStartsAt;
+
+        assertTrue("the second card starts at " + secondCardStartsAt + " on a "
+                        + SCREEN_WIDTH_PX + "px screen, so nothing of it is visible and the row"
+                        + " gives no sign that it scrolls",
+                visible > 0);
+    }
+
+    /**
+     * <b>And it takes most of the width, so it is a card and not a column.</b>
+     *
+     * <p>Bounds either side. Too narrow and the address wraps to four lines; too wide and the
+     * peek above disappears. The numbers are loose on purpose - this is a guard against a
+     * change of an order of magnitude, not a pin on the current value.
+     */
+    @Test
+    public void thecardTakesMostOfTheScreenButNotAllOfIt() {
+        final int width = cardWidthFor(SCREEN_WIDTH_PX);
+
+        assertTrue("a card " + width + "px wide on a " + SCREEN_WIDTH_PX + "px screen is too"
+                + " narrow to read an address on", width > SCREEN_WIDTH_PX * 0.6);
+        assertTrue("a card " + width + "px wide leaves nothing of the next one showing",
+                width < SCREEN_WIDTH_PX);
+    }
+
+    /**
+     * <b>A very long street name does not change the card's shape.</b>
+     *
+     * <p>The case that keeps breaking: the address is the one field with no bound on its length,
+     * and it is filled in by a geocoder rather than by anything this app controls. If it can
+     * push the card wider, the peek goes and the row stops looking scrollable - and it happens
+     * only to whoever lives on a long street.
+     */
+    @Test
+    public void averyLongStreetNameDoesNotChangeTheCardsShape() {
+        final List<Integer> edges = this.measureLeftEdges(
+                new CardSpec("Keys", A_RIDICULOUS_ADDRESS),
+                new CardSpec("Bike", SHORT_ADDRESS));
+
+        final List<Integer> heights = this.measureHeights(
+                new CardSpec("Keys", A_RIDICULOUS_ADDRESS),
+                new CardSpec("Bike", SHORT_ADDRESS));
+
+        assertEquals("a long address made its card a different height", heights.get(0), heights.get(1));
+        assertTrue("a long address pushed the next card off the screen",
+                SCREEN_WIDTH_PX - edges.get(1) > 0);
+    }
+
+    /** The same for a name nobody sensible would use, which is to say the one somebody used. */
+    @Test
+    public void averyLongTagNameDoesNotChangeTheCardsShape() {
+        final List<Integer> edges = this.measureLeftEdges(
+                new CardSpec(A_RIDICULOUS_NAME, SHORT_ADDRESS),
+                new CardSpec("Bike", SHORT_ADDRESS));
+
+        assertTrue("a long tag name pushed the next card off the screen",
+                SCREEN_WIDTH_PX - edges.get(1) > 0);
+    }
+
+    // --- the two kinds of tag icon ---------------------------------------------------------
+
+    /**
+     * <b>An emoji tag and an icon tag are the same shape.</b>
+     *
+     * <p>Two different views in the same slot - a {@code TextView} at 36sp and an
+     * {@code ImageView} - swapped by visibility, and only one of them is ever on screen at a
+     * time. So a difference between them is invisible until somebody sets an emoji on one tag
+     * and not another, at which point the row goes ragged for that person only.
+     *
+     * <p><b>The emoji one is also the one that follows the font scale.</b> 36sp grows with the
+     * system text size and 53dp does not, so this is measured at the largest accessibility
+     * setting rather than the default - which is where they come apart, if they do.
+     */
+    @Test
+    public void anemojiTagAndAnIconTagAreTheSameShape() {
+        final List<Integer> heights = this.measureIconVariantHeights(1.0f);
+
+        assertEquals("an emoji tag and an icon tag should be the same height",
+                heights.get(0), heights.get(1));
+    }
+
+    /** And they stay the same shape when the system text is turned all the way up. */
+    @Test
+    public void theystayTheSameShapeAtTheLargestTextSize() {
+        final List<Integer> heights = this.measureIconVariantHeights(2.0f);
+
+        assertEquals("at 2x text scale the emoji tag and the icon tag came apart",
+                heights.get(0), heights.get(1));
+    }
+
+    /**
+     * Card heights for [emoji tag, icon tag], at a given system font scale.
+     *
+     * <p>Each card is measured on its own rather than side by side: in a row they are forced to
+     * a uniform height, which is exactly the mechanism that would hide a difference between
+     * them.
+     */
+    private List<Integer> measureIconVariantHeights(final float fontScale) {
+        final List<Integer> heights = new ArrayList<>();
+
+        getInstrumentation().runOnMainSync(() -> {
+            final Configuration scaled = new Configuration(
+                    this.context.getResources().getConfiguration());
+            scaled.fontScale = fontScale;
+
+            final Context scaledContext = new ContextThemeWrapper(
+                    this.context.createConfigurationContext(scaled), R.style.Theme_OpenTagViewer);
+
+            for (final boolean emoji : new boolean[] {true, false}) {
+                final FrameLayout card = (FrameLayout) LayoutInflater.from(scaledContext)
+                        .inflate(R.layout.maps_tag_card, null);
+
+                card.findViewById(R.id.device_icon_emoji)
+                        .setVisibility(emoji ? View.VISIBLE : View.GONE);
+                card.findViewById(R.id.device_icon_img)
+                        .setVisibility(emoji ? View.GONE : View.VISIBLE);
+
+                if (emoji) {
+                    ((TextView) card.findViewById(R.id.device_icon_emoji)).setText("🚲");
+                }
+
+                ((TextView) card.findViewById(R.id.device_name)).setText("Bike");
+                ((TextView) card.findViewById(R.id.device_location)).setText(SHORT_ADDRESS);
+                ((TextView) card.findViewById(R.id.device_last_update))
+                        .setText("Last Updated: 2 minutes ago");
+
+                card.measure(
+                        View.MeasureSpec.makeMeasureSpec(
+                                cardWidthFor(SCREEN_WIDTH_PX), View.MeasureSpec.EXACTLY),
+                        View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
+
+                heights.add(card.getMeasuredHeight());
+            }
+        });
+
+        return heights;
+    }
+
+    // --- the buttons along the bottom -------------------------------------------------------
+
+    /**
+     * <b>Every action that ships still has room, whatever the card is holding.</b>
+     *
+     * <p>History, Refresh and More share the bottom row, each carrying a label under an icon.
+     * They are what a longer address squeezes, because it sits directly above them and the
+     * card's height is fixed by its shortest neighbour - so the failure is a row of icons with
+     * the words clipped away, on one card out of four.
+     *
+     * <p><b>Ring is not among them, and that is deliberate.</b> Its container is
+     * {@code visibility="gone"} in the layout because the feature does not exist - FindMy.py has
+     * no ring implementation - so it measures nothing. Pinned separately below rather than
+     * quietly skipped here.
+     */
+    @Test
+    public void everyActionOnTheCardStillHasRoomWithTheWorstContent() {
+        final int[][] sizes = new int[3][2];
+        final int[] buttonIds = {
+                R.id.device_history_button_container,
+                R.id.device_refresh_button_container,
+                R.id.device_more_button_container,
+        };
+
+        getInstrumentation().runOnMainSync(() -> {
+            final FrameLayout card = (FrameLayout) LayoutInflater.from(this.context)
+                    .inflate(R.layout.maps_tag_card, null);
+
+            ((TextView) card.findViewById(R.id.device_name)).setText(A_RIDICULOUS_NAME);
+            ((TextView) card.findViewById(R.id.device_location)).setText(A_RIDICULOUS_ADDRESS);
+            ((TextView) card.findViewById(R.id.device_last_update))
+                    .setText("Last Updated: 2 minutes ago");
+
+            final int width = cardWidthFor(SCREEN_WIDTH_PX);
+            card.measure(
+                    View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+                    View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
+            card.layout(0, 0, width, card.getMeasuredHeight());
+
+            for (int i = 0; i < buttonIds.length; i++) {
+                final View button = card.findViewById(buttonIds[i]);
+                sizes[i][0] = button.getMeasuredWidth();
+                sizes[i][1] = button.getMeasuredHeight();
+            }
+        });
+
+        for (int i = 0; i < buttonIds.length; i++) {
+            assertTrue("button " + i + " measured " + sizes[i][0] + "x" + sizes[i][1]
+                    + ", so it is not on the card", sizes[i][0] > 0 && sizes[i][1] > 0);
+        }
+
+        // They share the row, so a card that has run out of width shows up as one of them being
+        // visibly smaller than the rest rather than as anything failing.
+        final int widest = Math.max(Math.max(sizes[0][0], sizes[1][0]), sizes[2][0]);
+        for (int i = 0; i < buttonIds.length; i++) {
+            assertTrue("button " + i + " is " + sizes[i][0] + "px against a widest of " + widest
+                            + ", so the row is no longer sharing the width evenly",
+                    sizes[i][0] > widest / 2);
+        }
+    }
+
+    /**
+     * <b>Ring is hidden, because there is nothing behind it.</b>
+     *
+     * <p>{@code onClickRing} logs and returns: FindMy.py cannot ring an accessory, so the
+     * control exists in the layout and is switched off. This is here so that stops being true
+     * on purpose rather than by accident - a stray edit making it visible ships a button that
+     * does nothing at all, which is worse than not offering it.
+     */
+    @Test
+    public void theRingButtonStaysHiddenWhileThereIsNothingBehindIt() {
+        final int[] visibility = {View.VISIBLE};
+
+        getInstrumentation().runOnMainSync(() -> {
+            final FrameLayout card = (FrameLayout) LayoutInflater.from(this.context)
+                    .inflate(R.layout.maps_tag_card, null);
+            visibility[0] = card.findViewById(R.id.device_ring_button_container).getVisibility();
+        });
+
+        assertEquals("Ring is showing, but nothing implements it - see MapsActivity#onClickRing",
+                View.GONE, visibility[0]);
     }
 }

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/TheMapSurvivesALanguageOrThemeChangeTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/TheMapSurvivesALanguageOrThemeChangeTest.java
@@ -1,0 +1,149 @@
+package dev.wander.android.opentagviewer.ui.maps;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.os.LocaleListCompat;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import dev.wander.android.opentagviewer.Eventually;
+
+/**
+ * Changing the language or the theme does not lose the map.
+ *
+ * <p><b>Both of these have broken this app before, and both break it the same way.</b>
+ * {@code AppCompatDelegate.setDefaultNightMode} and {@code setApplicationLocales} do not repaint
+ * anything - they <b>relaunch every activity in the process</b>. Whatever the map was holding in
+ * fields is gone, {@code onCreate} runs again from nothing, and anything that only ever ran on
+ * the first launch does not run.
+ *
+ * <p>It is a nasty class of failure because the code compiles, the setting works, and the screen
+ * comes back looking plausible - just without its pins, or its cards, or with a fetch that never
+ * happens again. Nobody exercises it either: a person changes their language once, on a device
+ * they have already set up, which is the state hardest to reach deliberately.
+ *
+ * <p><b>What is asserted is what the user would notice</b>: the tags are still on the map
+ * afterwards. Not that the theme changed - that is AppCompat's job and it has its own tests -
+ * but that this app is still standing on the other side of it.
+ *
+ * <p><b>The pins are counted through the provider, not read off the screen.</b> A relaunch
+ * builds a new activity against the same substituted provider, so what is being asked is "did
+ * the rebuilt screen draw its tags again", which is precisely the thing that stops happening.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class TheMapSurvivesALanguageOrThemeChangeTest {
+
+    private final AMapWithTagsOnIt theMap = new AMapWithTagsOnIt();
+
+    private int nightModeBefore;
+    private LocaleListCompat localesBefore;
+
+    @Before
+    public void openTheMapWithTwoTagsOnIt() {
+        this.nightModeBefore = AppCompatDelegate.getDefaultNightMode();
+        this.localesBefore = AppCompatDelegate.getApplicationLocales();
+
+        this.theMap.seed("Bike", "Keys").open();
+
+        Eventually.check(() -> assertTrue("the map never became ready",
+                this.theMap.map().isReady()));
+        Eventually.check(() -> assertEquals("the tags were never drawn to begin with",
+                2, this.theMap.map().markerCount()));
+    }
+
+    @After
+    public void putEverythingBack() {
+        // Restored before the fixture, because both of these relaunch activities and the
+        // fixture's teardown wants a settled process to close its scenario in.
+        getInstrumentation().runOnMainSync(() -> {
+            AppCompatDelegate.setDefaultNightMode(this.nightModeBefore);
+            AppCompatDelegate.setApplicationLocales(this.localesBefore);
+        });
+        getInstrumentation().waitForIdleSync();
+
+        this.theMap.putItBack();
+    }
+
+    /** <b>Switching to dark and the tags are still there.</b> */
+    @Test
+    public void thetagsAreStillOnTheMapAfterSwitchingToDark() {
+        this.switchNightModeTo(AppCompatDelegate.MODE_NIGHT_YES);
+
+        Eventually.check(() -> assertEquals(
+                "the map came back from a theme change without its pins",
+                2, this.theMap.map().markerCount()));
+    }
+
+    /**
+     * <b>And after switching back, which is a second relaunch on top of the first.</b>
+     *
+     * <p>Worth its own case: the second relaunch starts from a process that has already been
+     * through one, so anything that survived the first by luck - a static left initialised, a
+     * flag not reset - has a second chance to be caught.
+     */
+    @Test
+    public void andafterSwitchingBackToLight() {
+        this.switchNightModeTo(AppCompatDelegate.MODE_NIGHT_YES);
+        Eventually.check(() -> assertEquals(2, this.theMap.map().markerCount()));
+
+        this.switchNightModeTo(AppCompatDelegate.MODE_NIGHT_NO);
+
+        Eventually.check(() -> assertEquals(
+                "the map lost its pins on the way back to the light theme",
+                2, this.theMap.map().markerCount()));
+    }
+
+    /**
+     * <b>And changing the language, which relaunches for a different reason.</b>
+     *
+     * <p>A language change also re-resolves every string and drawable through a new
+     * configuration, so it catches things a theme change does not - a resource looked up once
+     * and cached in a static, for instance.
+     */
+    @Test
+    public void thetagsAreStillOnTheMapAfterChangingLanguage() {
+        this.switchLanguageTo("de");
+
+        Eventually.check(() -> assertEquals(
+                "the map came back from a language change without its pins",
+                2, this.theMap.map().markerCount()));
+    }
+
+    /** And the cards come back too, not only the pins. */
+    @Test
+    public void thetagCardsAreRebuiltAfterALanguageChange() {
+        this.switchLanguageTo("de");
+
+        Eventually.check(() -> assertTrue(
+                "the tag cards were not rebuilt after the screen was relaunched",
+                this.theMap.cards().size() >= 2));
+    }
+
+    // ------------------------------------------------------------------ the two switches
+
+    /**
+     * Change the theme the way the app does, and wait for the relaunch to settle.
+     *
+     * <p>On the main thread: {@code setDefaultNightMode} tears down and rebuilds activities, and
+     * doing that from the test thread races the rebuild it starts.
+     */
+    private void switchNightModeTo(final int mode) {
+        getInstrumentation().runOnMainSync(() -> AppCompatDelegate.setDefaultNightMode(mode));
+        getInstrumentation().waitForIdleSync();
+    }
+
+    private void switchLanguageTo(final String languageTag) {
+        getInstrumentation().runOnMainSync(() -> AppCompatDelegate.setApplicationLocales(
+                LocaleListCompat.forLanguageTags(languageTag)));
+        getInstrumentation().waitForIdleSync();
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/TheTagCarouselAlwaysSettlesOnOneCardTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/TheTagCarouselAlwaysSettlesOnOneCardTest.java
@@ -1,0 +1,158 @@
+package dev.wander.android.opentagviewer.ui.maps;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.swipeLeft;
+import static androidx.test.espresso.action.ViewActions.swipeRight;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.R;
+
+/**
+ * However the tag row is dragged, it ends up centred on exactly one card.
+ *
+ * <p><b>The property, not the mechanism.</b> {@code TagListSwiperHelper} decides where to settle
+ * from a scroll offset, a velocity threshold and the three cards nearest the middle - and every
+ * one of those has been wrong at some point. What a user notices is none of that: it is a row
+ * resting halfway between two cards, with neither readable and no indication which one the
+ * buttons underneath belong to. That is the thing worth pinning, and it survives the mechanism
+ * being rewritten.
+ *
+ * <p><b>It needs a real window.</b> The helper positions cards with {@code getLocationOnScreen}
+ * and settles on {@code ACTION_UP}, so nothing about it can be observed from a detached
+ * inflation - which is why this is an activity test where the layout tests next door are not.
+ *
+ * <p><b>Off-centre is measured in pixels, not asserted as an id.</b> "Which card is primary"
+ * has an answer even when the row is resting between two, because the helper picks the nearest;
+ * asking only that question would pass with the row visibly half-way. The distance from the
+ * row's middle to the nearest card's middle is the number that tells the truth.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class TheTagCarouselAlwaysSettlesOnOneCardTest {
+
+    /**
+     * How far off centre still counts as settled.
+     *
+     * <p>Generous on purpose. The row is around a thousand pixels wide and a card fills nearly
+     * all of it, so resting between two cards puts the nearest one hundreds of pixels out. This
+     * is not a pin on the exact resting position - it is the difference between "on a card" and
+     * "between cards", and a threshold tight enough to argue about would flake on a scroller
+     * that settles by animation.
+     */
+    private static final int SETTLED_WITHIN_PX = 60;
+
+    private final AMapWithTagsOnIt theMap = new AMapWithTagsOnIt();
+
+    @Before
+    public void openTheMapWithThreeTagsOnIt() {
+        this.theMap.seed("Bike", "Keys", "Backpack").open();
+
+        Eventually.check(() -> assertTrue("the map never became ready",
+                this.theMap.map().isReady()));
+        Eventually.check(() -> assertTrue("the cards were never built",
+                this.theMap.cards().size() >= 3));
+    }
+
+    @After
+    public void putEverythingBack() {
+        this.theMap.putItBack();
+    }
+
+    /** <b>It starts centred, before anybody touches it.</b> */
+    @Test
+    public void itstartsRestingOnACard() {
+        Eventually.check(() -> assertTrue(
+                "the row opened resting " + this.theMap.howFarOffCentreTheNearestCardIs()
+                        + "px off centre, so no card is squarely in view",
+                this.theMap.howFarOffCentreTheNearestCardIs() <= SETTLED_WITHIN_PX));
+    }
+
+    /** <b>A swipe moves it on, and it settles on the next card rather than between two.</b> */
+    @Test
+    public void aswipeSettlesOnTheNextCard() {
+        final int firstCardLeft = this.leftEdgeOfTheFirstCard();
+
+        onView(withId(R.id.tags_scrollable_area)).perform(swipeLeft());
+
+        Eventually.check(() -> assertTrue(
+                "after a swipe the row rested " + this.theMap.howFarOffCentreTheNearestCardIs()
+                        + "px off centre, so it stopped between two cards",
+                this.theMap.howFarOffCentreTheNearestCardIs() <= SETTLED_WITHIN_PX));
+
+        assertNotEquals("the swipe did not move the row at all",
+                firstCardLeft, this.leftEdgeOfTheFirstCard());
+    }
+
+    /** And swiping back settles too, rather than only working in the direction of travel. */
+    @Test
+    public void swipingBackSettlesAsWell() {
+        onView(withId(R.id.tags_scrollable_area)).perform(swipeLeft());
+        Eventually.check(() -> assertTrue(
+                this.theMap.howFarOffCentreTheNearestCardIs() <= SETTLED_WITHIN_PX));
+
+        onView(withId(R.id.tags_scrollable_area)).perform(swipeRight());
+
+        Eventually.check(() -> assertTrue(
+                "swiping back rested " + this.theMap.howFarOffCentreTheNearestCardIs()
+                        + "px off centre",
+                this.theMap.howFarOffCentreTheNearestCardIs() <= SETTLED_WITHIN_PX));
+    }
+
+    /**
+     * <b>And it still settles after being thrown about.</b>
+     *
+     * <p>Several gestures in a row, including one that runs into the end of the row. The end is
+     * where this has gone wrong before: there is no card beyond the last one to settle onto, so
+     * a rule written in terms of "the next card" has nothing to pick and the row is left
+     * wherever the fling stopped.
+     */
+    @Test
+    public void itsettlesEvenAfterBeingThrownAtTheEndOfTheRow() {
+        for (int i = 0; i < 4; i++) {
+            onView(withId(R.id.tags_scrollable_area)).perform(swipeLeft());
+        }
+
+        Eventually.check(() -> assertTrue(
+                "swiped past the last card, the row rested "
+                        + this.theMap.howFarOffCentreTheNearestCardIs() + "px off centre",
+                this.theMap.howFarOffCentreTheNearestCardIs() <= SETTLED_WITHIN_PX));
+
+        for (int i = 0; i < 6; i++) {
+            onView(withId(R.id.tags_scrollable_area)).perform(swipeRight());
+        }
+
+        Eventually.check(() -> assertTrue(
+                "swiped back past the first card, the row rested "
+                        + this.theMap.howFarOffCentreTheNearestCardIs() + "px off centre",
+                this.theMap.howFarOffCentreTheNearestCardIs() <= SETTLED_WITHIN_PX));
+    }
+
+    /** Where the first card sits, as a cheap way to tell whether the row moved at all. */
+    private int leftEdgeOfTheFirstCard() {
+        final List<android.view.View> cards = this.theMap.cards();
+        if (cards.isEmpty()) {
+            return Integer.MIN_VALUE;
+        }
+
+        final int[] at = new int[2];
+        final int[] found = {Integer.MIN_VALUE};
+        this.theMap.scenario().onActivity(activity -> {
+            cards.get(0).getLocationOnScreen(at);
+            found[0] = at[0];
+        });
+        return found[0];
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/settings/AfreshSignInIsNeverOfferedTheUpgradeTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/settings/AfreshSignInIsNeverOfferedTheUpgradeTest.java
@@ -1,0 +1,234 @@
+package dev.wander.android.opentagviewer.ui.settings;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import android.app.Instrumentation.ActivityResult;
+import android.content.Context;
+import android.os.SystemClock;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import dev.wander.android.opentagviewer.AppleLoginActivity;
+import dev.wander.android.opentagviewer.DeviceStateGuard;
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.MapsActivity;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.anisette.FakeAnisetteSource;
+import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
+import dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStore;
+import dev.wander.android.opentagviewer.db.repo.UserAuthRepository;
+import dev.wander.android.opentagviewer.db.repo.UserSettingsRepository;
+import dev.wander.android.opentagviewer.db.repo.model.UserSettings;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.python.FakeAppleAuthService;
+import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
+
+/**
+ * Somebody signing in today is never invited to migrate something they never had.
+ *
+ * <p><b>The Anisette upgrade offer is meant for upgraders and nobody else.</b> It fires on
+ * "signed in, but never chose an Anisette mode", which is a good proxy for "signed in before
+ * that setting existed" - better than a version check, because an install old enough to need
+ * the offer has no stored version to compare against either.
+ *
+ * <p><b>The proxy only holds because signing in records a mode</b>, and that is the part with no
+ * test. {@code AnisetteUpgradeDialogTest} covers the decision thoroughly - who is asked, who is
+ * not, that nobody is asked twice - but every one of those cases writes the settings by hand and
+ * then asks the function. None of them signs in. So the claim a new user actually depends on
+ * rests entirely on {@code recordHowThisSessionWasEstablished} being reached, and nothing would
+ * notice if it stopped being.
+ *
+ * <p><b>It is not a hypothetical failure.</b> A test fixture here produced exactly that state by
+ * writing a session without a mode, and the dialog duly opened over the map. In the app, that is
+ * a brand-new user being told their phone "can now do this itself" about a middleman they never
+ * used - and being offered a sign-out to fix it.
+ *
+ * <p>There is also a live way to reach it: {@code recordHowThisSessionWasEstablished} returns
+ * early when the local Anisette source is null, leaving the mode unset. Nothing can produce that
+ * today, and this test is what says so out loud.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class AfreshSignInIsNeverOfferedTheUpgradeTest {
+
+    private static final String EMAIL = "fresh-install@example.com";
+    private static final String PASSWORD = "hunter2";
+    private static final String CODE = "123456";
+
+    private Context context;
+    private FakeAppleAuthService apple;
+    private DeviceStateGuard deviceState;
+    private ActivityScenario<AppleLoginActivity> scenario;
+
+    @Before
+    public void startFromAnInstallNobodyHasEverSignedInOn() {
+        this.context = getInstrumentation().getTargetContext();
+        this.deviceState = DeviceStateGuard.capture(this.context);
+
+        signEverybodyOut();
+        this.forgetAnyAnisetteChoice();
+
+        this.apple = FakeAppleAuthService.wantsTwoFactor();
+        AppDependencies.replaceAuthService(this.apple);
+        AppDependencies.replaceAnisette(settings -> FakeAnisetteSource.ready());
+
+        // The map is answered at the door: it needs Play Services the managed device has not
+        // got, and what is under test finished before it would have started.
+        Intents.init();
+        intending(hasComponent(MapsActivity.class.getName()))
+                .respondWith(new ActivityResult(Activity.RESULT_OK, null));
+    }
+
+    @After
+    public void putEverythingBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        Intents.release();
+        AppDependencies.reset();
+
+        signEverybodyOut();
+        this.deviceState.restore();
+    }
+
+    /**
+     * <b>Signing in writes down how the session was established.</b>
+     *
+     * <p>The link the whole thing hangs on. Asserted on the stored settings rather than on the
+     * absence of a dialog, because "no dialog appeared" is also what a broken screen looks like.
+     */
+    @Test
+    public void signingInRecordsWhichAnisetteEstablishedTheSession() {
+        this.signIn();
+
+        Eventually.check(() -> assertNotNull(
+                "signing in did not record an Anisette mode, so the next time the map opens this"
+                        + " brand-new user will be offered the upgrade meant for people coming"
+                        + " from an older version",
+                this.storedSettings().getAnisetteMode()));
+    }
+
+    /** <b>And so the offer is not due, which is the thing the user would actually see.</b> */
+    @Test
+    public void andisThereforeNotOfferedTheUpgrade() {
+        this.signIn();
+
+        Eventually.check(() -> assertNotNull(this.storedSettings().getAnisetteMode()));
+
+        assertFalse("a fresh sign-in is due the upgrade offer, which is only for sessions made"
+                        + " before the Anisette setting existed",
+                this.storedSettings().shouldOfferLocalAnisette(true));
+    }
+
+    /**
+     * <b>And the case it <i>is</i> for still qualifies.</b>
+     *
+     * <p>The mirror, and it is what stops the test above being satisfiable by never offering the
+     * upgrade to anyone. A session with no recorded mode is exactly what an install from before
+     * the setting looks like, and that one is still asked.
+     */
+    @Test
+    public void butasessionFromBeforeTheSettingStillIs() {
+        this.signIn();
+        Eventually.check(() -> assertNotNull(this.storedSettings().getAnisetteMode()));
+
+        // Wound back to what an older version left behind: a working session, no mode.
+        final UserSettings asAnUpgraderHasIt = this.storedSettings();
+        asAnUpgraderHasIt.setAnisetteMode(null);
+        asAnUpgraderHasIt.setAnisetteUpgradeOffered(null);
+
+        assertTrue("somebody who signed in under an older version should still be offered the"
+                        + " move to local Anisette",
+                asAnUpgraderHasIt.shouldOfferLocalAnisette(true));
+    }
+
+    // ------------------------------------------------------------------ the sign-in
+
+    private void signIn() {
+        this.scenario = ActivityScenario.launch(AppleLoginActivity.class);
+
+        onView(withId(R.id.email_or_phone_input_field)).perform(replaceText(EMAIL));
+        onView(withId(R.id.password_input_field))
+                .perform(replaceText(PASSWORD), closeSoftKeyboard());
+
+        Eventually.perform("the sign in button", () -> this.apple.timesCalled("login") > 0,
+                () -> onView(withId(R.id.login_button_main)).perform(click()));
+
+        Eventually.check(() -> onView(withText(this.context.getString(
+                R.string.auth_by_sms_to_x, FakeAppleAuthService.PHONE_ONE))).perform(click()));
+
+        Eventually.check(() -> onView(withId(R.id.twofa_sent_info_text))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.twofactorauth_textinput_1)).perform(replaceText(CODE));
+
+        // The sign-in is finished when it hands over to the map, and not before - the settings
+        // are written on the way there.
+        Eventually.check(() -> intended(hasComponent(MapsActivity.class.getName())));
+    }
+
+    private UserSettings storedSettings() {
+        return new UserSettingsRepository(UserSettingsDataStore.getInstance(this.context))
+                .getUserSettings();
+    }
+
+    private void forgetAnyAnisetteChoice() {
+        final UserSettingsRepository settings = new UserSettingsRepository(
+                UserSettingsDataStore.getInstance(this.context));
+
+        final UserSettings blank = settings.getUserSettings();
+        blank.setAnisetteMode(null);
+        blank.setAnisetteUpgradeOffered(null);
+        settings.storeUserSettings(blank).blockingAwait();
+    }
+
+    /**
+     * Clear any stored session, and wait until it stays cleared.
+     *
+     * <p>Storing a session is the last step of a sign-in and runs on a background scheduler, so
+     * a single look can see an empty store that is about to be written to.
+     */
+    private static void signEverybodyOut() {
+        final UserAuthRepository auth = new UserAuthRepository(
+                UserAuthDataStore.getInstance(getInstrumentation().getTargetContext()),
+                new AppCryptographyUtil());
+
+        int consecutivelyEmpty = 0;
+
+        for (int attempt = 0; attempt < 40 && consecutivelyEmpty < 3; attempt++) {
+            if (auth.getUserAuth().blockingFirst().isEmpty()) {
+                consecutivelyEmpty++;
+            } else {
+                consecutivelyEmpty = 0;
+                auth.clearUser().blockingAwait();
+            }
+            SystemClock.sleep(50);
+        }
+
+        if (consecutivelyEmpty < 3) {
+            throw new IllegalStateException("a stored session kept coming back");
+        }
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/settings/DebugModeReachesEveryScreenTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/settings/DebugModeReachesEveryScreenTest.java
@@ -1,0 +1,269 @@
+package dev.wander.android.opentagviewer.ui.settings;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isPlatformPopup;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.Intent;
+import android.view.View;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import dev.wander.android.opentagviewer.DeviceInfoActivity;
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.HistoryViewActivity;
+import dev.wander.android.opentagviewer.MapsActivity;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.SettingsActivity;
+import dev.wander.android.opentagviewer.python.PythonAppleService;
+import dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStore;
+import dev.wander.android.opentagviewer.db.repo.UserSettingsRepository;
+import dev.wander.android.opentagviewer.ui.maps.AMapWithTagsOnIt;
+
+/**
+ * One switch in Settings, and the three unrelated screens that have to obey it.
+ *
+ * <p><b>A setting is only as good as the screens that read it, and each reads it separately.</b>
+ * {@code DeviceInfoActivity} toggles a block's visibility, {@code MapsActivity} decides whether
+ * to put an item in a menu, and {@code HistoryItemsAdapter} decides whether each row carries a
+ * second line. Three independent {@code getEnableDebugData() == Boolean.TRUE} checks, none of
+ * which knows about the others - so a change to how the setting is stored or read can leave one
+ * of them behind, and nothing complains.
+ *
+ * <p><b>Turning it off again is half the test, and the half that rots.</b> Showing something new
+ * gets noticed the moment somebody enables the setting; the hiding path only runs for people who
+ * change their mind, so a screen that shows debug output permanently once enabled can survive a
+ * long time. Every assertion here has its mirror.
+ *
+ * <p>The switch is driven rather than the value written, because the wire from the control to
+ * the stored setting is part of what is under test - {@code SettingsActivity} saves on change
+ * rather than on exit, and that is easy to break while tidying.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class DebugModeReachesEveryScreenTest {
+
+    private final AMapWithTagsOnIt theMap = new AMapWithTagsOnIt();
+
+    private Context context;
+    private ActivityScenario<?> screen;
+
+    @Before
+    public void seedATagAndStartFromDebugOff() {
+        this.context = getInstrumentation().getTargetContext();
+
+        this.theMap.seed("Bike");
+        this.setDebugTo(false);
+    }
+
+    @After
+    public void putEverythingBack() {
+        this.closeTheScreen();
+        // Restores the settings this overwrote, including the debug flag.
+        this.theMap.putItBack();
+    }
+
+    // ------------------------------------------------------------------ the journey
+
+    /**
+     * <b>On: the switch sticks, and all three screens start showing more.</b>
+     */
+    @Test
+    public void turningItOnReachesTheTagPageTheMapMenuAndTheHistoryRows() {
+        this.flipTheSwitchInSettings();
+
+        assertTrue("the switch did not reach the stored settings",
+                this.storedDebugSetting());
+
+        assertTrue("the tag page is not showing its debug block",
+                this.tagPageShowsItsDebugBlock());
+        assertTrue("Export Logs is missing from the map's menu",
+                this.mapMenuOffersExportLogs());
+        assertTrue("the history rows carry no extra detail",
+                this.historyRowsCarryExtraDetail());
+    }
+
+    /**
+     * <b>Off again: all three go back, which is the part nobody exercises by hand.</b>
+     */
+    @Test
+    public void turningItOffAgainTakesAllOfItAway() {
+        this.setDebugTo(true);
+
+        this.flipTheSwitchInSettings();
+
+        assertEquals("the switch did not turn the setting back off",
+                Boolean.FALSE, this.storedDebugSetting());
+
+        assertTrue("the tag page kept its debug block after debug mode was turned off",
+                !this.tagPageShowsItsDebugBlock());
+        assertTrue("Export Logs stayed in the map's menu after debug mode was turned off",
+                !this.mapMenuOffersExportLogs());
+        assertTrue("the history rows kept their extra detail after debug mode was turned off",
+                !this.historyRowsCarryExtraDetail());
+    }
+
+    // ------------------------------------------------------------------ each screen, asked
+
+    /** Open Settings, tap the debug switch, and let it save. */
+    private void flipTheSwitchInSettings() {
+        this.openTheScreen(SettingsActivity.class);
+
+        // No scrollTo: activity_settings has no ScrollView of any kind, so asking Espresso to
+        // scroll to a view inside it throws rather than doing nothing. The switch is on screen
+        // as soon as the page lays out.
+        Eventually.check(() -> onView(withId(R.id.settings_app_debug_data_enabled))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.settings_app_debug_data_enabled)).perform(click());
+
+        // Saved on change rather than on exit, and on a background scheduler - so the write is
+        // in flight when the click returns.
+        Eventually.check(() -> assertTrue("the setting never reached storage",
+                this.storedDebugSetting() != null));
+
+        this.closeTheScreen();
+    }
+
+    private boolean tagPageShowsItsDebugBlock() {
+        final Intent intent = new Intent(this.context, DeviceInfoActivity.class);
+        intent.putExtra("beaconId", this.theMap.tagIds().get(0));
+
+        this.screen = ActivityScenario.launch(intent);
+
+        final boolean[] shown = {false};
+        Eventually.check(() -> {
+            this.screen.onActivity(activity -> {
+                final View block = activity.findViewById(R.id.device_debug_info);
+                shown[0] = block != null && block.getVisibility() == View.VISIBLE;
+            });
+            // Asked once the screen has drawn something, so "not yet built" is not read as
+            // "deliberately hidden".
+            onView(withId(R.id.device_debug_info)).check(matches(
+                    shown[0] ? isDisplayed() : not(isDisplayed())));
+        });
+
+        this.closeTheScreen();
+        return shown[0];
+    }
+
+    /**
+     * Whether the map's overflow offers Export Logs.
+     *
+     * <p>Answered by looking for the item and catching its absence, because "not in the menu"
+     * is a missing view rather than a hidden one - {@code MapsActivity} calls
+     * {@code setVisible(false)} on the {@code MenuItem}, and a {@code PopupMenu} does not
+     * inflate a view for an invisible item at all.
+     */
+    private boolean mapMenuOffersExportLogs() {
+        this.screen = ActivityScenario.launch(new Intent(this.context, MapsActivity.class));
+
+        Eventually.check(() -> onView(withId(R.id.button_more_settings))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.button_more_settings)).perform(click());
+
+        boolean offered;
+        try {
+            onView(withText(R.string.export_logs)).inRoot(isPlatformPopup())
+                    .check(matches(isDisplayed()));
+            offered = true;
+        } catch (final RuntimeException | AssertionError absent) {
+            offered = false;
+        }
+
+        this.closeTheScreen();
+        return offered;
+    }
+
+    /**
+     * Whether a history row carries its second line.
+     *
+     * <p>Opened after the map, deliberately: {@code HistoryViewActivity} takes its Apple session
+     * from {@code PythonAppleService.getInstance()}, which only the map sets up, so launching it
+     * cold gives a screen that cannot fetch anything.
+     */
+    private boolean historyRowsCarryExtraDetail() {
+        // **Waited on the singleton, not on the map object.** The map is opened only to set up
+        // PythonAppleService, which HistoryViewActivity reads and cannot work without - and
+        // `theMap.map()` is non-null from the moment the fixture is built, so checking that
+        // let this close the map before it had set anything up. The history screen then had no
+        // service, its fetch failed, and the row count was zero for a reason nowhere near the
+        // setting under test.
+        this.screen = ActivityScenario.launch(new Intent(this.context, MapsActivity.class));
+        Eventually.check(() -> assertTrue("the map never set up the Python service",
+                PythonAppleService.getInstance() != null));
+        this.closeTheScreen();
+
+        final Intent intent = new Intent(this.context, HistoryViewActivity.class);
+        intent.putExtra("beaconId", this.theMap.tagIds().get(0));
+        this.screen = ActivityScenario.launch(intent);
+
+        final boolean[] shown = {false};
+        Eventually.check(() -> {
+            this.screen.onActivity(activity -> {
+                final View detail = activity.findViewById(R.id.history_item_location_detail);
+                shown[0] = detail != null && detail.getVisibility() == View.VISIBLE;
+            });
+            assertTrue("no history row was built at all, so there is nothing to look at",
+                    this.aHistoryRowExists());
+        });
+
+        this.closeTheScreen();
+        return shown[0];
+    }
+
+    private boolean aHistoryRowExists() {
+        final boolean[] any = {false};
+        this.screen.onActivity(activity -> {
+            final androidx.recyclerview.widget.RecyclerView list =
+                    activity.findViewById(R.id.recycler_view_history_items);
+            any[0] = list != null && list.getAdapter() != null
+                    && list.getAdapter().getItemCount() > 0;
+        });
+        return any[0];
+    }
+
+    // ------------------------------------------------------------------ plumbing
+
+    private void openTheScreen(final Class<?> activity) {
+        this.closeTheScreen();
+        this.screen = ActivityScenario.launch(new Intent(this.context, activity));
+    }
+
+    private void closeTheScreen() {
+        if (this.screen != null) {
+            this.screen.close();
+            this.screen = null;
+        }
+    }
+
+    private Boolean storedDebugSetting() {
+        return new UserSettingsRepository(UserSettingsDataStore.getInstance(this.context))
+                .getUserSettings()
+                .getEnableDebugData();
+    }
+
+    private void setDebugTo(final boolean enabled) {
+        final UserSettingsRepository settings = new UserSettingsRepository(
+                UserSettingsDataStore.getInstance(this.context));
+
+        final var current = settings.getUserSettings();
+        current.setEnableDebugData(enabled);
+        settings.storeUserSettings(current).blockingAwait();
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/util/rx/ScanOrderTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/util/rx/ScanOrderTest.java
@@ -36,6 +36,16 @@ public class ScanOrderTest {
         return new ScanOrder.Candidate(id, false, false);
     }
 
+    /** Never scanned, but the export said when macOS last saw it. */
+    private static ScanOrder.Candidate neverScannedButObserved(
+            final String id, final long observedAtMillis) {
+        return new ScanOrder.Candidate(id, false, false, observedAtMillis);
+    }
+
+    private static final long JANUARY = 1_704_067_200_000L;   // 2024-01-01
+    private static final long JUNE = 1_719_792_000_000L;      // 2024-07-01
+    private static final long DECEMBER = 1_735_689_600_000L;  // 2025-01-01
+
     /** <b>Tags that answered last time come first.</b> They are cheap and they change the screen. */
     @Test
     public void tagsThatAnsweredGoBeforeTagsThatDidNot() {
@@ -130,5 +140,103 @@ public class ScanOrderTest {
     @Test
     public void anemptyBatchIsAnEmptyOrder() {
         assertTrue(ScanOrder.forScheduledFetch(List.of(), new Random(1)).isEmpty());
+    }
+
+    // --- what the export knows, on a first import ------------------------------------------
+
+    /**
+     * <b>The most recently observed tag is asked about first.</b>
+     *
+     * <p>The whole point of reading the alignment record. A tag macOS saw last week has a key
+     * window of a hundred or so indices; one it last saw a year ago has tens of thousands, and
+     * Apple takes about 290 keys per request. Asking in this order is the difference between a
+     * pin appearing in seconds and an empty map for minutes.
+     */
+    @Test
+    public void themostRecentlyObservedTagIsAskedAboutFirst() {
+        final List<String> order = ScanOrder.forScheduledFetch(List.of(
+                neverScannedButObserved("old", JANUARY),
+                neverScannedButObserved("newest", DECEMBER),
+                neverScannedButObserved("middling", JUNE)),
+                new Random(1));
+
+        assertEquals(List.of("newest", "middling", "old"), order);
+    }
+
+    /**
+     * <b>Tags the export knew nothing about go behind the ones it did.</b>
+     *
+     * <p>No alignment record means the search starts at the pairing date and covers the tag's
+     * whole life, which is the most expensive thing in the batch. Putting those first would
+     * spend the user's first minute on the one tag least likely to answer quickly.
+     */
+    @Test
+    public void tagsWithNoAlignmentRecordGoBehindTheOnesThatHaveOne() {
+        final List<String> order = ScanOrder.forScheduledFetch(List.of(
+                neverScanned("unknown-one"),
+                neverScannedButObserved("observed", JANUARY),
+                neverScanned("unknown-two")),
+                new Random(1));
+
+        assertEquals("a tag with an alignment record should be asked about first",
+                "observed", order.get(0));
+        assertTrue(order.containsAll(List.of("unknown-one", "unknown-two")));
+    }
+
+    /**
+     * <b>And they are still shuffled among themselves.</b>
+     *
+     * <p>The reason the original group was shuffled at all, and it survives the change: the
+     * batch is sequential and routinely abandoned, so a fixed order among the expensive tags
+     * would leave the same one permanently last and therefore permanently unscanned. Ordering
+     * the groups is fine; ordering within the last group is not.
+     */
+    @Test
+    public void tagsWithNoAlignmentAreNotAlwaysInTheSameOrder() {
+        final Set<String> everFirst = new HashSet<>();
+
+        for (int seed = 0; seed < 50; seed++) {
+            final List<String> order = ScanOrder.forScheduledFetch(List.of(
+                    neverScanned("a"), neverScanned("b"), neverScanned("c")),
+                    new Random(seed));
+            everFirst.add(order.get(0));
+        }
+
+        assertTrue("the unaligned tags are in a fixed order, so one of them is always last and"
+                + " never gets scanned at all", everFirst.size() > 1);
+    }
+
+    /**
+     * <b>A real scan still beats anything a file says.</b>
+     *
+     * <p>The alignment date is evidence about cost, not about whether the tag answers. Once
+     * there has been an actual fetch, that is better evidence - so a tag known to be answering
+     * goes first even if its record is ancient, and a tag known to be silent goes last even if
+     * its record is fresh.
+     */
+    @Test
+    public void alignmentOnlyDecidesAnythingForTagsNobodyHasScannedYet() {
+        final List<String> order = ScanOrder.forScheduledFetch(List.of(
+                new ScanOrder.Candidate("silent-but-freshly-aligned", true, false, DECEMBER),
+                neverScannedButObserved("never-scanned", JUNE),
+                new ScanOrder.Candidate("answering-but-ancient", true, true, JANUARY)),
+                new Random(1));
+
+        assertEquals(List.of(
+                "answering-but-ancient", "never-scanned", "silent-but-freshly-aligned"), order);
+    }
+
+    /** And nothing is lost or duplicated by the extra bucket. */
+    @Test
+    public void everyTagIsStillAskedAboutExactlyOnceWithAlignmentInPlay() {
+        final List<String> order = ScanOrder.forScheduledFetch(List.of(
+                answering("a"), silent("b"),
+                neverScanned("c"), neverScannedButObserved("d", JUNE),
+                neverScannedButObserved("e", JANUARY)),
+                new Random(7));
+
+        assertEquals(5, order.size());
+        assertEquals(5, new HashSet<>(order).size());
+        assertTrue(order.containsAll(List.of("a", "b", "c", "d", "e")));
     }
 }

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -23,6 +23,36 @@
             android:exported="false"
             android:theme="@style/Theme.OpenTagViewer" />
 
+        <!--
+            Something for a "navigate to this tag" intent to resolve to, in debug builds only.
+
+            **Without it that path cannot be tested at all on the managed device.** aosp-atd
+            carries no maps application of any kind, so `resolveActivity` for a geo: link
+            correctly finds nothing and the app shows its "no app can open a map" message
+            instead of sending the intent. The test then sees no intent and cannot tell "the
+            button is broken" from "this device has no maps app".
+
+            It also exercises the fix it belongs to. MapsActivity used to name
+            com.google.android.apps.maps explicitly, and from Android 11 an app cannot see a
+            package it has not declared in <queries> - so resolveActivity returned null on
+            every current device, with or without Google Maps, and the button silently did
+            nothing. This activity is only visible to the app because of the geo: <queries>
+            entry in the main manifest; delete that entry and the test goes red.
+
+            Debug source set, not androidTest, for the same reason as TestHostActivity above:
+            an activity declared in the instrumentation manifest belongs to the test package.
+        -->
+        <activity
+            android:name="dev.wander.android.opentagviewer.ui.maps.SomewhereToNavigateTo"
+            android:exported="true"
+            android:theme="@style/Theme.OpenTagViewer">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="geo" />
+            </intent-filter>
+        </activity>
+
     </application>
 
 </manifest>

--- a/app/src/debug/java/dev/wander/android/opentagviewer/ui/maps/SomewhereToNavigateTo.java
+++ b/app/src/debug/java/dev/wander/android/opentagviewer/ui/maps/SomewhereToNavigateTo.java
@@ -1,0 +1,29 @@
+package dev.wander.android.opentagviewer.ui.maps;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+/**
+ * An activity that claims to open {@code geo:} links, so a test has something to navigate to.
+ *
+ * <p>It does nothing and shows nothing - it exists to be <i>resolvable</i>. The managed device
+ * has no maps application at all, so without it {@code MapsActivity#onClickNavigateTo} correctly
+ * finds no handler and shows its "no app can open a map" message, and a test watching for the
+ * intent cannot tell that apart from the button being broken.
+ *
+ * <p>It is also the only thing that proves the {@code <queries>} entry for {@code geo:} works:
+ * from Android 11 the app cannot see a package it has not declared, so with that entry removed
+ * this activity becomes invisible to {@code resolveActivity} and the test fails - which is
+ * exactly the bug it was added for.
+ *
+ * <p>Debug builds only. It is never started in a test either, because Espresso stubs the intent
+ * before it can be.
+ */
+public class SomewhereToNavigateTo extends Activity {
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        this.finish();
+    }
+}

--- a/app/src/debug/python/apple_test_double.py
+++ b/app/src/debug/python/apple_test_double.py
@@ -70,12 +70,35 @@ class _FakeAccessory:
 
     def __init__(self, beaconId: str) -> None:
         self._id = beaconId
+        #: Every ``(timestamp, index)`` the ranged fetch fed back in, so a test can ask whether
+        #: alignment was maintained rather than only whether reports came out.
+        self.alignedAt: list[tuple[Any, int]] = []
 
     def get_min_index(self, _dt: Any) -> int:
         return 0
 
     def get_max_index(self, _dt: Any) -> int:
         return 96  # a day of keys, at one every fifteen minutes
+
+    def keys_between(self, _start: Any, _end: Any) -> list[tuple[int, str]]:
+        """
+        The ``(index, key)`` pairs a ranged fetch searches.
+
+        **The history screen cannot be reached without this.** ``getLastReports`` asks the
+        account for a location; ``getReports`` does not - it generates the window's keys itself
+        and asks for *those*, because 0.9.x's ``fetch_location_history(accessory)`` ignores any
+        range it is given. So a double with no ``keys_between`` sends every history fetch down
+        ``_keysForRange``'s except branch, which returns an empty list and reports the day as
+        genuinely empty. Which is the shape of the bug that path exists to fix, arriving from
+        the test double instead.
+
+        Four keys rather than one: ``_fetchChunkAndAlign`` maps reports back to indices through
+        the key they arrived under, and a single-key window would let a mix-up there pass.
+        """
+        return [(index, f"key-{self._id}-{index}") for index in range(4)]
+
+    def update_alignment(self, timestamp: Any, index: int) -> None:
+        self.alignedAt.append((timestamp, index))
 
     def to_json(self) -> dict[str, Any]:
         return {"type": "accessory", "id": self._id}
@@ -86,6 +109,9 @@ class _FakeAccount:
 
     def __init__(self) -> None:
         self.fetchedFor: list[str] = []
+        #: Ranged fetches, counted separately - the history screen is the only caller, and
+        #: "did the day's fetch happen at all" is a different question from "did any fetch".
+        self.rangedFetches: int = 0
 
     # `main` only ever reads this to decide whether a restore succeeded, and only inside the
     # real getAccount - which is replaced. Present so anything else that looks is not surprised.
@@ -99,8 +125,22 @@ class _FakeAccount:
         self.fetchedFor.append(getattr(accessory, "_id", "?"))
         return list(_reports)
 
-    def fetch_location_history(self, accessory: Any) -> list[_FakeReport]:
-        self.fetchedFor.append(getattr(accessory, "_id", "?"))
+    def fetch_location_history(self, accessoryOrKeys: Any) -> Any:
+        """
+        **Two callers, two argument types, two return types** - which is FindMy.py's shape, not
+        an invention here. ``_fetchReportsForAccessory`` passes the accessory and expects a list
+        of reports; ``_fetchChunkAndAlign`` passes a list of plain keys and expects a dict of
+        key to reports. A double that answered only the first looks correct and turns every
+        history fetch into an exception the screen reports as a failed day.
+        """
+        if isinstance(accessoryOrKeys, list):
+            self.rangedFetches += 1
+            # All under the first key. Which key carries them does not matter to the caller,
+            # but it must be one `keys_between` handed out, or the index lookup that follows
+            # finds nothing and alignment is silently never updated.
+            return {accessoryOrKeys[0]: list(_reports)} if accessoryOrKeys else {}
+
+        self.fetchedFor.append(getattr(accessoryOrKeys, "_id", "?"))
         return list(_reports)
 
 
@@ -159,6 +199,28 @@ def installWithNothingToReport() -> None:
     _reports = []
 
 
+def clearReports() -> None:
+    """Forget what the fetches return, leaving the account restorable. Pairs with `reportAt`."""
+    global _reports
+
+    _reports = []
+
+
+def reportAt(unixMs: int, latitude: float, longitude: float) -> None:
+    """
+    Add one report at an exact moment, rather than at an offset from now.
+
+    **The history screen is why this takes an absolute time.** It asks for one local day at a
+    time, so "two hours ago" lands on yesterday for anybody running the suite shortly after
+    midnight - a test that passes all day and fails at 00:30 for reasons that have nothing to
+    do with the app. The caller knows which day it means; it says so.
+    """
+    _reports.append(_FakeReport(
+        timestamp=datetime.fromtimestamp(unixMs / 1000, tz=timezone.utc),
+        latitude=latitude,
+        longitude=longitude))
+
+
 def uninstall() -> None:
     """Put the real functions back. Safe to call without a matching install."""
     global theAccount, _reports
@@ -174,3 +236,14 @@ def uninstall() -> None:
 def howManyFetches() -> int:
     """How many accessories were fetched for, for a test to assert on from Java."""
     return 0 if theAccount is None else len(theAccount.fetchedFor)
+
+
+def howManyRangedFetches() -> int:
+    """
+    How many requests the ranged path made - the history screen's, and nothing else's.
+
+    Separate from :func:`howManyFetches` because the two say different things, and only this
+    one distinguishes "the day was searched and Apple had nothing" from "the day was never
+    searched". The screen renders both as an empty list.
+    """
+    return 0 if theAccount is None else theAccount.rangedFetches

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,22 @@
             <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="https" />
         </intent>
+        <!--
+            Maps applications, so "navigate to this tag" can find one.
+
+            Without this the app cannot see any package that handles geo:, and on Android 11
+            and up that is not a permission error - resolveActivity simply returns null, as
+            though nothing on the phone could open a map. The button then did nothing at all
+            and logged, which is indistinguishable from a tag having no location.
+
+            It applied to every device on Android 11 or newer, Google Maps installed or not,
+            because package visibility hid the target package too - so naming it explicitly
+            could not have worked either. See MapsActivity#onClickNavigateTo.
+        -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="geo" />
+        </intent>
     </queries>
 
     <application

--- a/app/src/main/java/dev/wander/android/opentagviewer/FetchFromICloudActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/FetchFromICloudActivity.java
@@ -36,6 +36,7 @@ import dev.wander.android.opentagviewer.python.icloud.ICloudFailure;
 import dev.wander.android.opentagviewer.python.icloud.ICloudFetch;
 import dev.wander.android.opentagviewer.python.icloud.ICloudService;
 import dev.wander.android.opentagviewer.python.icloud.KeychainMembership;
+import dev.wander.android.opentagviewer.python.PythonLock;
 import dev.wander.android.opentagviewer.python.icloud.RecoverableDevice;
 import dev.wander.android.opentagviewer.ui.RecoverableDeviceIcon;
 import dev.wander.android.opentagviewer.ui.login.StepTransition;
@@ -84,6 +85,13 @@ public class FetchFromICloudActivity extends AppCompatActivity {
     private List<RecoverableDevice> devices = List.of();
 
     private RecoverableDevice chosenDevice;
+
+    /**
+     * Whether a passcode is currently being tried against Apple.
+     *
+     * <p>The one state this screen refuses to be left from - see {@link #onBackWithin}.
+     */
+    private boolean anUnlockIsInFlight;
 
     /**
      * Which attempt the next press will be, starting at 1.
@@ -165,7 +173,24 @@ public class FetchFromICloudActivity extends AppCompatActivity {
      */
     private void onBackWithin() {
         if (this.isShowing(R.id.icloud_loading_container)) {
-            Log.d(TAG, "Back pressed while a call was in flight; ignoring");
+            // **Only an unlock is worth trapping somebody for.** Swallowing every back press
+            // while the loading step was up meant that a screen waiting on PythonLock - which a
+            // first import holds for minutes, walking key indices for tags with no alignment -
+            // could not be left at all. Neither the in-app arrow nor the device's own back
+            // button did anything, and the wait looked like a hang.
+            //
+            // An unlock attempt is different: it is already talking to Apple, and attempts are
+            // probably a limited resource on their end, so abandoning one mid-flight risks
+            // spending it for nothing. Everything else here - opening the session, listing
+            // recovery options, importing - is safe to walk away from, and onDestroy closes the
+            // session behind us.
+            if (this.anUnlockIsInFlight) {
+                Log.d(TAG, "Back pressed during an unlock attempt; ignoring");
+                return;
+            }
+
+            Log.d(TAG, "Back pressed while waiting; leaving rather than trapping the user");
+            this.finish();
             return;
         }
 
@@ -194,7 +219,17 @@ public class FetchFromICloudActivity extends AppCompatActivity {
 
     /** Open a session and ask what the keychain can be recovered from. */
     private void start() {
-        this.showWaiting(R.string.icloud_loading_looking_for_devices);
+        // **Not "looking for a device", because at this point that is not what is happening -
+        // and for most people it never will be.** Whether a device is needed at all is decided
+        // by the membership check further down: an app that has already joined resumes as the
+        // member it is and never sees the device list. Saying otherwise up front tells somebody
+        // who just linked their account that the app is hunting for hardware to unlock with,
+        // when the thing it is actually waiting for is its turn to talk to Python.
+        //
+        // askForADevice() sets that message, at the point it becomes true.
+        this.showWaiting(PythonLock.isBusy()
+                ? R.string.icloud_loading_waiting_for_location_check
+                : R.string.icloud_loading_opening_account);
 
         if (this.icloud != null) {
             this.icloud.close();
@@ -333,11 +368,16 @@ public class FetchFromICloudActivity extends AppCompatActivity {
         // to use it. So the membership is written before the fetch, and a failure to write stops
         // the flow rather than being logged past: carrying on would leave them with a peer this
         // app can neither use nor clean up, and nothing on screen to say so.
+        // Held from here until the chain settles, whichever way it goes - this is the one
+        // stretch the user is deliberately not allowed to walk out of. See onBackWithin.
+        this.anUnlockIsInFlight = true;
+
         var async = this.icloud.unlock(this.chosenDevice.getSerial(), passcode)
                 .andThen(this.icloud.join(EscrowPasscode.generate()))
                 .flatMapCompletable(this.membershipRepo::store)
                 .andThen(this.icloud.fetch())
                 .observeOn(AndroidSchedulers.mainThread())
+                .doFinally(() -> this.anUnlockIsInFlight = false)
                 .subscribe(this::importEverything, this::onUnlockFailed);
     }
 

--- a/app/src/main/java/dev/wander/android/opentagviewer/HistoryViewActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/HistoryViewActivity.java
@@ -9,7 +9,6 @@ import static com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_
 
 import android.annotation.SuppressLint;
 import android.content.Intent;
-import android.location.Geocoder;
 import android.os.Bundle;
 import android.text.format.DateFormat;
 import android.util.Log;
@@ -83,9 +82,11 @@ import dev.wander.android.opentagviewer.db.repo.model.UserSettings;
 import dev.wander.android.opentagviewer.db.room.OpenTagViewerDatabase;
 import dev.wander.android.opentagviewer.db.room.entity.DailyHistoryFetchRecord;
 import dev.wander.android.opentagviewer.db.util.BeaconCombinerUtil;
+import dev.wander.android.opentagviewer.python.AppDependencies;
 import dev.wander.android.opentagviewer.python.PythonAppleService;
 import dev.wander.android.opentagviewer.ui.compat.WindowPaddingUtil;
 import dev.wander.android.opentagviewer.ui.history.HistoryItemsAdapter;
+import dev.wander.android.opentagviewer.util.android.AddressLookup;
 import dev.wander.android.opentagviewer.util.parse.BeaconDataParser;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Completable;
@@ -114,7 +115,7 @@ public class HistoryViewActivity extends AppCompatActivity implements IMapProvid
     private UserSettingsRepository userSettingsRepo;
     private PythonAppleService appleService;
 
-    private Geocoder geocoder = null;
+    private AddressLookup geocoder = null;
 
     private UserSettings userSettings;
 
@@ -168,7 +169,8 @@ public class HistoryViewActivity extends AppCompatActivity implements IMapProvid
 
         this.appleService = PythonAppleService.getInstance();
 
-        this.geocoder = new Geocoder(this.getApplicationContext(), Locale.getDefault());
+        this.geocoder = AppDependencies.geocoder(
+                this.getApplicationContext(), Locale.getDefault());
 
         this.userSettings = this.userSettingsRepo.getUserSettings();
 
@@ -380,49 +382,51 @@ public class HistoryViewActivity extends AppCompatActivity implements IMapProvid
         var asyncReq = this.beaconRepo.toAccessoryRequests(reqData)
                 .flatMap(requests -> this.appleService.getReportsBetween(requests, beginningOfDay, endOfDay));
 
-        final long now = System.currentTimeMillis();
-        if (beginningOfDay < now - SEVEN_DAYS_IN_MS) {
-            // we have a small issue here: the api does not seem to return data older than 7 days.
-            // so if we are trying to fetch anything older than 7 days,
-            // try to retrieve it from our local DB/cache, too.
+        // **What Apple returns is merged with what we already hold, for every day.**
+        //
+        // This used to merge only for days older than a week, on the reasoning that Apple stops
+        // serving history beyond seven days so the local copy is the only source there. True,
+        // and it left the far more common case wrong: inside the week the screen took the
+        // remote answer alone and discarded rows already in the database.
+        //
+        // Those rows are not stale duplicates - they are reports this app fetched and stored,
+        // often minutes earlier from the map. Apple returning nothing for a window is ordinary:
+        // reports age out, and a narrow key window covers less than the day being asked for. So
+        // a tag the map had just located showed an empty history, and going back a day and
+        // returning made reports appear - which is exactly the behaviour that got reported.
+        //
+        // Merging always is strictly better: the remote answer is still authoritative and still
+        // stored, combineAndSort de-duplicates by report, and the only difference is that
+        // reports the app already had stop being thrown away.
+        var asyncDB = this.beaconRepo.getLocationsFor(beaconId, beginningOfDay, endOfDay);
 
-            var asyncDB = this.beaconRepo.getLocationsFor(beaconId, beginningOfDay, endOfDay);
+        Log.d(TAG, "Going to perform a merged localdb + remote fetch for beaconId=" + beaconId
+                + " location data in range: " + beginningOfDay + "-" + endOfDay);
 
-            Log.d(TAG, "Going to perform a merged localdb + remote fetch for beaconId=" + beaconId + " location data in range: " + beginningOfDay + "-" + endOfDay);
-            return Observable.zip(
-                            // try to fetch remotely anyways and combine uniquely later
-                            asyncReq.flatMap(this.beaconRepo::storeFetchResult).map(locations -> locations.get(beaconId)),
-                            // also try to fetch from DB for same time range
-                            asyncDB,
-                            (locationsRemote, locationsLocal) -> {
-                                Log.d(TAG, "Got " + locationsRemote.size() + " locations from Apple server and got " + locationsLocal.size() + " locations from local DB for beaconId" + beaconId);
+        return Observable.zip(
+                        asyncReq.flatMap(this.beaconRepo::storeFetchResult)
+                                .map(locations -> locations.get(beaconId)),
+                        asyncDB,
+                        (locationsRemote, locationsLocal) -> {
+                            Log.d(TAG, "Got " + locationsRemote.size() + " locations from Apple"
+                                    + " server and got " + locationsLocal.size() + " locations"
+                                    + " from local DB for beaconId" + beaconId);
 
-                                // merge both lists for unique events
-                                var mergedList = BeaconCombinerUtil.combineAndSort(beaconId, locationsRemote, locationsLocal);
-                                Log.d(TAG, "Final merged location history list has " + mergedList.size() + " items!");
+                            var mergedList = BeaconCombinerUtil.combineAndSort(
+                                    beaconId, locationsRemote, locationsLocal);
+                            Log.d(TAG, "Final merged location history list has "
+                                    + mergedList.size() + " items!");
 
-                                return mergedList;
-                            }).doOnNext(locations -> {
-                        // Don't cache the current day (it could still update)!
-                        if (!isForToday) {
-                            MEMORY_REPORTS_CACHE.put(cacheKey, locations);
-                        }
-                    })
-                    .flatMap(locations -> this.storeLocationFetchToLocalDb(isForToday, beaconId, beginningOfDay).andThen(Observable.just(locations)))
-                    .subscribeOn(Schedulers.computation()); // cache this combination, there will be no more updates at this point
-        }
-
-        Log.d(TAG, "Going to perform a fresh fetch for beaconId=" + beaconId + " location data in range: " + beginningOfDay + "-" + endOfDay);
-        return asyncReq
-                .doOnNext(fetchResult -> {
+                            return mergedList;
+                        })
+                .doOnNext(locations -> {
                     // Don't cache the current day (it could still update)!
                     if (!isForToday) {
-                        MEMORY_REPORTS_CACHE.put(cacheKey, fetchResult.getReports().get(beaconId));
+                        MEMORY_REPORTS_CACHE.put(cacheKey, locations);
                     }
                 })
-                .flatMap(fetchResult -> this.storeLocationFetchToLocalDb(isForToday, beaconId, beginningOfDay).andThen(Observable.just(fetchResult)))
-                .flatMap(this.beaconRepo::storeFetchResult)
-                .map(locations -> locations.get(beaconId))
+                .flatMap(locations -> this.storeLocationFetchToLocalDb(
+                        isForToday, beaconId, beginningOfDay).andThen(Observable.just(locations)))
                 .subscribeOn(Schedulers.computation());
     }
 

--- a/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
@@ -105,6 +105,7 @@ import dev.wander.android.opentagviewer.ui.maps.TagListSwiperHelper;
 import dev.wander.android.opentagviewer.util.LogCollectorUtil;
 import dev.wander.android.opentagviewer.util.MapUtils;
 import dev.wander.android.opentagviewer.python.icloud.AccountRefresher;
+import dev.wander.android.opentagviewer.util.android.AddressLookup;
 import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
 import dev.wander.android.opentagviewer.util.android.PermissionUtil;
 import dev.wander.android.opentagviewer.ui.maps.VectorImageGeneratorUtil;
@@ -180,7 +181,7 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
 
     private FusedLocationProviderClient fusedLocationClient = null;
 
-    private Geocoder geocoder = null;
+    private AddressLookup geocoder = null;
 
     private final Map<String, BeaconData> beacons = new ConcurrentHashMap<>();
 
@@ -372,7 +373,8 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
         this.fusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
 
         Places.initialize(this.getApplicationContext(), BuildConfig.MAPS_API_KEY);
-        this.geocoder = new Geocoder(this.getApplicationContext(), Locale.getDefault());
+        this.geocoder = AppDependencies.geocoder(
+                this.getApplicationContext(), Locale.getDefault());
 
         this.setupTagScrollArea();
 
@@ -716,12 +718,29 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
         }
         final BeaconLocationReport lastLocation = maybeLast.get();
         Uri uri = Uri.parse(String.format(Locale.ROOT, "geo:%.7f,%.7f?q=%.7f,%.7f", lastLocation.getLatitude(), lastLocation.getLongitude(), lastLocation.getLatitude(), lastLocation.getLongitude()));
+
+        // **Whatever the user's maps application is, not Google's.** This used to name
+        // com.google.android.apps.maps, which is the wrong shape of answer twice over. geo: is
+        // a standard scheme that Organic Maps, OsmAnd, Magic Earth and the rest all register
+        // for, and naming one package means the system chooser - which already remembers what
+        // this user picked last time - never gets to offer any of them. This app exists for
+        // people who have opted out of one walled garden; sending them into another is the
+        // wrong default.
+        //
+        // It also could not work. From Android 11 the app cannot see a package it has not
+        // declared in <queries>, so resolveActivity returned null on every current device with
+        // or without Google Maps, and the button silently did nothing. The manifest now
+        // declares the geo: intent; without that entry this check fails again exactly as
+        // before, so the two changes belong together.
         Intent mapIntent = new Intent(Intent.ACTION_VIEW, uri);
-        mapIntent.setPackage("com.google.android.apps.maps");
         if (mapIntent.resolveActivity(getPackageManager()) != null) {
             startActivity(mapIntent);
         } else {
-            Log.e(TAG, "Could not start maps activity for currently visible tag!");
+            // Said out loud, because the alternative is a button that does nothing. A phone
+            // with no maps application at all is unusual but entirely possible on a stripped
+            // build, and "nothing happened" is the one outcome the user cannot act on.
+            Log.e(TAG, "No installed application can open a geo: link for the visible tag");
+            Toast.makeText(this, R.string.no_app_to_open_a_map_with, LENGTH_SHORT).show();
         }
     }
 

--- a/app/src/main/java/dev/wander/android/opentagviewer/MyDevicesListActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/MyDevicesListActivity.java
@@ -462,6 +462,15 @@ public class MyDevicesListActivity extends AppCompatActivity {
         PopupMenu menu = new PopupMenu(this, this.binding.selectionToolbar.selectionMenuButton);
         menu.getMenuInflater().inflate(R.menu.device_selection_menu, menu.getMenu());
 
+        // **Nothing selected means nothing to do to it, and the menu has to say so.** Both of
+        // these read the selection, find it empty and return - so with "0 selected" they were
+        // offered in full, did nothing at all when tapped, and gave no reason. Disabled rather
+        // than hidden, for the reason already written on Export Tags: a menu that changes shape
+        // is harder to learn than one where an item is visibly not available yet.
+        final boolean anythingSelected = !this.deviceListAdaptor.getSelectedBeacons().isEmpty();
+        menu.getMenu().findItem(R.id.action_export_history).setEnabled(anythingSelected);
+        menu.getMenu().findItem(R.id.action_remove_devices).setEnabled(anythingSelected);
+
         menu.setOnMenuItemClickListener(item -> {
             final int id = item.getItemId();
 

--- a/app/src/main/java/dev/wander/android/opentagviewer/SettingsActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/SettingsActivity.java
@@ -1003,12 +1003,31 @@ public class SettingsActivity extends AppCompatActivity {
         this.findViewById(R.id.login_details_placeholder).setVisibility(GONE);
         this.findViewById(R.id.login_details).setVisibility(VISIBLE);
 
+        // **A stored session might not carry a name and email, and that must not be fatal.**
+        // This used to chain straight through getAccount().getInfo(), so a session that
+        // deserialised without an account block - an older format, a partial write, anything
+        // FindMy.py's shape has changed since - took the whole Settings screen down with a
+        // NullPointerException on open. Settings is also where the sign-out button lives, which
+        // makes it precisely the screen somebody with a broken session needs to reach.
+        //
+        // Missing details are left blank instead. The account row still renders, and the row
+        // that actually matters - Sign out - is still there and still works.
+        final UserAuthData.UserAccountInfo info = userAuthData.getAccount() == null
+                ? null : userAuthData.getAccount().getInfo();
+
+        if (info == null) {
+            Log.w(TAG, "The stored session carries no account details, so the name and email are"
+                    + " left blank. Signing out still works, which is the point of showing the"
+                    + " row at all.");
+        }
+
         TextView firstnameLastnameText = this.findViewById(R.id.firstame_lastname_settings_block);
-        final String userFirstNameLastName = userAuthData.getAccount().getInfo().getFirstName() + " " + userAuthData.getAccount().getInfo().getLastName();
+        final String userFirstNameLastName = info == null
+                ? "" : info.getFirstName() + " " + info.getLastName();
         firstnameLastnameText.setText(userFirstNameLastName);
 
         TextView emailText = this.findViewById(R.id.email_settings_block);
-        final String userEmail = userAuthData.getAccount().getInfo().getAccountName();
+        final String userEmail = info == null ? "" : info.getAccountName();
         emailText.setText(userEmail);
 
         Button logoutButton = this.findViewById(R.id.logout_button);

--- a/app/src/main/java/dev/wander/android/opentagviewer/db/repo/BeaconRepository.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/db/repo/BeaconRepository.java
@@ -31,6 +31,7 @@ import dev.wander.android.opentagviewer.python.icloud.AccessoryRecords;
 import dev.wander.android.opentagviewer.util.parse.NamingRecordEditor;
 import dev.wander.android.opentagviewer.python.PlistToAccessoryJsonConverter;
 import dev.wander.android.opentagviewer.util.BeaconLocationReportHasher;
+import dev.wander.android.opentagviewer.util.parse.KeyAlignmentPlist;
 import dev.wander.android.opentagviewer.util.rx.ScanOrder;
 import dev.wander.android.opentagviewer.util.rx.WideScanBackoff;
 import io.reactivex.rxjava3.core.Completable;
@@ -402,7 +403,12 @@ public class BeaconRepository {
             candidates.add(new ScanOrder.Candidate(
                     entry.getKey(),
                     row != null && row.lastScanAt != null,
-                    row != null && row.lastScanAt != null && row.fruitlessScans == 0));
+                    row != null && row.lastScanAt != null && row.fruitlessScans == 0,
+                    // Only ever consulted for a tag with no scan history, so this is read for
+                    // every candidate and used for very few. It is a small XPath over a plist
+                    // already in memory - cheaper than the schema change that storing it would
+                    // cost, and rule 1 makes that a migration.
+                    row == null ? null : KeyAlignmentPlist.observedAtMillis(row.alignmentPlist)));
         }
 
         if (ignored > 0 || waiting > 0) {

--- a/app/src/main/java/dev/wander/android/opentagviewer/python/AppDependencies.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/python/AppDependencies.java
@@ -1,11 +1,14 @@
 package dev.wander.android.opentagviewer.python;
 
 import android.content.Context;
+import android.location.Geocoder;
 
 import org.chromium.net.CronetEngine;
 
 import androidx.annotation.VisibleForTesting;
 
+import java.util.Locale;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -15,6 +18,7 @@ import dev.wander.android.opentagviewer.python.icloud.ICloudService;
 import dev.wander.android.opentagviewer.python.icloud.PythonICloudService;
 import dev.wander.android.opentagviewer.db.repo.model.UserSettings;
 import dev.wander.android.opentagviewer.service.web.AnisetteServerTesterService;
+import dev.wander.android.opentagviewer.util.android.AddressLookup;
 
 /**
  * What the sign-in screen depends on, in one place a test can replace.
@@ -69,6 +73,35 @@ public final class AppDependencies {
      * "an accessory nothing recognises" renderable on demand, rather than needing such a tag.
      */
     private static HardwareDescriber hardwareDescriber = new ChaquopyHardwareDescriber();
+
+    /**
+     * Turns coordinates into something a person recognises.
+     *
+     * <p><b>Here because a screen with no geocoder does not look broken.</b> The card falls back
+     * to the raw latitude and longitude, which is a perfectly reasonable thing for it to show
+     * when an address genuinely cannot be found - so a geocoder that answers nothing at all is
+     * indistinguishable, on screen and in a screenshot, from one that answered honestly.
+     *
+     * <p>Which is the state every instrumented run is in: the {@code aosp-atd} image carries no
+     * geocoding backend, so {@code getFromLocation} returns an empty list for every point on
+     * earth and the whole path - the rounding, the cache, the fallback - is exercised by
+     * nothing. A test that wants to assert a place name has to be able to supply one.
+     *
+     * <p>A factory rather than an instance, because a {@link Geocoder} is built per screen from
+     * that screen's context and the current locale.
+     */
+    private static BiFunction<Context, Locale, AddressLookup> geocoderFactory =
+            (context, locale) -> AddressLookup.through(new Geocoder(context, locale));
+
+    public static AddressLookup geocoder(final Context context, final Locale locale) {
+        return geocoderFactory.apply(context, locale);
+    }
+
+    @VisibleForTesting
+    public static void replaceGeocoder(
+            final BiFunction<Context, Locale, AddressLookup> replacement) {
+        geocoderFactory = replacement;
+    }
 
     /**
      * Opens a conversation with iCloud on the signed-in account.
@@ -153,5 +186,7 @@ public final class AppDependencies {
         serverTesterFactory = AnisetteServerTesterService::new;
         hardwareDescriber = new ChaquopyHardwareDescriber();
         icloudFactory = AppDependencies::openRealICloud;
+        geocoderFactory = (context, locale) ->
+                AddressLookup.through(new Geocoder(context, locale));
     }
 }

--- a/app/src/main/java/dev/wander/android/opentagviewer/ui/history/HistoryItemsAdapter.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/ui/history/HistoryItemsAdapter.java
@@ -6,7 +6,7 @@ import static android.view.View.VISIBLE;
 import android.content.Context;
 import android.content.res.Resources;
 import android.location.Address;
-import android.location.Geocoder;
+import dev.wander.android.opentagviewer.util.android.AddressLookup;
 import android.text.format.DateFormat;
 import android.util.Log;
 import android.util.Pair;
@@ -48,7 +48,7 @@ public class HistoryItemsAdapter extends RecyclerView.Adapter<HistoryItemsAdapte
     private final List<BeaconLocationReport> locations;
 
     private final Set<Integer> selectedItems;
-    private final Geocoder geocoder;
+    private final AddressLookup geocoder;
     private final @lombok.NonNull UserSettings userSettings;
     private final Consumer<ClickedItemInfo> onClickCallback;
     private final @lombok.NonNull Resources resources;
@@ -56,7 +56,7 @@ public class HistoryItemsAdapter extends RecyclerView.Adapter<HistoryItemsAdapte
 
     public HistoryItemsAdapter(
             @lombok.NonNull Resources resources,
-            @lombok.NonNull Geocoder geocoder,
+            @lombok.NonNull AddressLookup geocoder,
             @lombok.NonNull List<BeaconLocationReport> locations,
             @lombok.NonNull UserSettings userSettings,
             @lombok.NonNull Set<Integer> selectedItems,

--- a/app/src/main/java/dev/wander/android/opentagviewer/ui/mydevices/DeviceListAdaptor.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/ui/mydevices/DeviceListAdaptor.java
@@ -173,12 +173,20 @@ public class DeviceListAdaptor extends RecyclerView.Adapter<DeviceListAdaptor.Vi
             // user staring at the generic line has no way to tell those apart, and the second
             // one is the one they can act on - the tag page offers to look again.
             viewHolder.getLastUpdated().setText(R.string.tag_ignored_summary);
-            viewHolder.getWarningIcon().setVisibility(VISIBLE);
 
         } else {
             viewHolder.getLastUpdated().setText(R.string.no_last_location_known);
-            viewHolder.getWarningIcon().setVisibility(VISIBLE);
         }
+
+        // **No warning triangle on either of these.** Both lines already say exactly what is
+        // going on, in words, and the icon added alarm without adding information.
+        //
+        // It was also permanent for the people most likely to see it. The rows that carry these
+        // lines are largely the user's own Apple hardware, read from their account - a MacBook,
+        // an iPad - and those never report to the Find My network the way a tag does. So the
+        // list showed a column of warnings about a situation that is not a fault, cannot be
+        // fixed, and will still be there tomorrow. A warning that is always on is not a warning.
+        viewHolder.getWarningIcon().setVisibility(GONE);
 
         final boolean isSelected = this.selectedBeaconIds.contains(beaconId);
 

--- a/app/src/main/java/dev/wander/android/opentagviewer/util/android/AddressLookup.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/util/android/AddressLookup.java
@@ -1,0 +1,40 @@
+package dev.wander.android.opentagviewer.util.android;
+
+import android.location.Address;
+import android.location.Geocoder;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Turning a coordinate into something a person recognises.
+ *
+ * <p><b>An interface because {@link Geocoder} is final.</b> The obvious seam - a subclass that
+ * answers from a table - does not compile, and the platform offers no other way to substitute
+ * one. This is the smallest thing that does: the single method the app actually calls, with the
+ * real implementation being a one-line delegation.
+ *
+ * <p>Worth the indirection because a geocoder that answers nothing does not look broken.
+ * {@code Geocoder.getFromLocation} returns an empty list when it has no backend, which is what
+ * every instrumented run is in - the {@code aosp-atd} image has none - and the app's response to
+ * an empty answer is to print the raw latitude and longitude. That is the right thing to show
+ * when an address genuinely cannot be found, and it makes "no geocoder on this device" and "no
+ * address for this point" identical on screen. So the rounding, the caching and the fallback
+ * were exercised by nothing, and every screenshot of the map or the history list showed numbers
+ * where a phone shows a street.
+ */
+public interface AddressLookup {
+
+    /**
+     * @return what is at this point, nearest first, or empty if nothing is known. Never null.
+     * @throws IOException if the lookup could not be made at all - which is not the same as
+     *         there being nothing there, and callers treat it differently.
+     */
+    List<Address> getFromLocation(double latitude, double longitude, int maxResults)
+            throws IOException;
+
+    /** The real one. */
+    static AddressLookup through(final Geocoder geocoder) {
+        return geocoder::getFromLocation;
+    }
+}

--- a/app/src/main/java/dev/wander/android/opentagviewer/util/parse/KeyAlignmentPlist.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/util/parse/KeyAlignmentPlist.java
@@ -1,0 +1,81 @@
+package dev.wander.android.opentagviewer.util.parse;
+
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+import org.w3c.dom.Document;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+
+/**
+ * When macOS last saw a tag, read out of its key alignment record.
+ *
+ * <p><b>The one thing known about a tag before anybody has ever scanned for it.</b> A
+ * {@code KeyAlignmentRecord} carries {@code lastIndexObserved} and
+ * {@code lastIndexObservationDate}, and the date is what says how wide the next key search will
+ * be: an accessory steps its rolling key every fifteen minutes, so a record from yesterday
+ * leaves a window of about a hundred keys and one from eighteen months ago leaves tens of
+ * thousands. That is the difference between a fetch of a second or two and one of minutes.
+ *
+ * <p><b>Read here rather than stored.</b> The obvious alternative is a column on
+ * {@code OwnedBeacons}, and it would cost a Room migration - see rule 1 - for a value that is
+ * wanted a handful of times per fetch and takes microseconds to parse out of a plist that is
+ * already in memory. Not worth a schema version.
+ *
+ * <p><b>Absence is normal and is not an error.</b> Exports before format {@code 0.0.2} carry no
+ * alignment records at all, and macOS has none for an accessory it never observed. Every failure
+ * here answers {@code null}, which callers read as "nothing is known about this one" - the same
+ * answer as a record that will not parse, because there is nothing useful to distinguish them.
+ */
+public final class KeyAlignmentPlist {
+
+    private static final String TAG = KeyAlignmentPlist.class.getSimpleName();
+
+    /** The same shape {@code BeaconDataParser} uses: a key, then its typed sibling. */
+    private static final String XPATH_OBSERVED_AT =
+            "/plist/dict/key[.='lastIndexObservationDate']/following-sibling::date[1]";
+
+    private KeyAlignmentPlist() {
+    }
+
+    /**
+     * When the record says the accessory was last observed.
+     *
+     * @param alignmentPlistXml the record as exported, or null if the tag has none.
+     * @return milliseconds since the epoch, or null if there is no usable date in it.
+     */
+    @Nullable
+    public static Long observedAtMillis(@Nullable final String alignmentPlistXml) {
+        if (alignmentPlistXml == null || alignmentPlistXml.isBlank()) {
+            return null;
+        }
+
+        try {
+            final Document document = XmlParser.parse(alignmentPlistXml);
+            final XPath xPath = XPathFactory.newInstance().newXPath();
+            final String value = xPath.evaluate(XPATH_OBSERVED_AT, document);
+
+            if (value == null || value.isBlank()) {
+                return null;
+            }
+
+            // Apple writes plist dates as ISO-8601 in UTC, which is what Instant reads.
+            return Instant.parse(value.trim()).toEpochMilli();
+
+        } catch (final DateTimeParseException badDate) {
+            Log.w(TAG, "A key alignment record carried a date this cannot read: " + badDate);
+            return null;
+        } catch (final Exception unreadable) {
+            // Deliberately broad. This runs on data somebody else's machine wrote, on a path
+            // whose whole purpose is to make the first fetch feel quicker - so nothing here is
+            // worth failing a fetch over. Unknown is a perfectly good answer.
+            Log.w(TAG, "Could not read a key alignment record", unreadable);
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/dev/wander/android/opentagviewer/util/rx/ScanOrder.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/util/rx/ScanOrder.java
@@ -1,9 +1,11 @@
 package dev.wander.android.opentagviewer.util.rx;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
 
@@ -32,8 +34,21 @@ import java.util.Random;
  *
  * <p>Tags nobody has ever scanned sit between the two: there is no evidence about them either
  * way, so they should not be made to wait behind known-silent ones, and they have not earned a
- * place ahead of tags known to be answering. On a fresh install every tag is in that middle
- * group, which makes the whole batch simply random - the right answer when nothing is known.
+ * place ahead of tags known to be answering.
+ *
+ * <p><b>Within that middle group, the export is consulted.</b> This used to be a plain shuffle,
+ * on the reasoning that nothing is known about a tag nobody has scanned. That is true of scans
+ * and false of the tag: a bundle from format {@code 0.0.2} onward carries a
+ * {@code KeyAlignmentRecord} saying when macOS last observed it, and that predicts what the
+ * first fetch will cost. A tag observed yesterday is a request or two; one observed eighteen
+ * months ago is a walk through tens of thousands of key indices.
+ *
+ * <p>It matters most exactly where the app is slowest. On a first import every tag is in this
+ * group <i>and</i> gets the full seven-day window rather than the usual twenty-four hours, so a
+ * new user's first minutes are the worst the app ever performs - and the order decides whether
+ * they see a pin appear within seconds or watch an empty map and conclude it does not work.
+ * Tags with no alignment record go last, because they are the expensive ones, and are shuffled
+ * among themselves so that none of them is permanently the one that never gets reached.
  *
  * <p>Takes its {@link Random} rather than making one, so a test can ask what the order <i>is</i>
  * instead of only what it is not.
@@ -43,17 +58,31 @@ public final class ScanOrder {
     private ScanOrder() {
     }
 
-    /** One tag, in the two facts that decide where it goes. */
+    /** One tag, in the three facts that decide where it goes. */
     public static final class Candidate {
         private final String beaconId;
         private final boolean everScanned;
         private final boolean lastScanFoundSomething;
+        private final Long alignedAtMillis;
 
         public Candidate(@NonNull final String beaconId, final boolean everScanned,
                          final boolean lastScanFoundSomething) {
+            this(beaconId, everScanned, lastScanFoundSomething, null);
+        }
+
+        /**
+         * @param alignedAtMillis when the export said the tag was last observed, or null if it
+         *                        carried no alignment record. Only consulted for a tag nobody
+         *                        has scanned yet - once there is a real scan to go on, that is
+         *                        better evidence than a date from a file.
+         */
+        public Candidate(@NonNull final String beaconId, final boolean everScanned,
+                         final boolean lastScanFoundSomething,
+                         @Nullable final Long alignedAtMillis) {
             this.beaconId = beaconId;
             this.everScanned = everScanned;
             this.lastScanFoundSomething = lastScanFoundSomething;
+            this.alignedAtMillis = alignedAtMillis;
         }
 
         public String getBeaconId() {
@@ -71,12 +100,17 @@ public final class ScanOrder {
             @NonNull final List<Candidate> candidates, @NonNull final Random random) {
 
         final List<String> answering = new ArrayList<>();
-        final List<String> unknown = new ArrayList<>();
+        final List<Candidate> aligned = new ArrayList<>();
+        final List<String> neverAligned = new ArrayList<>();
         final List<String> silent = new ArrayList<>();
 
         for (final Candidate candidate : candidates) {
             if (!candidate.everScanned) {
-                unknown.add(candidate.beaconId);
+                if (candidate.alignedAtMillis == null) {
+                    neverAligned.add(candidate.beaconId);
+                } else {
+                    aligned.add(candidate);
+                }
             } else if (candidate.lastScanFoundSomething) {
                 answering.add(candidate.beaconId);
             } else {
@@ -85,12 +119,30 @@ public final class ScanOrder {
         }
 
         Collections.shuffle(answering, random);
-        Collections.shuffle(unknown, random);
         Collections.shuffle(silent, random);
+
+        // **Most recently observed first, and this is the whole point of the group.** A tag
+        // whose export says macOS saw it yesterday has a key window of about a hundred indices;
+        // one last seen eighteen months ago has tens of thousands, at Apple's ~290 keys per
+        // request. On a first import every tag is in this group and gets the full seven-day
+        // window, so this is the slowest the app is ever going to be - and the order decides
+        // whether a new user sees a pin in seconds or watches nothing happen for minutes.
+        aligned.sort(Comparator.comparingLong(
+                (Candidate candidate) -> candidate.alignedAtMillis).reversed());
+
+        // **Shuffled, not sorted, and last.** They cost the most, so they go behind the tags
+        // that can answer quickly. But the batch is sequential and routinely abandoned - the
+        // user closes the app - so a fixed order here would leave the same tag permanently
+        // last, never scanned, and permanently without a location. Shuffling is what stops any
+        // individual one from being the unlucky one every time.
+        Collections.shuffle(neverAligned, random);
 
         final List<String> order = new ArrayList<>(candidates.size());
         order.addAll(answering);
-        order.addAll(unknown);
+        for (final Candidate candidate : aligned) {
+            order.add(candidate.beaconId);
+        }
+        order.addAll(neverAligned);
         order.addAll(silent);
 
         return order;

--- a/app/src/main/python/icloud_bridge.py
+++ b/app/src/main/python/icloud_bridge.py
@@ -231,7 +231,25 @@ class ICloudSession:
         except Exception:
             return _unexpected("asking what this account can be recovered from")
 
-        self._records = list(options.recoverable)
+        # **This app's own escrow record is dropped, not shown.**
+        #
+        # Joining the trust circle registers this app as a device, so the account then holds a
+        # record for `0PENTAGVIEWR` alongside the user's real hardware - and the picker offered
+        # it, asking for "the screen-lock passcode of one of your Apple devices" for a device
+        # that has no screen and no lock. There is no answer to that question: the escrow
+        # passcode was generated, never shown, and is not the user's to know.
+        #
+        # Matched on the serial from `APP_IDENTITY`, which is the one place this app's identity
+        # is written (rule 11) - not on the name, which Apple does not carry for this entry, nor
+        # on a literal, which would be a second copy of the identity to keep in step.
+        #
+        # Filtered here rather than in the screen so the count below is honest: an account whose
+        # only recoverable record is this app's has nothing the user can recover from, and
+        # should be told so rather than shown one unusable tile.
+        self._records = [
+            record for record in options.recoverable
+            if record.serial != APP_IDENTITY.serial
+        ]
 
         if not self._records:
             if not options.viability_is_trustworthy:

--- a/app/src/main/res/layout/activity_information.xml
+++ b/app/src/main/res/layout/activity_information.xml
@@ -35,9 +35,26 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
                 android:orientation="vertical"
                 android:paddingTop="30dp"
                 android:textAlignment="center">
+
+                <!--
+                    The same mark the sign-in screen opens with, and the same drawable - so it
+                    takes the theme's colours here too, including a wallpaper-derived one.
+
+                    Worth the space it occupies: this page had a large empty middle, and the app
+                    was named in text three times over without ever being shown. It is also the
+                    one screen a person opens on purpose to find out what this thing is.
+                -->
+                <ImageView
+                    android:id="@+id/appLogo"
+                    android:layout_width="96dp"
+                    android:layout_height="96dp"
+                    android:layout_marginBottom="16dp"
+                    android:contentDescription="@string/app_name"
+                    app:srcCompat="@drawable/opentagviewer_icon_themed" />
 
                 <TextView
                     android:id="@+id/appTitle"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -110,8 +110,8 @@
     <string name="map_provider_amap">AMap (高德地图)</string>
     <string name="maps_api_key_missing_title">Google Maps API-Schlüssel fehlt</string>
     <string name="maps_api_key_missing_message">Dieser Build enthält keinen Google Maps API-Schlüssel, daher wird die Karte nicht geladen. Fügen Sie MAPS_API_KEY zu secrets.properties hinzu und erstellen Sie den Build neu, oder wählen Sie in den Einstellungen einen anderen Kartenanbieter.</string>
-    <string name="resolving_tags_banner">Ihre Tags werden zum ersten Mal geortet. Das kann einige Minuten dauern – bitte lassen Sie die App geöffnet.</string>
-    <string name="resolving_tags_banner_progress">Ihre Tags werden geortet (%1$d von %2$d). Das kann einige Minuten dauern – bitte lassen Sie die App geöffnet.</string>
+    <string name="resolving_tags_banner">Ihre Tags werden zum ersten Mal geortet. Sie erscheinen nach und nach, zuletzt gesehene zuerst – bitte lassen Sie die App geöffnet.</string>
+    <string name="resolving_tags_banner_progress">Tags werden geortet (%1$d von %2$d). Sie erscheinen nach und nach, zuletzt gesehene zuerst – bitte lassen Sie die App geöffnet.</string>
     <string name="anisette_mode_title">Anmeldedaten</string>
     <string name="anisette_mode_local">Auf diesem Gerät</string>
     <string name="anisette_mode_remote">Externer Server</string>
@@ -245,4 +245,10 @@ Du kannst sie später wieder verknüpfen. Dafür brauchst du den Gerätecode dei
     <string name="icloud_unlink_confirm_button">Verknüpfung aufheben</string>
     <string name="icloud_unlink_done">Dein Apple-Konto ist nicht mehr verknüpft</string>
     <string name="icloud_unlink_failed">Die Verknüpfung mit deinem Apple-Konto konnte nicht aufgehoben werden. Bitte versuche es erneut.</string>
+    <string name="no_app_to_open_a_map_with">Keine App auf diesem Telefon kann eine Karte öffnen</string>
+    <string name="icloud_loading_opening_account">Apple-Konto wird geöffnet …</string>
+    <string name="icloud_loading_waiting_for_location_check">Warten auf den Abschluss der Standortprüfung …</string>
+    <string name="export_logs">Protokolle exportieren</string>
+    <string name="log_file_has_been_exported_successfully">Protokolldatei wurde exportiert</string>
+    <string name="failed_to_export_log_file">Protokolldatei konnte nicht exportiert werden</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -110,8 +110,8 @@
     <string name="map_provider_amap">AMap (高德地图)</string>
     <string name="maps_api_key_missing_title">Google Maps API key missing</string>
     <string name="maps_api_key_missing_message">This build has no Google Maps API key, so the map will not load. Add MAPS_API_KEY to secrets.properties and rebuild, or pick a different map provider in Settings.</string>
-    <string name="resolving_tags_banner">Locating your tags for the first time. This can take a few minutes — please keep the app open.</string>
-    <string name="resolving_tags_banner_progress">Locating your tags (%1$d of %2$d). This can take a few minutes — please keep the app open.</string>
+    <string name="resolving_tags_banner">Locating your tags for the first time. They appear as they are found, most recently seen first — please keep the app open.</string>
+    <string name="resolving_tags_banner_progress">Locating your tags (%1$d of %2$d). They appear as they are found, most recently seen first — please keep the app open.</string>
     <string name="anisette_mode_title">Sign-in data</string>
     <string name="anisette_mode_local">On this device</string>
     <string name="anisette_mode_remote">Remote server</string>
@@ -245,4 +245,10 @@ You can link again later. That needs your Apple device passcode.</string>
     <string name="icloud_unlink_confirm_button">Unlink</string>
     <string name="icloud_unlink_done">Your Apple account is no longer linked</string>
     <string name="icloud_unlink_failed">Could not unlink your Apple account. Please try again.</string>
+    <string name="no_app_to_open_a_map_with">No app on this phone can open a map</string>
+    <string name="icloud_loading_opening_account">Opening your Apple account…</string>
+    <string name="icloud_loading_waiting_for_location_check">Waiting for the location check to finish…</string>
+    <string name="export_logs">Export Logs</string>
+    <string name="log_file_has_been_exported_successfully">Log file has been exported successfully</string>
+    <string name="failed_to_export_log_file">Could not export the log file</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -110,8 +110,8 @@
     <string name="map_provider_amap">AMap (高德地图)</string>
     <string name="maps_api_key_missing_title">Clé API Google Maps manquante</string>
     <string name="maps_api_key_missing_message">Cette version ne contient pas de clé API Google Maps, la carte ne se chargera donc pas. Ajoutez MAPS_API_KEY à secrets.properties et recompilez, ou choisissez un autre fournisseur de cartes dans les paramètres.</string>
-    <string name="resolving_tags_banner">Localisation de vos balises pour la première fois. Cela peut prendre quelques minutes : veuillez laisser l’application ouverte.</string>
-    <string name="resolving_tags_banner_progress">Localisation de vos balises (%1$d sur %2$d). Cela peut prendre quelques minutes : veuillez laisser l’application ouverte.</string>
+    <string name="resolving_tags_banner">Localisation de vos balises pour la première fois. Elles apparaissent au fur et à mesure, les plus récemment vues d’abord : veuillez laisser l’application ouverte.</string>
+    <string name="resolving_tags_banner_progress">Localisation de vos balises (%1$d sur %2$d). Elles apparaissent au fur et à mesure, les plus récemment vues d’abord : veuillez laisser l’application ouverte.</string>
     <string name="anisette_mode_title">Données de connexion</string>
     <string name="anisette_mode_local">Sur cet appareil</string>
     <string name="anisette_mode_remote">Serveur distant</string>
@@ -245,4 +245,10 @@ Vous pourrez réassocier votre compte plus tard. Le code de votre appareil Apple
     <string name="icloud_unlink_confirm_button">Dissocier</string>
     <string name="icloud_unlink_done">Votre compte Apple n’est plus associé</string>
     <string name="icloud_unlink_failed">Impossible de dissocier votre compte Apple. Veuillez réessayer.</string>
+    <string name="no_app_to_open_a_map_with">Aucune application de ce téléphone ne peut ouvrir une carte</string>
+    <string name="icloud_loading_opening_account">Ouverture de votre compte Apple…</string>
+    <string name="icloud_loading_waiting_for_location_check">En attente de la fin de la recherche de position…</string>
+    <string name="export_logs">Exporter les journaux</string>
+    <string name="log_file_has_been_exported_successfully">Le fichier journal a bien été exporté</string>
+    <string name="failed_to_export_log_file">Impossible d’exporter le fichier journal</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -110,8 +110,8 @@
     <string name="map_provider_amap">AMap (高德地图)</string>
     <string name="maps_api_key_missing_title">Google マップ API キーがありません</string>
     <string name="maps_api_key_missing_message">このビルドには Google マップ API キーがないため、地図を読み込めません。secrets.properties に MAPS_API_KEY を追加してビルドし直すか、設定で別の地図プロバイダを選択してください。</string>
-    <string name="resolving_tags_banner">タグの位置を初めて特定しています。数分かかる場合があります。アプリを開いたままにしてください。</string>
-    <string name="resolving_tags_banner_progress">タグの位置を特定しています (%1$d/%2$d)。数分かかる場合があります。アプリを開いたままにしてください。</string>
+    <string name="resolving_tags_banner">タグの位置を初めて特定しています。見つかったものから順に、最近確認されたものから表示されます。アプリを開いたままにしてください。</string>
+    <string name="resolving_tags_banner_progress">タグの位置を特定しています（%2$d 件中 %1$d 件）。見つかったものから順に、最近確認されたものから表示されます。アプリを開いたままにしてください。</string>
     <string name="anisette_mode_title">サインインデータ</string>
     <string name="anisette_mode_local">この端末で生成</string>
     <string name="anisette_mode_remote">リモートサーバー</string>
@@ -245,4 +245,10 @@
     <string name="icloud_unlink_confirm_button">連携を解除</string>
     <string name="icloud_unlink_done">Apple アカウントの連携を解除しました</string>
     <string name="icloud_unlink_failed">Apple アカウントの連携を解除できませんでした。もう一度お試しください。</string>
+    <string name="no_app_to_open_a_map_with">この端末には地図を開けるアプリがありません</string>
+    <string name="icloud_loading_opening_account">Apple アカウントを開いています…</string>
+    <string name="icloud_loading_waiting_for_location_check">位置情報の確認が終わるのを待っています…</string>
+    <string name="export_logs">ログを書き出す</string>
+    <string name="log_file_has_been_exported_successfully">ログファイルを書き出しました</string>
+    <string name="failed_to_export_log_file">ログファイルを書き出せませんでした</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -110,8 +110,8 @@
     <string name="map_provider_amap">AMap (高德地图)</string>
     <string name="maps_api_key_missing_title">Google 지도 API 키가 없습니다</string>
     <string name="maps_api_key_missing_message">이 빌드에는 Google 지도 API 키가 없어 지도를 불러올 수 없습니다. secrets.properties에 MAPS_API_KEY를 추가한 후 다시 빌드하거나, 설정에서 다른 지도 제공자를 선택하세요.</string>
-    <string name="resolving_tags_banner">태그의 위치를 처음으로 확인하는 중입니다. 몇 분 정도 걸릴 수 있으니 앱을 열어 두세요.</string>
-    <string name="resolving_tags_banner_progress">태그 위치를 확인하는 중입니다 (%1$d/%2$d). 몇 분 정도 걸릴 수 있으니 앱을 열어 두세요.</string>
+    <string name="resolving_tags_banner">태그의 위치를 처음으로 확인하는 중입니다. 찾는 대로 최근에 확인된 것부터 표시됩니다. 앱을 열어 두세요.</string>
+    <string name="resolving_tags_banner_progress">태그 위치를 확인하는 중입니다(%2$d개 중 %1$d개). 찾는 대로 최근에 확인된 것부터 표시됩니다. 앱을 열어 두세요.</string>
     <string name="anisette_mode_title">로그인 데이터</string>
     <string name="anisette_mode_local">이 기기에서 생성</string>
     <string name="anisette_mode_remote">원격 서버</string>
@@ -245,4 +245,10 @@
     <string name="icloud_unlink_confirm_button">연결 해제</string>
     <string name="icloud_unlink_done">Apple 계정 연결이 해제되었습니다</string>
     <string name="icloud_unlink_failed">Apple 계정 연결을 해제하지 못했습니다. 다시 시도해 주세요.</string>
+    <string name="no_app_to_open_a_map_with">이 휴대전화에는 지도를 열 수 있는 앱이 없습니다</string>
+    <string name="icloud_loading_opening_account">Apple 계정을 여는 중…</string>
+    <string name="icloud_loading_waiting_for_location_check">위치 확인이 끝나기를 기다리는 중…</string>
+    <string name="export_logs">로그 내보내기</string>
+    <string name="log_file_has_been_exported_successfully">로그 파일을 내보냈습니다</string>
+    <string name="failed_to_export_log_file">로그 파일을 내보내지 못했습니다</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -110,8 +110,8 @@
     <string name="map_provider_amap">AMap (高德地图)</string>
     <string name="maps_api_key_missing_title">Google Maps API-sleutel ontbreekt</string>
     <string name="maps_api_key_missing_message">Deze build heeft geen Google Maps API-sleutel, dus de kaart wordt niet geladen. Voeg MAPS_API_KEY toe aan secrets.properties en bouw opnieuw, of kies een andere kaartaanbieder in de instellingen.</string>
-    <string name="resolving_tags_banner">Je tags worden voor het eerst gelokaliseerd. Dit kan een paar minuten duren — houd de app open.</string>
-    <string name="resolving_tags_banner_progress">Je tags worden gelokaliseerd (%1$d van %2$d). Dit kan een paar minuten duren — houd de app open.</string>
+    <string name="resolving_tags_banner">Je tags worden voor het eerst gelokaliseerd. Ze verschijnen zodra ze gevonden zijn, meest recent gezien eerst — houd de app open.</string>
+    <string name="resolving_tags_banner_progress">Je tags worden gelokaliseerd (%1$d van %2$d). Ze verschijnen zodra ze gevonden zijn, meest recent gezien eerst — houd de app open.</string>
     <string name="anisette_mode_title">Aanmeldgegevens</string>
     <string name="anisette_mode_local">Op dit apparaat</string>
     <string name="anisette_mode_remote">Externe server</string>
@@ -245,4 +245,10 @@ Je kunt later opnieuw koppelen. Daarvoor heb je de toegangscode van je Apple-app
     <string name="icloud_unlink_confirm_button">Ontkoppelen</string>
     <string name="icloud_unlink_done">Je Apple-account is niet meer gekoppeld</string>
     <string name="icloud_unlink_failed">Kan de koppeling met je Apple-account niet opheffen. Probeer het opnieuw.</string>
+    <string name="no_app_to_open_a_map_with">Geen app op deze telefoon kan een kaart openen</string>
+    <string name="icloud_loading_opening_account">Je Apple-account wordt geopend…</string>
+    <string name="icloud_loading_waiting_for_location_check">Wachten tot de locatiecontrole klaar is…</string>
+    <string name="export_logs">Logboeken exporteren</string>
+    <string name="log_file_has_been_exported_successfully">Logbestand is geëxporteerd</string>
+    <string name="failed_to_export_log_file">Kon het logbestand niet exporteren</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -110,8 +110,8 @@
     <string name="map_provider_amap">AMap (高德地图)</string>
     <string name="maps_api_key_missing_title">Отсутствует ключ API Google Карт</string>
     <string name="maps_api_key_missing_message">В этой сборке нет ключа API Google Карт, поэтому карта не загрузится. Добавьте MAPS_API_KEY в secrets.properties и пересоберите приложение или выберите другого поставщика карт в настройках.</string>
-    <string name="resolving_tags_banner">Первое определение местоположения ваших меток. Это может занять несколько минут — не закрывайте приложение.</string>
-    <string name="resolving_tags_banner_progress">Определение местоположения меток (%1$d из %2$d). Это может занять несколько минут — не закрывайте приложение.</string>
+    <string name="resolving_tags_banner">Первое определение местоположения ваших меток. Они появляются по мере обнаружения, недавно замеченные — первыми. Не закрывайте приложение.</string>
+    <string name="resolving_tags_banner_progress">Определение местоположения меток (%1$d из %2$d). Они появляются по мере обнаружения, недавно замеченные — первыми. Не закрывайте приложение.</string>
     <string name="anisette_mode_title">Данные для входа</string>
     <string name="anisette_mode_local">На этом устройстве</string>
     <string name="anisette_mode_remote">Удалённый сервер</string>
@@ -245,4 +245,10 @@
     <string name="icloud_unlink_confirm_button">Отвязать</string>
     <string name="icloud_unlink_done">Учётная запись Apple больше не связана</string>
     <string name="icloud_unlink_failed">Не удалось отвязать учётную запись Apple. Повторите попытку.</string>
+    <string name="no_app_to_open_a_map_with">На этом телефоне нет приложения, способного открыть карту</string>
+    <string name="icloud_loading_opening_account">Открытие вашей учётной записи Apple…</string>
+    <string name="icloud_loading_waiting_for_location_check">Ожидание завершения проверки местоположения…</string>
+    <string name="export_logs">Экспорт журналов</string>
+    <string name="log_file_has_been_exported_successfully">Файл журнала экспортирован</string>
+    <string name="failed_to_export_log_file">Не удалось экспортировать файл журнала</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -110,8 +110,8 @@
     <string name="how_do_i_get_the_zip"><u>如何获取 zip 文件？</u></string>
     <string name="maps_api_key_missing_title">缺少 Google 地图 API Key</string>
     <string name="maps_api_key_missing_message">此版本未包含 Google 地图 API Key，因此无法加载地图。请在 secrets.properties 中添加 MAPS_API_KEY 后重新构建，或在设置中选择其他地图提供商。</string>
-    <string name="resolving_tags_banner">正在首次定位你的标签。这可能需要几分钟，请保持应用开启。</string>
-    <string name="resolving_tags_banner_progress">正在定位你的标签（%1$d / %2$d）。这可能需要几分钟，请保持应用开启。</string>
+    <string name="resolving_tags_banner">正在首次定位你的标签。找到一个显示一个，最近出现过的优先，请保持应用开启。</string>
+    <string name="resolving_tags_banner_progress">正在定位你的标签（第 %1$d 个，共 %2$d 个）。找到一个显示一个，最近出现过的优先，请保持应用开启。</string>
     <string name="anisette_mode_title">登录数据</string>
     <string name="anisette_mode_local">在本设备生成</string>
     <string name="anisette_mode_remote">远程服务器</string>
@@ -245,4 +245,10 @@
     <string name="icloud_unlink_confirm_button">取消关联</string>
     <string name="icloud_unlink_done">你的 Apple 账户已取消关联</string>
     <string name="icloud_unlink_failed">无法取消关联你的 Apple 账户，请重试。</string>
+    <string name="no_app_to_open_a_map_with">此手机上没有可以打开地图的应用</string>
+    <string name="icloud_loading_opening_account">正在打开您的 Apple 账户…</string>
+    <string name="icloud_loading_waiting_for_location_check">正在等待位置检查完成…</string>
+    <string name="export_logs">导出日志</string>
+    <string name="log_file_has_been_exported_successfully">日志文件已导出</string>
+    <string name="failed_to_export_log_file">无法导出日志文件</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -110,8 +110,8 @@
     <string name="how_do_i_get_the_zip"><u>如何取得 zip 檔案？</u></string>
     <string name="maps_api_key_missing_title">缺少 Google 地圖 API Key</string>
     <string name="maps_api_key_missing_message">此版本未包含 Google 地圖 API Key，因此無法載入地圖。請在 secrets.properties 中新增 MAPS_API_KEY 後重新建置，或在設定中選擇其他地圖提供商。</string>
-    <string name="resolving_tags_banner">正在首次定位你的標籤。這可能需要幾分鐘，請保持應用程式開啟。</string>
-    <string name="resolving_tags_banner_progress">正在定位你的標籤（%1$d / %2$d）。這可能需要幾分鐘，請保持應用程式開啟。</string>
+    <string name="resolving_tags_banner">正在首次定位你的標籤。找到一個顯示一個，最近出現過的優先，請保持應用程式開啟。</string>
+    <string name="resolving_tags_banner_progress">正在定位你的標籤（第 %1$d 個，共 %2$d 個）。找到一個顯示一個，最近出現過的優先，請保持應用程式開啟。</string>
     <string name="anisette_mode_title">登入資料</string>
     <string name="anisette_mode_local">在本裝置產生</string>
     <string name="anisette_mode_remote">遠端伺服器</string>
@@ -245,4 +245,10 @@
     <string name="icloud_unlink_confirm_button">取消連結</string>
     <string name="icloud_unlink_done">你的 Apple 帳戶已取消連結</string>
     <string name="icloud_unlink_failed">無法取消連結你的 Apple 帳戶，請重試。</string>
+    <string name="no_app_to_open_a_map_with">此手機上沒有可以開啟地圖的應用程式</string>
+    <string name="icloud_loading_opening_account">正在開啟您的 Apple 帳戶…</string>
+    <string name="icloud_loading_waiting_for_location_check">正在等待位置檢查完成…</string>
+    <string name="export_logs">匯出日誌</string>
+    <string name="log_file_has_been_exported_successfully">日誌檔案已匯出</string>
+    <string name="failed_to_export_log_file">無法匯出日誌檔案</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,9 +123,6 @@
     <string name="failed_to_request_code_please_try_again">Failed to request code. Please try again.</string>
     <string name="lang_ko">한국어</string>
     <string name="lang_ja">日本語</string>
-    <string name="export_logs" translatable="false">Export Logs</string>
-    <string name="log_file_has_been_exported_successfully" translatable="false">Log file has been exported successfully</string>
-    <string name="failed_to_export_log_file" translatable="false">Failed to export log file!</string>
     <string name="map_provider">Map Provider</string>
     <string name="map_provider_google">Google Maps</string>
     <string name="map_provider_amap">高德地图 (AMap)</string>
@@ -137,8 +134,8 @@
     <string name="amap_key_saved">AMap API key saved.</string>
     <string name="amap_key_cleared">AMap API key removed.</string>
     <string name="amap_how_to_get_a_key">How to get a key</string>
-    <string name="resolving_tags_banner">Locating your tags for the first time. This can take a few minutes — please keep the app open.</string>
-    <string name="resolving_tags_banner_progress">Locating your tags (%1$d of %2$d). This can take a few minutes — please keep the app open.</string>
+    <string name="resolving_tags_banner">Locating your tags for the first time. They appear as they are found, most recently seen first — please keep the app open.</string>
+    <string name="resolving_tags_banner_progress">Locating your tags (%1$d of %2$d). They appear as they are found, most recently seen first — please keep the app open.</string>
     <string name="maps_api_key_missing_title">Google Maps API key missing</string>
     <string name="maps_api_key_missing_message">This build has no Google Maps API key, so the map will not load. Add MAPS_API_KEY to secrets.properties and rebuild, or pick a different map provider in Settings.</string>
     <string name="no_devices_imported_yet">No devices yet</string>
@@ -280,4 +277,10 @@ You can link again later. That needs your Apple device passcode.</string>
     <string name="icloud_unlink_confirm_button">Unlink</string>
     <string name="icloud_unlink_done">Your Apple account is no longer linked</string>
     <string name="icloud_unlink_failed">Could not unlink your Apple account. Please try again.</string>
+    <string name="no_app_to_open_a_map_with">No app on this phone can open a map</string>
+    <string name="icloud_loading_opening_account">Opening your Apple account…</string>
+    <string name="icloud_loading_waiting_for_location_check">Waiting for the location check to finish…</string>
+    <string name="export_logs">Export Logs</string>
+    <string name="log_file_has_been_exported_successfully">Log file has been exported successfully</string>
+    <string name="failed_to_export_log_file">Could not export the log file</string>
 </resources>

--- a/app/src/test/java/dev/wander/android/opentagviewer/ui/maps/CoordinateConverterTest.java
+++ b/app/src/test/java/dev/wander/android/opentagviewer/ui/maps/CoordinateConverterTest.java
@@ -1,0 +1,193 @@
+package dev.wander.android.opentagviewer.ui.maps;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * The GCJ-02 shift AMap needs, and the places it must not touch.
+ *
+ * <p><b>This is the only piece of the AMap path anything tests.</b> Both real map providers are
+ * untestable on the managed device - {@code aosp-atd} has no Play Services and the AMap SDK is
+ * optional at compile time - so everything else runs against {@code FakeMapProvider}. This class
+ * is the exception, because it is arithmetic: no Android, no device, no map. It runs on the JVM
+ * in milliseconds.
+ *
+ * <p><b>Worth having out of all proportion to its size.</b> A wrong conversion does not fail: it
+ * puts every pin a few hundred metres from where the tag actually is, consistently, for everyone
+ * using AMap - which is to say everyone in mainland China, the users least able to report it
+ * back. Nothing else in the app would notice.
+ *
+ * <p><b>Properties, not published magic numbers.</b> The reference values for a given landmark
+ * vary between sources by a few metres, so asserting one would be pinning somebody else's
+ * rounding. What is asserted instead is what has to be true of any correct implementation: the
+ * round trip comes back, the offset is the size GCJ-02 offsets actually are, and coordinates
+ * outside the covered region are returned untouched.
+ */
+public class CoordinateConverterTest {
+
+    /** Metres per degree of latitude, near enough for a sanity bound. */
+    private static final double METRES_PER_DEGREE = 111_320.0;
+
+    // Inside the region the converter treats as covered.
+    private static final double BEIJING_LAT = 39.90869;
+    private static final double BEIJING_LON = 116.39123;
+
+    private static final double SHANGHAI_LAT = 31.23039;
+    private static final double SHANGHAI_LON = 121.47370;
+
+    // Comfortably outside it - and where most of this app's users are.
+    private static final double AMSTERDAM_LAT = 52.370216;
+    private static final double AMSTERDAM_LON = 4.895168;
+
+    private static final double NEW_YORK_LAT = 40.712776;
+    private static final double NEW_YORK_LON = -74.005974;
+
+    // --- the shift itself -------------------------------------------------------------------
+
+    /**
+     * <b>A covered coordinate is moved, and by the distance GCJ-02 actually moves things.</b>
+     *
+     * <p>The published offset runs from roughly a hundred metres to about seven hundred,
+     * depending where you are. Bounded on both sides on purpose: too small catches a conversion
+     * that quietly became a no-op, too large catches one that ran twice or lost a unit.
+     */
+    @Test
+    public void acoordinateInsideTheRegionIsShiftedByARealisticAmount() {
+        for (final double[] point : new double[][] {
+                {BEIJING_LAT, BEIJING_LON}, {SHANGHAI_LAT, SHANGHAI_LON}}) {
+
+            final double[] shifted = CoordinateConverter.wgs84ToGcj02(point[0], point[1]);
+            final double metres = roughDistanceInMetres(point[0], point[1],
+                    shifted[0], shifted[1]);
+
+            assertTrue("a coordinate inside the region moved " + Math.round(metres)
+                            + "m, which is too little to be the GCJ-02 shift - the conversion"
+                            + " has probably become a no-op",
+                    metres > 50);
+            assertTrue("a coordinate inside the region moved " + Math.round(metres)
+                            + "m, far more than GCJ-02 ever shifts - the conversion has probably"
+                            + " been applied twice, or a unit is wrong",
+                    metres < 1_000);
+        }
+    }
+
+    /**
+     * <b>And the round trip comes back to where it started.</b>
+     *
+     * <p>The property the app depends on most, because it converts in both directions at the
+     * provider boundary: out to AMap for markers and the camera, back for map clicks and
+     * {@code getCameraPosition}. A round trip that drifted would move a tag every time the user
+     * tapped the map.
+     *
+     * <p>Ten metres of tolerance because the inverse is a single-step approximation rather than
+     * an exact inverse - that is how every implementation of this does it, and it is far below
+     * the accuracy of the location reports themselves.
+     */
+    @Test
+    public void theroundTripReturnsToWhereItStarted() {
+        for (final double[] point : new double[][] {
+                {BEIJING_LAT, BEIJING_LON}, {SHANGHAI_LAT, SHANGHAI_LON}}) {
+
+            final double[] there = CoordinateConverter.wgs84ToGcj02(point[0], point[1]);
+            final double[] back = CoordinateConverter.gcj02ToWgs84(there[0], there[1]);
+
+            final double metres = roughDistanceInMetres(point[0], point[1], back[0], back[1]);
+
+            assertTrue("a round trip landed " + Math.round(metres) + "m from where it started,"
+                            + " so a tag would walk every time the map is tapped",
+                    metres < 10);
+        }
+    }
+
+    /** Converting the same point twice gives the same answer - there is nothing stateful here. */
+    @Test
+    public void theconversionIsDeterministic() {
+        final double[] first = CoordinateConverter.wgs84ToGcj02(BEIJING_LAT, BEIJING_LON);
+        final double[] second = CoordinateConverter.wgs84ToGcj02(BEIJING_LAT, BEIJING_LON);
+
+        assertEquals(first[0], second[0], 0.0);
+        assertEquals(first[1], second[1], 0.0);
+    }
+
+    // --- everywhere else --------------------------------------------------------------------
+
+    /**
+     * <b>Outside the region, nothing is touched at all.</b>
+     *
+     * <p>The case that matters to almost every user of this app. The shift is a property of
+     * Chinese survey law and applies nowhere else, so applying it to Amsterdam or New York would
+     * move a tag several hundred metres for no reason - and only for people who had chosen AMap,
+     * which is nobody who would expect a Chinese coordinate system to affect them.
+     *
+     * <p>Asserted as exactly equal, not approximately: the correct behaviour is to return the
+     * input, and "close enough" would hide a shift that had started leaking out of the region.
+     */
+    @Test
+    public void acoordinateOutsideTheRegionIsReturnedUntouched() {
+        for (final double[] point : new double[][] {
+                {AMSTERDAM_LAT, AMSTERDAM_LON}, {NEW_YORK_LAT, NEW_YORK_LON}}) {
+
+            final double[] out = CoordinateConverter.wgs84ToGcj02(point[0], point[1]);
+            assertEquals("latitude was shifted outside the covered region",
+                    point[0], out[0], 0.0);
+            assertEquals("longitude was shifted outside the covered region",
+                    point[1], out[1], 0.0);
+
+            final double[] back = CoordinateConverter.gcj02ToWgs84(point[0], point[1]);
+            assertEquals(point[0], back[0], 0.0);
+            assertEquals(point[1], back[1], 0.0);
+        }
+    }
+
+    /**
+     * <b>The region is a bounding box, and these are its edges.</b>
+     *
+     * <p>Pinned because the box is a crude rectangle - it takes in a good deal of Mongolia and
+     * the sea - and somebody tightening it later would silently change which coordinates get
+     * shifted. That is a correctness change for real users, not a tidy-up, so it should have to
+     * come past a red test.
+     */
+    @Test
+    public void theregionIsTheBoundingBoxItClaimsToBe() {
+        // Just inside each edge: shifted.
+        assertTrue("a point just inside the western edge was not shifted",
+                isShifted(30.0, 72.1));
+        assertTrue("a point just inside the eastern edge was not shifted",
+                isShifted(30.0, 137.8));
+        assertTrue("a point just inside the southern edge was not shifted",
+                isShifted(0.9, 100.0));
+        assertTrue("a point just inside the northern edge was not shifted",
+                isShifted(55.8, 100.0));
+
+        // Just outside: untouched.
+        assertTrue("a point west of the region was shifted anyway", !isShifted(30.0, 71.9));
+        assertTrue("a point east of the region was shifted anyway", !isShifted(30.0, 137.9));
+        assertTrue("a point south of the region was shifted anyway", !isShifted(0.8, 100.0));
+        assertTrue("a point north of the region was shifted anyway", !isShifted(55.9, 100.0));
+    }
+
+    // --- helpers ----------------------------------------------------------------------------
+
+    private static boolean isShifted(final double latitude, final double longitude) {
+        final double[] out = CoordinateConverter.wgs84ToGcj02(latitude, longitude);
+        return out[0] != latitude || out[1] != longitude;
+    }
+
+    /**
+     * Distance in metres, flat-earth style.
+     *
+     * <p>Good to a fraction of a percent over the hundreds of metres being measured here, and
+     * this is a sanity bound rather than a survey.
+     */
+    private static double roughDistanceInMetres(
+            final double lat1, final double lon1, final double lat2, final double lon2) {
+
+        final double dLat = (lat2 - lat1) * METRES_PER_DEGREE;
+        final double dLon = (lon2 - lon1) * METRES_PER_DEGREE
+                * Math.cos(Math.toRadians((lat1 + lat2) / 2));
+
+        return Math.sqrt((dLat * dLat) + (dLon * dLon));
+    }
+}

--- a/app/src/test/python/test_icloud_bridge.py
+++ b/app/src/test/python/test_icloud_bridge.py
@@ -270,6 +270,58 @@ class TestWhatCanBeRecoveredFrom:
         assert [d["serial"] for d in answer["devices"]] == ["F2LX9Q", "C02XK"]
         assert all(d["description"] for d in answer["devices"])
 
+    def test_this_apps_own_record_is_not_offered_to_unlock_with(self, session):
+        """
+        **Joining registers this app as a device, and its record is useless to the user.**
+
+        The screen asks for "the screen-lock passcode of one of your Apple devices". This app
+        has no screen and no lock: its escrow passcode was generated and never shown, so the
+        question has no answer a person could give. It was listed anyway, above the user's real
+        hardware, looking exactly like something they had forgotten the PIN to.
+        """
+        made = session(FakeClient(FakeOptions([
+            FakeRecord("F2LX9Q"),
+            FakeRecord(icloud_bridge.APP_IDENTITY.serial, name="OpenTagViewer"),
+            FakeRecord("C02XK"),
+        ])))
+
+        answer = json.loads(made.recoveryOptions())
+
+        assert [d["serial"] for d in answer["devices"]] == ["F2LX9Q", "C02XK"]
+
+    def test_it_cannot_be_unlocked_with_either(self, session):
+        """
+        Dropped from the records, not merely from the listing.
+
+        `unlock` finds a record by serial in the same list, so filtering only the JSON would
+        leave the app's own record selectable by anything that already knew the serial - and
+        that is the one entry no passcode can ever open.
+        """
+        made = session(FakeClient(FakeOptions([
+            FakeRecord("F2LX9Q"),
+            FakeRecord(icloud_bridge.APP_IDENTITY.serial),
+        ])))
+        made.recoveryOptions()
+
+        answer = json.loads(made.unlock(icloud_bridge.APP_IDENTITY.serial, "123456"))
+
+        assert not answer["ok"]
+
+    def test_an_account_holding_only_this_apps_record_has_nothing_to_recover_from(self, session):
+        """
+        And it is told the truth rather than shown one unusable tile.
+
+        Filtering in the screen instead would leave this account reporting a device to choose
+        from, then presenting a list with nothing in it.
+        """
+        made = session(FakeClient(FakeOptions(
+            [FakeRecord(icloud_bridge.APP_IDENTITY.serial)], trustworthy=True)))
+
+        answer = json.loads(made.recoveryOptions())
+
+        assert not answer["ok"]
+        assert answer["reason"] == icloud_bridge.REASON_NOTHING_TO_RECOVER_FROM
+
     def test_an_account_with_nothing_to_recover_from_says_so(self, session):
         """
         The real case this whole flow has to answer for.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 espresso-intents = { group = "androidx.test.espresso", name = "espresso-intents", version.ref = "espressoCore" }
+espresso-contrib = { group = "androidx.test.espresso", name = "espresso-contrib", version.ref = "espressoCore" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }


### PR DESCRIPTION
Eight user-visible bugs, one performance change, and the coverage that found them.

**Every bug here was found by writing a test for behaviour that was assumed to work**, not by
looking for bugs. That is the argument for the second commit being as large as it is.

## The fixes

| | |
| --- | --- |
| **History discarded reports it already had** | `getReportsForDay` merged the local database with Apple's answer only for days *older* than a week. Inside the week it took the remote answer alone — and Apple returning nothing for a window is ordinary, so a tag the map had located minutes earlier showed an empty history. Stepping back a day and returning made it reappear, which is how @parawanderer originally reported it |
| **Navigate-to was dead on every Android 11+ device** | it named `com.google.android.apps.maps`, and package visibility hides a package the manifest has not declared — so `resolveActivity` returned null with or without Google Maps installed, and the button silently logged |
| **The iCloud screen could not be left** | back was swallowed for the whole loading step, which is right for an unlock in flight and wrong for everything else — and `PythonLock` serialises that screen behind the location fetch, which a first import holds for minutes. It also claimed to be "looking for a device that can unlock it" before knowing whether one was needed, which for a linked account it never is |
| **Settings crashed on a session with no account details** | chained through `getAccount().getInfo()`. That is the screen with the sign-out button on it |
| **The app's own escrow record was offered as an unlock option** | joining the trust circle registers this app as a device, so the picker asked for the screen-lock passcode of a device with no screen and no lock |
| **Menu actions offered with nothing selected** | read the empty selection and returned — tappable, did nothing, said nothing |
| **`Export Logs` untranslated** | it sat in English in a menu of translated items. The `debug_*` field labels stay English deliberately, so a pasted bug report stays readable |
| **Permanent warning triangles** | on rows whose text already said the same thing, and permanent for anyone with Apple hardware on their account |

Plus: the Information page shows the themed app mark rather than a large empty middle.

## First import, ordered by what the export already knows

`ScanOrder` shuffled every never-scanned tag, reasoning that nothing is known about them. Nothing
is known about their *scans* — but the bundle records when macOS last observed each one, and that
predicts what the first fetch costs: a recent record is a request or two, an old one is a walk
through tens of thousands of key indices.

It matters most exactly where the app is slowest, since a first import gives every tag the full
seven-day window. Tags with no alignment record go last and stay shuffled among themselves, so
none is permanently the one that never gets reached.

## Coverage

Roughly sixty tests. Two screens had **none at all**: `HistoryViewActivity` (its Apple session
comes from a singleton only the map sets up, so nothing could launch it) and `InformationActivity`.

- `AMapWithTagsOnIt` — the fixture behind seven of these, so the eight-step arrangement to reach a
  drawn map exists once rather than seven times
- `FakeMapView`, `FakeGeocoder`, `AddressLookup` — for what the managed device cannot provide.
  `aosp-atd` has no geocoding backend, and the app's fallback for "no address" is to print
  coordinates, so a missing geocoder was indistinguishable from an honest answer
- `CoordinateConverterTest` — JVM, and the **only** coverage the AMap path has (see #127)
- `espresso-contrib` excludes `protobuf-lite`, which otherwise breaks every Cronet-touching test
  with a failure naming protobuf and Chromium and nothing about the test

**Full suite: 543 tests, 9m 31s, green.** Up from 493.

## Not in this PR

- Export from the app — separate PR, as agreed
- `versionCode` / `versionName` are still `3` / `1.0.5`
- The four known gaps are filed rather than worked: #126, #127, #128

---

🤖 Written by [Claude Code](https://claude.com/claude-code)
