### PR TITLE
Offer the iCloud account route once, to the people who have never seen it

### DIFF
--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/TheWholeAppJourneyTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/TheWholeAppJourneyTest.java
@@ -7,6 +7,7 @@ import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.RootMatchers.isPlatformPopup;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
@@ -320,6 +321,29 @@ public class TheWholeAppJourneyTest {
                 this.map.isReady()));
 
         assertTrue("a fresh install drew a pin for something", this.map.markers().isEmpty());
+        TestPace.afterAStep();
+
+        this.theofferToConnectTheAccountIsWaitingThere();
+    }
+
+    /**
+     * <b>The first thing a new user actually meets on the map.</b>
+     *
+     * <p>Somebody who has just signed in has no account connected and has never been asked, which
+     * is exactly who the offer is for - so it is part of this journey rather than something to
+     * suppress. Asserted rather than merely dismissed: it is the only time the app ever mentions
+     * the feature that removes the Mac from the story, and a journey test that quietly clicked
+     * past it would not notice it disappearing.
+     *
+     * <p>Declined, because the rest of this journey goes the long way round - through My Devices
+     * and the account screen - which is the route somebody who says "not now" then takes.
+     */
+    private void theofferToConnectTheAccountIsWaitingThere() {
+        Eventually.check(() -> onView(withText(R.string.icloud_offer_title))
+                .inRoot(isDialog()).check(matches(isDisplayed())));
+        TestPace.afterAStep();
+
+        onView(withText(R.string.icloud_offer_not_now)).inRoot(isDialog()).perform(click());
         TestPace.afterAStep();
     }
 

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/history/TheHistoryScreenDrawsTheDayTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/history/TheHistoryScreenDrawsTheDayTest.java
@@ -46,6 +46,7 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
+import dev.wander.android.opentagviewer.anisette.FakeAnisetteSource;
 import dev.wander.android.opentagviewer.DeviceStateGuard;
 import dev.wander.android.opentagviewer.Eventually;
 import dev.wander.android.opentagviewer.HistoryViewActivity;
@@ -133,6 +134,11 @@ public class TheHistoryScreenDrawsTheDayTest {
 
     @Before
     public void substituteTheWorldAndSeedATag() {
+        // Or the map/login/settings screen loads Apple's real ADI library: a download,
+        // a dlopen and a native initialise, none of which this test is about - and two
+        // screens reaching it at once segfaults the process and aborts the whole run.
+        // See issue #135.
+        AppDependencies.replaceAnisette(whateverTheSettingsSay -> FakeAnisetteSource.ready());
         final Context context = getInstrumentation().getTargetContext();
 
         this.guard = DeviceStateGuard.capture(context);

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/AMapWithTagsOnIt.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/AMapWithTagsOnIt.java
@@ -142,6 +142,14 @@ public final class AMapWithTagsOnIt {
                 UserSettingsDataStore.getInstance(this.context));
         final UserSettings settings = settingsRepo.getUserSettings();
         settings.setAnisetteUpgradeOffered(true);
+        // **And the same for the iCloud offer, for exactly the same reason.** A hand-written
+        // session with no keychain membership is precisely who that one is for, so without this
+        // every test built on this fixture opens the map behind a dialog and Espresso's default
+        // root becomes the dialog rather than the map.
+        //
+        // A test that is *about* the offer must not use this fixture's default - see
+        // TheICloudOfferAppearsOnceTest, which arranges its own state.
+        settings.setIcloudOfferMade(true);
         settingsRepo.storeUserSettings(settings).blockingAwait();
 
         final long importId = this.db.importDao().insert(Import.builder()

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/TheMapDrawsWhatIsStoredTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/TheMapDrawsWhatIsStoredTest.java
@@ -25,6 +25,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import dev.wander.android.opentagviewer.anisette.FakeAnisetteSource;
+import dev.wander.android.opentagviewer.python.AppDependencies;
 import dev.wander.android.opentagviewer.DeviceStateGuard;
 import dev.wander.android.opentagviewer.Eventually;
 import dev.wander.android.opentagviewer.MapsActivity;
@@ -103,6 +105,11 @@ public class TheMapDrawsWhatIsStoredTest {
 
     @Before
     public void seedTwoTagsAndSubstituteTheMap() {
+        // Or the map/login/settings screen loads Apple's real ADI library: a download,
+        // a dlopen and a native initialise, none of which this test is about - and two
+        // screens reaching it at once segfaults the process and aborts the whole run.
+        // See issue #135.
+        AppDependencies.replaceAnisette(whateverTheSettingsSay -> FakeAnisetteSource.ready());
         final Context context = getInstrumentation().getTargetContext();
 
         this.guard = DeviceStateGuard.capture(context);
@@ -179,6 +186,8 @@ public class TheMapDrawsWhatIsStoredTest {
 
     @After
     public void putEverythingBack() {
+        // Put the real Anisette source back, or the next class inherits the fake.
+        AppDependencies.reset();
         if (this.scenario != null) {
             this.scenario.close();
         }

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/settings/FetchFromAccountSettingTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/settings/FetchFromAccountSettingTest.java
@@ -26,6 +26,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import dev.wander.android.opentagviewer.anisette.FakeAnisetteSource;
+import dev.wander.android.opentagviewer.python.AppDependencies;
 import dev.wander.android.opentagviewer.Eventually;
 import dev.wander.android.opentagviewer.FetchFromICloudActivity;
 import dev.wander.android.opentagviewer.R;
@@ -57,6 +59,11 @@ public class FetchFromAccountSettingTest {
 
     @Before
     public void answerTheFetchScreenAtTheDoor() {
+        // Or the map/login/settings screen loads Apple's real ADI library: a download,
+        // a dlopen and a native initialise, none of which this test is about - and two
+        // screens reaching it at once segfaults the process and aborts the whole run.
+        // See issue #135.
+        AppDependencies.replaceAnisette(whateverTheSettingsSay -> FakeAnisetteSource.ready());
         this.memberships = new KeychainMembershipRepository(
                 UserAuthDataStore.getInstance(getInstrumentation().getTargetContext()),
                 new AppCryptographyUtil());
@@ -69,6 +76,8 @@ public class FetchFromAccountSettingTest {
 
     @After
     public void closeIt() {
+        // Put the real Anisette source back, or the next class inherits the fake.
+        AppDependencies.reset();
         if (this.scenario != null) {
             this.scenario.close();
         }

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/settings/TheICloudOfferAppearsOnceTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/settings/TheICloudOfferAppearsOnceTest.java
@@ -1,0 +1,359 @@
+package dev.wander.android.opentagviewer.ui.settings;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.espresso.NoMatchingRootException;
+import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import com.chaquo.python.PyObject;
+import com.chaquo.python.Python;
+import com.chaquo.python.android.AndroidPlatform;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import dev.wander.android.opentagviewer.DeviceStateGuard;
+import dev.wander.android.opentagviewer.anisette.FakeAnisetteSource;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.FetchFromICloudActivity;
+import dev.wander.android.opentagviewer.MapsActivity;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
+import dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStore;
+import dev.wander.android.opentagviewer.db.repo.KeychainMembershipRepository;
+import dev.wander.android.opentagviewer.db.repo.UserAuthRepository;
+import dev.wander.android.opentagviewer.db.repo.UserSettingsRepository;
+import dev.wander.android.opentagviewer.db.repo.model.UserSettings;
+import dev.wander.android.opentagviewer.python.icloud.KeychainMembership;
+import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
+import dev.wander.android.opentagviewer.util.rx.RefreshPolicy;
+
+/**
+ * The one-time offer to read tags out of the Apple account.
+ *
+ * <p><b>Two people are meant to see it and nobody else.</b> Somebody setting the app up from
+ * scratch, and somebody updating from an older version - both have no account connected and no
+ * record of being asked, which is what the condition actually tests. There is no migration code
+ * and no version check: an upgrader simply has no flag, because the flag did not exist when they
+ * last ran the app.
+ *
+ * <p><b>And it must never come back.</b> Somebody happy importing zips should be asked once, ever.
+ * That is the half worth the most tests, because getting it wrong turns the app into something
+ * that nags - and a returning prompt is one people learn to dismiss without reading, which costs
+ * the offer any value it had.
+ *
+ * <p>Arranges its own settings rather than using {@code AMapWithTagsOnIt}, whose whole job is to
+ * get to a map with no dialogs in front of it - it suppresses this offer deliberately.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class TheICloudOfferAppearsOnceTest {
+
+    private final Context context = getInstrumentation().getTargetContext();
+
+    private DeviceStateGuard guard;
+    private PyObject appleDouble;
+    private UserSettingsRepository settingsRepo;
+    private KeychainMembershipRepository memberships;
+    private ActivityScenario<MapsActivity> scenario;
+
+    @Before
+    public void startFromNothing() {
+        this.guard = DeviceStateGuard.capture(this.context);
+        this.settingsRepo = new UserSettingsRepository(
+                UserSettingsDataStore.getInstance(this.context));
+        this.memberships = new KeychainMembershipRepository(
+                UserAuthDataStore.getInstance(this.context), new AppCryptographyUtil());
+
+        this.memberships.forget().blockingAwait();
+
+        // Signed in, because the offer is only made to somebody who got past the door.
+        new UserAuthRepository(
+                UserAuthDataStore.getInstance(this.context), new AppCryptographyUtil())
+                .storeUserAuth("{\"not\":\"a restorable account\"}".getBytes(StandardCharsets.UTF_8))
+                .blockingAwait();
+
+        // **The session has to restore, or the map tears itself down mid-test.** A hand-written
+        // blob cannot be restored for real, and MapsActivity's response to that is correct and
+        // fatal here: it clears the login and finishes for the login screen. The offer is raised
+        // before the restore resolves, so the dialog appears and is then pulled off screen a
+        // second later - which reads as "the offer did not appear" and, when it happens during
+        // teardown, takes the instrumentation process with it.
+        if (!Python.isStarted()) {
+            Python.start(new AndroidPlatform(this.context));
+        }
+        this.appleDouble = Python.getInstance().getModule("apple_test_double");
+        this.appleDouble.callAttr("installWithNothingToReport");
+
+        // **Or the map loads Apple's real ADI library and can take the whole run down.**
+        // MapsActivity asks for Anisette on the way to restoring, and the real source dlopens
+        // libstoreservicescore.so and initialises it - which segfaults often enough to abort a
+        // suite, on an Rx thread, killing every test after it. Nothing here is testing Anisette.
+        AppDependencies.replaceAnisette(whateverTheSettingsSay -> FakeAnisetteSource.ready());
+
+        // Process-wide and outlives any activity, so a previous test's fetch would suppress the
+        // startup one here.
+        RefreshPolicy.resetShared();
+
+        Intents.init();
+    }
+
+    @After
+    public void putItBack() {
+        Intents.release();
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        if (this.appleDouble != null) {
+            this.appleDouble.callAttr("uninstall");
+        }
+        AppDependencies.reset();
+        this.memberships.forget().blockingAwait();
+        if (this.guard != null) {
+            this.guard.restore();
+        }
+    }
+
+    // --- the two people it is for ---------------------------------------------------------------
+
+    /**
+     * <b>Somebody setting the app up from scratch is asked.</b>
+     *
+     * <p>A new install resolves to local Anisette without being asked, so that offer is not due
+     * and this one has the screen to itself.
+     */
+    @Test
+    public void anewUserIsOffered() {
+        this.settingsWhere(settings -> settings.setAnisetteMode(UserSettings.ANISETTE_LOCAL));
+
+        this.openTheMap();
+
+        Eventually.check(() -> onView(withText(R.string.icloud_offer_title))
+                .inRoot(isDialog()).check(matches(isDisplayed())));
+    }
+
+    /**
+     * <b>And so is somebody updating from an older version.</b>
+     *
+     * <p>They have a session and a server URL and no {@code icloudOfferMade} key, because it did
+     * not exist when they last ran the app. Their Anisette question is already answered here, so
+     * it is not standing in front of this one - the test below covers when it is.
+     */
+    @Test
+    public void anupgraderIsOfferedToo() {
+        this.settingsWhere(settings -> {
+            settings.setAnisetteServerUrl("https://someone-elses-server.example");
+            settings.setAnisetteUpgradeOffered(true);
+        });
+
+        this.openTheMap();
+
+        Eventually.check(() -> onView(withText(R.string.icloud_offer_title))
+                .inRoot(isDialog()).check(matches(isDisplayed())));
+    }
+
+    // --- and nobody else ------------------------------------------------------------------------
+
+    /**
+     * <b>Dismissing it once is final.</b>
+     *
+     * <p>The assertion that matters most. Somebody who is happy importing zips should never be
+     * bothered again, and the flag is written when the dialog is <i>shown</i> rather than when a
+     * button is pressed - so this covers declining, swiping away, and the screen being torn down
+     * mid-dialog alike.
+     *
+     * <p>Reopening the map is the real test of that, not reading the setting back: a stored flag
+     * nothing consults would look identical in the database and still nag.
+     */
+    @Test
+    public void itneverComesBackOnceItHasBeenSeen() {
+        this.settingsWhere(settings -> settings.setAnisetteMode(UserSettings.ANISETTE_LOCAL));
+
+        this.openTheMap();
+        Eventually.check(() -> onView(withText(R.string.icloud_offer_title))
+                .inRoot(isDialog()).check(matches(isDisplayed())));
+
+        onView(withText(R.string.icloud_offer_not_now)).inRoot(isDialog()).perform(click());
+
+        Eventually.check(() -> assertTrue("declining still has to record that it was offered",
+                this.settingsRepo.getUserSettings().getIcloudOfferMade() == Boolean.TRUE));
+
+        this.scenario.close();
+        this.openTheMap();
+
+        this.letTheMapSettle();
+        assertFalse("somebody who said no once must never be asked again",
+                this.theOfferIsShowing());
+    }
+
+    /**
+     * <b>Somebody already reading their account is not asked.</b>
+     *
+     * <p>Asking would read as the app having lost track of what it is already doing - and would
+     * spend their one prompt on a question that does not apply to them.
+     */
+    @Test
+    public void somebodyAlreadyConnectedIsNotAsked() {
+        this.settingsWhere(settings -> settings.setAnisetteMode(UserSettings.ANISETTE_LOCAL));
+        this.memberships.store(new KeychainMembership(
+                "{\"peer_id\":\"peer-ours\"}", "ZW50cm9weQ==", "a-passcode", "a-label", 2))
+                .blockingAwait();
+
+        this.openTheMap();
+
+        this.letTheMapSettle();
+        assertFalse("an account is already connected; there is nothing to offer",
+                this.theOfferHasBeenMade());
+    }
+
+    /**
+     * <b>The Anisette offer goes first, and this one is deferred rather than spent.</b>
+     *
+     * <p>Somebody updating qualifies for both at the same moment. Two dialogs stacked on the map
+     * is how people learn to dismiss dialogs unread, so Anisette wins - it is about the session
+     * continuing to work at all.
+     *
+     * <p>The half that could go wrong quietly is the deferral: nothing may mark this offer as
+     * made while it is being skipped, or the user simply never sees it.
+     */
+    @Test
+    public void thedeferredOfferIsNotSilentlySpent() {
+        this.settingsWhere(settings ->
+                settings.setAnisetteServerUrl("https://someone-elses-server.example"));
+
+        this.openTheMap();
+
+        Eventually.check(() -> onView(withText(R.string.anisette_upgrade_title))
+                .inRoot(isDialog()).check(matches(isDisplayed())));
+
+        assertFalse("the iCloud offer must not be marked made while it was never shown",
+                this.settingsRepo.getUserSettings().getIcloudOfferMade() == Boolean.TRUE);
+    }
+
+    // --- accepting --------------------------------------------------------------------------------
+
+    /** <b>Set up now takes them to the screen that does it.</b> */
+    @Test
+    public void acceptingOpensTheAccountFetch() {
+        this.settingsWhere(settings -> settings.setAnisetteMode(UserSettings.ANISETTE_LOCAL));
+
+        this.openTheMap();
+        Eventually.check(() -> onView(withText(R.string.icloud_offer_title))
+                .inRoot(isDialog()).check(matches(isDisplayed())));
+
+        onView(withText(R.string.icloud_offer_set_up_now)).inRoot(isDialog()).perform(click());
+
+        Eventually.check(() -> intended(hasComponent(FetchFromICloudActivity.class.getName())));
+    }
+
+    // --- helpers ------------------------------------------------------------------------------
+
+    /**
+     * Put the settings in a known state, then let the test say what is different about it.
+     *
+     * <p><b>Every field the decision reads is reset, not just the obvious one.</b> These settings
+     * are the real device's and survive between tests in the class, and the condition under test
+     * depends on four of them. Resetting only {@code icloudOfferMade} meant
+     * {@code anupgraderIsOfferedToo} left {@code anisetteUpgradeOffered} true behind it, and the
+     * next test - whose whole point is that the Anisette offer comes first - silently ran with
+     * the Anisette offer already answered. It failed for a reason that had nothing to do with
+     * the behaviour, and would have passed or failed depending on the order tests ran in.
+     */
+    private void settingsWhere(final java.util.function.Consumer<UserSettings> arrange) {
+        final UserSettings settings = this.settingsRepo.getUserSettings();
+
+        settings.setIcloudOfferMade(false);
+        settings.setAnisetteUpgradeOffered(false);
+        settings.setAnisetteMode(null);
+        settings.setAnisetteServerUrl(null);
+
+        arrange.accept(settings);
+        this.settingsRepo.storeUserSettings(settings).blockingAwait();
+    }
+
+    private void openTheMap() {
+        this.scenario = ActivityScenario.launch(
+                new Intent(this.context, MapsActivity.class));
+    }
+
+    /**
+     * Whether the offer has been made, read from storage rather than from the screen.
+     *
+     * <p><b>Never ask {@code inRoot(isDialog())} whether a dialog is absent.</b> Espresso's root
+     * picker retries internally for seconds before admitting there is no dialog, so the "no"
+     * answer is the slow one - and inside an {@code Eventually} loop that is seconds per retry,
+     * for as long as the loop runs. The same mistake cost {@code UnlinkTheAccountSettingTest}
+     * 6m 33s for seven tests before it was rewritten to ask a repository. This class had three
+     * of them and took minutes.
+     *
+     * <p>Reading the flag is also the better assertion. The flag is written the moment the
+     * dialog is shown, so "was it offered" is exactly what it records - and unlike a screenshot
+     * of the screen it stays true after the dialog goes away.
+     */
+    private boolean theOfferHasBeenMade() {
+        return this.settingsRepo.getUserSettings().getIcloudOfferMade() == Boolean.TRUE;
+    }
+
+    /**
+     * Whether the dialog is on screen right now.
+     *
+     * <p><b>Call this once, never inside a retry loop.</b> Answering "no" means Espresso's root
+     * picker exhausting its internal retries first, which takes seconds - fine once, ruinous
+     * repeatedly. Use {@link #letTheMapSettle()} to make the moment meaningful instead of
+     * retrying the question.
+     *
+     * <p>Needed despite {@link #theOfferHasBeenMade()} for the one case the flag cannot answer:
+     * on a second visit the flag is already true whether or not the dialog came back, so only
+     * looking at the screen distinguishes "asked once" from "asked again".
+     */
+    private boolean theOfferIsShowing() {
+        try {
+            onView(withText(R.string.icloud_offer_title))
+                    .inRoot(isDialog()).check(matches(isDisplayed()));
+            return true;
+        } catch (final NoMatchingViewException | NoMatchingRootException | AssertionError e) {
+            // **NoMatchingRootException is the one that actually fires here.** With no dialog up
+            // there is no dialog *root* to search, so Espresso gives up a step earlier than the
+            // obvious exception - and catching only NoMatchingViewException lets the real case
+            // through as a failure.
+            return false;
+        }
+    }
+
+    /**
+     * Give the map long enough to have raised the offer if it were going to.
+     *
+     * <p>Needed because the assertions above are about an <i>absence</i>, and an absence is true
+     * immediately whether or not anything was ever going to happen. The offer is raised off a
+     * membership lookup that hops threads, so this waits for the thing that always happens on
+     * this screen - the tag carousel being laid out - before concluding that the thing that
+     * should not happen did not.
+     */
+    private void letTheMapSettle() {
+        Eventually.check(() -> onView(withId(R.id.map_container))
+                .check(matches(isDisplayed())));
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/settings/UnlinkTheAccountSettingTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/settings/UnlinkTheAccountSettingTest.java
@@ -23,6 +23,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import dev.wander.android.opentagviewer.anisette.FakeAnisetteSource;
+import dev.wander.android.opentagviewer.python.AppDependencies;
 import dev.wander.android.opentagviewer.Eventually;
 import dev.wander.android.opentagviewer.R;
 import dev.wander.android.opentagviewer.SettingsActivity;
@@ -54,6 +56,11 @@ public class UnlinkTheAccountSettingTest {
 
     @Before
     public void startUnlinked() {
+        // Or the map/login/settings screen loads Apple's real ADI library: a download,
+        // a dlopen and a native initialise, none of which this test is about - and two
+        // screens reaching it at once segfaults the process and aborts the whole run.
+        // See issue #135.
+        AppDependencies.replaceAnisette(whateverTheSettingsSay -> FakeAnisetteSource.ready());
         this.memberships = new KeychainMembershipRepository(
                 UserAuthDataStore.getInstance(getInstrumentation().getTargetContext()),
                 new AppCryptographyUtil());
@@ -62,6 +69,8 @@ public class UnlinkTheAccountSettingTest {
 
     @After
     public void closeIt() {
+        // Put the real Anisette source back, or the next class inherits the fake.
+        AppDependencies.reset();
         if (this.scenario != null) {
             this.scenario.close();
         }

--- a/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
@@ -1125,14 +1125,23 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
         }
         // Somebody is signed in, which is the only moment this is worth raising: they can see
         // what they already have, and what switching would cost them.
+        // **Asked before the dialog runs, not after.** `AnisetteUpgradeDialog.offerIfDue` marks
+        // itself as offered by mutating this very settings object, deliberately, so that a
+        // dismissal counts. That means asking afterwards whether it was due always answers "no"
+        // - and the iCloud offer below, whose whole condition is "not while Anisette is
+        // outstanding", would open on top of it. Both dialogs appeared at once, which is exactly
+        // the thing the deferral exists to prevent.
+        final boolean anisetteWasDue = this.userSettings.shouldOfferLocalAnisette(true);
+
         this.offerLocalAnisetteUpgradeIfDue();
 
-        // And, for anybody not already reading their account, the offer to start. Second
-        // deliberately: both are due at once for somebody updating, and the Anisette one wins
-        // because it is about the session continuing to work. This one is skipped entirely
-        // while that is outstanding and comes back on the next launch - see
-        // UserSettings.shouldOfferICloud.
-        this.offerICloudSetupIfDue();
+        // And, for anybody not already reading their account, the offer to start. Second and
+        // only when the screen is free: both are due at once for somebody updating, and the
+        // Anisette one wins because it is about the session continuing to work. Nothing marks
+        // this one as made in the meantime, so it returns on the next launch.
+        if (!anisetteWasDue) {
+            this.offerICloudSetupIfDue();
+        }
 
         // else stay here & restore the account.
         // Note: FindMy 0.9.x embeds the anisette URL in the account JSON itself,

--- a/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
@@ -51,6 +51,7 @@ import dev.wander.android.opentagviewer.ui.compat.WindowPaddingUtil;
 import dev.wander.android.opentagviewer.ui.importing.BundlePasscodeDialog;
 import dev.wander.android.opentagviewer.ui.login.TwoFactorAgainOverlay;
 import dev.wander.android.opentagviewer.ui.settings.AnisetteUpgradeDialog;
+import dev.wander.android.opentagviewer.ui.settings.ICloudSetupOfferDialog;
 import dev.wander.android.opentagviewer.ui.maps.IMapProvider;
 import dev.wander.android.opentagviewer.ui.maps.MapProviderFactory;
 import dev.wander.android.opentagviewer.ui.maps.GoogleMapProvider;
@@ -291,6 +292,33 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
                             || data.getBooleanExtra("shownDevicesChanged", false))) {
                         this.recreate();
                     }
+                }
+            }
+    );
+
+    /**
+     * Connecting an iCloud account, from the one-time offer after signing in.
+     *
+     * <p>A rebuild when anything came back, for the reason the device list already does it: tags
+     * read from the account have to appear without the user going somewhere else and returning,
+     * and this screen accumulates its tags on load rather than merging.
+     */
+    private final ActivityResultLauncher<Intent> fetchFromICloudLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            (ActivityResult result) -> {
+                final Intent data = result.getData();
+                if (data == null) {
+                    return;
+                }
+                // The iCloud screen offers a file import as its way out for anybody who cannot
+                // use an account; the picker lives here, so it asks us to start it.
+                if (data.getBooleanExtra(
+                        FetchFromICloudActivity.RESULT_WANTS_FILE_IMPORT, false)) {
+                    this.handleImport();
+                    return;
+                }
+                if (data.getBooleanExtra(FetchFromICloudActivity.RESULT_IMPORTED, false)) {
+                    this.handleDeviceListChanged();
                 }
             }
     );
@@ -1099,6 +1127,13 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
         // what they already have, and what switching would cost them.
         this.offerLocalAnisetteUpgradeIfDue();
 
+        // And, for anybody not already reading their account, the offer to start. Second
+        // deliberately: both are due at once for somebody updating, and the Anisette one wins
+        // because it is about the session continuing to work. This one is skipped entirely
+        // while that is outstanding and comes back on the next launch - see
+        // UserSettings.shouldOfferICloud.
+        this.offerICloudSetupIfDue();
+
         // else stay here & restore the account.
         // Note: FindMy 0.9.x embeds the anisette URL in the account JSON itself,
         // so we no longer need to read userSettings.getAnisetteServerUrl() here.
@@ -1317,6 +1352,48 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
         }
 
         this.twoFactorAgain.show(methods);
+    }
+
+    /**
+     * Offer to connect an iCloud account, once, to anybody who has not.
+     *
+     * <p><b>Asked after the membership lookup rather than off {@link #accountIsLinked}.</b> That
+     * field is filled in asynchronously, and reading it here would usually catch its default of
+     * false - offering the account to somebody who already has one connected, and burning their
+     * one-and-only prompt on a question that does not apply to them.
+     *
+     * <p>Declining still saves, because the flag recording that the offer was made is written
+     * into the same settings object. Without that write the prompt returns on every launch,
+     * which is precisely what somebody happy importing zips should never see.
+     */
+    private void offerICloudSetupIfDue() {
+        var async = new KeychainMembershipRepository(
+                UserAuthDataStore.getInstance(this.getApplicationContext()),
+                new AppCryptographyUtil())
+                .get()
+                .firstOrError()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        held -> ICloudSetupOfferDialog.offerIfDue(
+                                this, this.userSettings, held.isPresent(), this::recordICloudOffer),
+                        error -> Log.w(TAG,
+                                "Could not tell whether an account is linked, so not offering"
+                                        + " to connect one", error));
+    }
+
+    /** Persist the answer, and act on it if they said yes. */
+    private void recordICloudOffer(final boolean accepted) {
+        var async = this.userSettingsRepo.storeUserSettings(this.userSettings)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(() -> {
+                    if (accepted) {
+                        Log.i(TAG, "taking them to connect an iCloud account");
+                        this.fetchFromICloudLauncher.launch(
+                                new Intent(this, FetchFromICloudActivity.class));
+                    }
+                }, error -> Log.e(TAG, "Failed to record the iCloud offer", error));
     }
 
     private static boolean isAccountRestoreFailure(Throwable t) {

--- a/app/src/main/java/dev/wander/android/opentagviewer/db/datastore/UserSettingsDataStore.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/db/datastore/UserSettingsDataStore.java
@@ -28,6 +28,7 @@ public final class UserSettingsDataStore {
     public static final Preferences.Key<String> ANISETTE_APK_URI = PreferencesKeys.stringKey("anisette_apk_uri");
     public static final Preferences.Key<Boolean> ANISETTE_UPGRADE_OFFERED = PreferencesKeys.booleanKey("anisette_upgrade_offered");
     public static final Preferences.Key<Boolean> SHOW_APPLE_DEVICES = PreferencesKeys.booleanKey("show_apple_devices");
+    public static final Preferences.Key<Boolean> ICLOUD_OFFER_MADE = PreferencesKeys.booleanKey("icloud_offer_made");
 
     public static RxDataStore<Preferences> getInstance(Context context) {
         if (PREFERENCES_DATA_STORE == null) {

--- a/app/src/main/java/dev/wander/android/opentagviewer/db/repo/UserSettingsRepository.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/db/repo/UserSettingsRepository.java
@@ -6,6 +6,7 @@ import static dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStor
 import static dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStore.ANISETTE_UPGRADE_OFFERED;
 import static dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStore.ANISETTE_SERVER_URL;
 import static dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStore.ENABLE_DEBUG_DATA;
+import static dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStore.ICLOUD_OFFER_MADE;
 import static dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStore.LANGUAGE;
 import static dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStore.MAP_PROVIDER;
 import static dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStore.SHOW_APPLE_DEVICES;
@@ -42,6 +43,7 @@ public class UserSettingsRepository {
                 String anisetteApkUri = settings.get(ANISETTE_APK_URI);
                 Boolean anisetteUpgradeOffered = settings.get(ANISETTE_UPGRADE_OFFERED);
                 Boolean showAppleDevices = settings.get(SHOW_APPLE_DEVICES);
+                Boolean icloudOfferMade = settings.get(ICLOUD_OFFER_MADE);
 
                 return UserSettings.builder()
                         .anisetteServerUrl(anisetteServerUrl)
@@ -55,6 +57,7 @@ public class UserSettingsRepository {
                         .anisetteApkUri(anisetteApkUri)
                         .anisetteUpgradeOffered(anisetteUpgradeOffered)
                         .showAppleDevices(showAppleDevices)
+                        .icloudOfferMade(icloudOfferMade)
                         .build();
 
             }).subscribeOn(Schedulers.io())
@@ -104,6 +107,11 @@ public class UserSettingsRepository {
             // Null reads as off, which is the intended default - the app shows only what it can
             // actually keep up to date. See UserSettings.showAppleDevices.
             mutablePreferences.set(SHOW_APPLE_DEVICES, userSettings.shouldShowAppleDevices());
+            // Once true this never goes back to false: somebody who dismissed the offer has
+            // answered it, and asking again is how a prompt becomes something people close
+            // without reading. See UserSettings.icloudOfferMade.
+            mutablePreferences.set(ICLOUD_OFFER_MADE,
+                    userSettings.getIcloudOfferMade() == Boolean.TRUE);
 
             return Single.just(mutablePreferences);
         }).subscribeOn(Schedulers.io())

--- a/app/src/main/java/dev/wander/android/opentagviewer/db/repo/model/UserSettings.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/db/repo/model/UserSettings.java
@@ -105,6 +105,19 @@ public class UserSettings {
      */
     private Boolean showAppleDevices;
 
+    /**
+     * Whether the one-time offer to connect an iCloud account has been made.
+     *
+     * <p>Reading tags live out of the account is the thing that removes the Mac from the story
+     * entirely, and it is buried in Settings where somebody who has just signed in has no reason
+     * to look. So it is worth putting in front of them once, at the moment it would help - which
+     * is the same argument, and the same mechanism, as {@link #anisetteUpgradeOffered}.
+     *
+     * <p><b>Once, and marked when shown rather than when answered.</b> A prompt that returns is
+     * a prompt people learn to dismiss without reading.
+     */
+    private Boolean icloudOfferMade;
+
     public static final String ANISETTE_LOCAL = "local";
     public static final String ANISETTE_REMOTE = "remote";
 
@@ -176,5 +189,34 @@ public class UserSettings {
      */
     public boolean shouldShowAppleDevices() {
         return this.showAppleDevices == Boolean.TRUE;
+    }
+
+    /**
+     * Whether to offer connecting an iCloud account.
+     *
+     * <p>Two conditions, and between them they pick out exactly the people this helps:
+     *
+     * <ul>
+     *   <li><b>Nothing connected yet.</b> Somebody already reading their account does not need
+     *       to be asked, and asking would read as the app having lost track.</li>
+     *   <li><b>Never asked before.</b> Covers a fresh install and somebody updating from an
+     *       earlier version alike - neither has the flag - and stops the offer returning for
+     *       anyone who said no.</li>
+     * </ul>
+     *
+     * <p><b>Not while the Anisette offer is due.</b> Somebody updating qualifies for both, and
+     * two dialogs stacked on the map is how people learn to dismiss dialogs unread. Anisette
+     * goes first because it is about the session continuing to work at all; this one can wait
+     * for the next launch, and will, because nothing marks it made in the meantime.
+     *
+     * @param hasLinkedAccount whether an iCloud keychain membership is already held.
+     * @param hasExistingSession whether somebody is signed in, for the Anisette question.
+     */
+    public boolean shouldOfferICloud(
+            final boolean hasLinkedAccount, final boolean hasExistingSession) {
+
+        return !hasLinkedAccount
+                && this.icloudOfferMade != Boolean.TRUE
+                && !this.shouldOfferLocalAnisette(hasExistingSession);
     }
 }

--- a/app/src/main/java/dev/wander/android/opentagviewer/ui/settings/ICloudSetupOfferDialog.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/ui/settings/ICloudSetupOfferDialog.java
@@ -1,0 +1,97 @@
+package dev.wander.android.opentagviewer.ui.settings;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.util.Log;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.db.repo.model.UserSettings;
+
+/**
+ * The one-time offer to read tags straight out of the user's iCloud account.
+ *
+ * <p><b>It is the feature that removes the Mac, and it is invisible.</b> Everything else about
+ * this app works from a zip somebody exported on a Mac once. Connecting the account instead means
+ * tags arrive on their own, new ones appear without another export, and renaming one writes back
+ * - and all of that lives behind a Settings item that somebody who has just signed in has no
+ * reason to open. So it is worth saying once, at the moment it would help.
+ *
+ * <p><b>Asked of exactly two groups, by the same condition.</b> Someone setting the app up for
+ * the first time and someone updating from an older version both have no account connected and
+ * no record of being asked - see {@link UserSettings#shouldOfferICloud(boolean, boolean)}. Nobody
+ * else is bothered.
+ *
+ * <p><b>Once, and dismissing counts as an answer.</b> The flag is written when the dialog is
+ * shown rather than when a button is pressed, so closing it, swiping it away or having the
+ * activity torn down mid-dialog all mean the same thing: that was the one time. Somebody who is
+ * happy importing zips should never see this again, and a prompt that returns is a prompt people
+ * learn to close without reading.
+ *
+ * <p>Modelled on {@link AnisetteUpgradeDialog}, deliberately - it is the same shape of problem,
+ * and two one-time offers behaving differently would be worse than either.
+ */
+public final class ICloudSetupOfferDialog {
+
+    private static final String TAG = "ICloudSetupOffer";
+
+    private ICloudSetupOfferDialog() {
+    }
+
+    /**
+     * Ask, if there is anything to ask about.
+     *
+     * <p>The decision lives here rather than at the call site for the same reason it does on the
+     * Anisette offer: the conditions are subtle enough that a second caller would get them
+     * slightly wrong, and wrong means either nagging or never asking.
+     *
+     * @param settings         the current settings, <b>updated in place</b> before the decision
+     *                         is delivered, so the caller only has to persist them.
+     * @param hasLinkedAccount whether an iCloud keychain membership is already held.
+     * @param onDecision       called exactly once - true if they want to set it up now. Either
+     *                         way the settings need saving: false still records that the offer
+     *                         was made, and without that write the prompt returns forever.
+     * @return the dialog, or null when there was nothing to offer.
+     */
+    public static Dialog offerIfDue(
+            final Activity activity,
+            final UserSettings settings,
+            final boolean hasLinkedAccount,
+            final Consumer<Boolean> onDecision) {
+
+        if (!settings.shouldOfferICloud(hasLinkedAccount, true)) {
+            return null;
+        }
+
+        // Marked before anything is shown. Whatever happens next, this was their one time.
+        settings.setIcloudOfferMade(true);
+
+        Log.i(TAG, "offering to connect an iCloud account, for the first and only time");
+
+        // A dismiss follows a button press as well as a cancel, so without this the decision
+        // arrives twice for every answer - saving settings twice, and racing the save against
+        // the activity this starts.
+        final AtomicBoolean delivered = new AtomicBoolean(false);
+        final Consumer<Boolean> deliverOnce = accepted -> {
+            if (delivered.compareAndSet(false, true)) {
+                onDecision.accept(accepted);
+            }
+        };
+
+        return new MaterialAlertDialogBuilder(activity)
+                .setTitle(R.string.icloud_offer_title)
+                .setMessage(R.string.icloud_offer_message)
+                .setPositiveButton(R.string.icloud_offer_set_up_now,
+                        (dialog, which) -> deliverOnce.accept(true))
+                .setNegativeButton(R.string.icloud_offer_not_now,
+                        (dialog, which) -> deliverOnce.accept(false))
+                // Dismissing without answering is still an answer, and still has to be recorded
+                // or the flag is never written.
+                .setOnDismissListener(dialog -> deliverOnce.accept(false))
+                .show();
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -262,4 +262,10 @@ Du kannst sie später wieder verknüpfen. Dafür brauchst du den Gerätecode dei
     <string name="two_factor_again_sign_out">Stattdessen abmelden</string>
     <string name="two_factor_again_wrong_code">Dieser Code wurde nicht akzeptiert. Noch %1$d Versuche.</string>
     <string name="two_factor_again_giving_up">Dieser Code wurde nicht akzeptiert. Du wirst abgemeldet und musst dich erneut anmelden.</string>
+    <string name="icloud_offer_title">Deine Tags aus iCloud lesen?</string>
+    <string name="icloud_offer_message">Diese App kann sich mit deinem Apple-Konto verbinden und deine Tags direkt daraus lesen. Neue Tags erscheinen von selbst, ein neuer Name wird zurückgeschrieben, und es muss keine ZIP-Datei mehr auf einem Mac exportiert werden.
+
+Du kannst das jetzt einrichten oder jederzeit später in den Einstellungen.</string>
+    <string name="icloud_offer_set_up_now">Jetzt einrichten</string>
+    <string name="icloud_offer_not_now">Jetzt nicht</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -262,4 +262,10 @@ You can link again later. That needs your Apple device passcode.</string>
     <string name="two_factor_again_sign_out">Sign out instead</string>
     <string name="two_factor_again_wrong_code">That code was not accepted. %1$d attempts left.</string>
     <string name="two_factor_again_giving_up">That code was not accepted. Signing out — you will need to sign in again.</string>
+    <string name="icloud_offer_title">Read your tags from iCloud?</string>
+    <string name="icloud_offer_message">This app can connect to your Apple account and read your tags from it directly. New tags show up on their own, renaming one writes it back, and there is no zip to export from a Mac.
+
+You can set this up now, or any time later from Settings.</string>
+    <string name="icloud_offer_set_up_now">Set up now</string>
+    <string name="icloud_offer_not_now">Not now</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -262,4 +262,10 @@ Vous pourrez réassocier votre compte plus tard. Le code de votre appareil Apple
     <string name="two_factor_again_sign_out">Se déconnecter plutôt</string>
     <string name="two_factor_again_wrong_code">Ce code a été refusé. Il reste %1$d tentatives.</string>
     <string name="two_factor_again_giving_up">Ce code a été refusé. Déconnexion : vous devrez vous reconnecter.</string>
+    <string name="icloud_offer_title">Lire vos balises depuis iCloud ?</string>
+    <string name="icloud_offer_message">Cette app peut se connecter à votre compte Apple et y lire vos balises directement. Les nouvelles balises apparaissent d’elles-mêmes, un changement de nom est réenregistré, et il n’y a plus d’archive zip à exporter depuis un Mac.
+
+Vous pouvez configurer cela maintenant, ou à tout moment depuis les réglages.</string>
+    <string name="icloud_offer_set_up_now">Configurer</string>
+    <string name="icloud_offer_not_now">Plus tard</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -262,4 +262,10 @@
     <string name="two_factor_again_sign_out">代わりにサインアウト</string>
     <string name="two_factor_again_wrong_code">コードが認証されませんでした。残り %1$d 回です。</string>
     <string name="two_factor_again_giving_up">コードが認証されませんでした。サインアウトします。再度サインインしてください。</string>
+    <string name="icloud_offer_title">iCloud からタグを読み込みますか？</string>
+    <string name="icloud_offer_message">このアプリは Apple アカウントに接続し、タグを直接読み込めます。新しいタグは自動的に表示され、名前の変更は書き戻され、Mac から zip を書き出す必要もありません。
+
+今すぐ設定することも、後から設定画面で行うこともできます。</string>
+    <string name="icloud_offer_set_up_now">今すぐ設定</string>
+    <string name="icloud_offer_not_now">今はしない</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -262,4 +262,10 @@
     <string name="two_factor_again_sign_out">대신 로그아웃</string>
     <string name="two_factor_again_wrong_code">코드가 거부되었습니다. %1$d회 남았습니다.</string>
     <string name="two_factor_again_giving_up">코드가 거부되었습니다. 로그아웃합니다. 다시 로그인해야 합니다.</string>
+    <string name="icloud_offer_title">iCloud에서 태그를 불러올까요?</string>
+    <string name="icloud_offer_message">이 앱은 Apple 계정에 연결해 태그를 직접 불러올 수 있습니다. 새 태그가 저절로 나타나고, 이름을 바꾸면 계정에도 반영되며, Mac에서 zip을 내보낼 필요가 없습니다.
+
+지금 설정하거나, 나중에 설정에서 언제든 설정할 수 있습니다.</string>
+    <string name="icloud_offer_set_up_now">지금 설정</string>
+    <string name="icloud_offer_not_now">나중에</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -262,4 +262,10 @@ Je kunt later opnieuw koppelen. Daarvoor heb je de toegangscode van je Apple-app
     <string name="two_factor_again_sign_out">In plaats daarvan uitloggen</string>
     <string name="two_factor_again_wrong_code">Die code is niet geaccepteerd. Nog %1$d pogingen over.</string>
     <string name="two_factor_again_giving_up">Die code is niet geaccepteerd. Je wordt uitgelogd en moet opnieuw inloggen.</string>
+    <string name="icloud_offer_title">Je tags uit iCloud lezen?</string>
+    <string name="icloud_offer_message">Deze app kan verbinding maken met je Apple-account en je tags er rechtstreeks uit lezen. Nieuwe tags verschijnen vanzelf, een nieuwe naam wordt teruggeschreven, en er hoeft geen zip meer vanaf een Mac te worden geëxporteerd.
+
+Je kunt dit nu instellen, of later altijd nog via Instellingen.</string>
+    <string name="icloud_offer_set_up_now">Nu instellen</string>
+    <string name="icloud_offer_not_now">Niet nu</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -262,4 +262,10 @@
     <string name="two_factor_again_sign_out">Выйти из аккаунта</string>
     <string name="two_factor_again_wrong_code">Код не принят. Осталось попыток: %1$d.</string>
     <string name="two_factor_again_giving_up">Код не принят. Выполняется выход — потребуется войти снова.</string>
+    <string name="icloud_offer_title">Читать метки из iCloud?</string>
+    <string name="icloud_offer_message">Приложение может подключиться к вашей учётной записи Apple и читать метки прямо из неё. Новые метки появляются сами, переименование сохраняется обратно, и не нужно экспортировать zip-архив на Mac.
+
+Можно настроить сейчас или в любой момент позже в настройках.</string>
+    <string name="icloud_offer_set_up_now">Настроить</string>
+    <string name="icloud_offer_not_now">Не сейчас</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -262,4 +262,10 @@
     <string name="two_factor_again_sign_out">改为退出登录</string>
     <string name="two_factor_again_wrong_code">验证码未通过。还剩 %1$d 次机会。</string>
     <string name="two_factor_again_giving_up">验证码未通过。正在退出登录，你需要重新登录。</string>
+    <string name="icloud_offer_title">从 iCloud 读取你的标签？</string>
+    <string name="icloud_offer_message">本应用可以连接你的 Apple 账户并直接读取标签。新标签会自动出现，重命名会写回账户，也不需要在 Mac 上导出 zip 文件。
+
+你可以现在设置，也可以随时到设置里再设置。</string>
+    <string name="icloud_offer_set_up_now">立即设置</string>
+    <string name="icloud_offer_not_now">暂不</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -262,4 +262,10 @@
     <string name="two_factor_again_sign_out">改為登出</string>
     <string name="two_factor_again_wrong_code">驗證碼未通過。還剩 %1$d 次機會。</string>
     <string name="two_factor_again_giving_up">驗證碼未通過。正在登出，你需要重新登入。</string>
+    <string name="icloud_offer_title">從 iCloud 讀取你的標籤？</string>
+    <string name="icloud_offer_message">本 App 可以連接你的 Apple 帳戶並直接讀取標籤。新標籤會自動出現，重新命名會寫回帳戶，也不需要在 Mac 上匯出 zip 檔案。
+
+你可以現在設定，也可以隨時到設定裡再設定。</string>
+    <string name="icloud_offer_set_up_now">立即設定</string>
+    <string name="icloud_offer_not_now">暫不</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -294,4 +294,10 @@ You can link again later. That needs your Apple device passcode.</string>
     <string name="two_factor_again_sign_out">Sign out instead</string>
     <string name="two_factor_again_wrong_code">That code was not accepted. %1$d attempts left.</string>
     <string name="two_factor_again_giving_up">That code was not accepted. Signing out — you will need to sign in again.</string>
+    <string name="icloud_offer_title">Read your tags from iCloud?</string>
+    <string name="icloud_offer_message">This app can connect to your Apple account and read your tags from it directly. New tags show up on their own, renaming one writes it back, and there is no zip to export from a Mac.
+
+You can set this up now, or any time later from Settings.</string>
+    <string name="icloud_offer_set_up_now">Set up now</string>
+    <string name="icloud_offer_not_now">Not now</string>
 </resources>

--- a/app/src/test/java/dev/wander/android/opentagviewer/db/repo/model/OfferingICloudSetupTest.java
+++ b/app/src/test/java/dev/wander/android/opentagviewer/db/repo/model/OfferingICloudSetupTest.java
@@ -1,0 +1,149 @@
+package dev.wander.android.opentagviewer.db.repo.model;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Who gets asked whether they want to connect an iCloud account.
+ *
+ * <p><b>A one-time prompt has exactly two ways to be wrong</b>, and both are bad enough to pin
+ * every case: shown to somebody it does not apply to, or shown again to somebody who already
+ * said no. The second is worse - it is how a prompt becomes something people close without
+ * reading, and this one is the only mention they will ever get of the feature that removes the
+ * Mac from the story.
+ *
+ * <p>Pure decision logic, so it lives on the JVM. The dialog itself, and the two real journeys
+ * through it, are {@code TheICloudOfferAppearsOnceTest}.
+ */
+public class OfferingICloudSetupTest {
+
+    private static final boolean LINKED = true;
+    private static final boolean NOT_LINKED = false;
+    private static final boolean SIGNED_IN = true;
+
+    /**
+     * <b>Somebody setting the app up from scratch is asked.</b>
+     *
+     * <p>Nothing stored at all: no account, no record of being asked. They have just signed in
+     * and their only route to tags is exporting a zip on a Mac, which is exactly the situation
+     * the offer exists for.
+     */
+    @Test
+    public void anewUserIsAsked() {
+        final UserSettings fresh = UserSettings.builder()
+                // A new install resolves to local Anisette without being asked, so the Anisette
+                // offer is not due and does not stand in front of this one.
+                .anisetteMode(UserSettings.ANISETTE_LOCAL)
+                .build();
+
+        assertTrue("a new user should be offered the account route",
+                fresh.shouldOfferICloud(NOT_LINKED, SIGNED_IN));
+    }
+
+    /**
+     * <b>Somebody updating from an earlier version is asked too</b> - eventually.
+     *
+     * <p>They have settings, a session and no account, and crucially no {@code icloudOfferMade}
+     * key, because the key did not exist when they last ran the app. Absence is what makes the
+     * offer reach them without any migration code.
+     */
+    @Test
+    public void anupgraderIsAskedOnceTheAnisetteQuestionIsSettled() {
+        final UserSettings updated = UserSettings.builder()
+                .anisetteServerUrl("https://someone-elses-server.example")
+                // Already answered, so it is not competing for the screen.
+                .anisetteUpgradeOffered(true)
+                .build();
+
+        assertTrue("somebody updating should be offered the account route",
+                updated.shouldOfferICloud(NOT_LINKED, SIGNED_IN));
+    }
+
+    /**
+     * <b>But not while the Anisette offer is still due.</b>
+     *
+     * <p>Somebody updating qualifies for both at the same moment, and two dialogs stacked on the
+     * map is how people learn to dismiss dialogs unread. Anisette wins because it is about the
+     * session continuing to work at all.
+     *
+     * <p>The important half is that this is a <i>deferral</i>, not a refusal - nothing marks the
+     * offer made, so it comes back on the next launch. The test below pins that.
+     */
+    @Test
+    public void theanisetteOfferGoesFirst() {
+        final UserSettings updating = UserSettings.builder()
+                .anisetteServerUrl("https://someone-elses-server.example")
+                .build();
+
+        assertTrue("this test is meaningless unless the Anisette offer really is due",
+                updating.shouldOfferLocalAnisette(SIGNED_IN));
+        assertFalse("two one-time offers must not arrive at once",
+                updating.shouldOfferICloud(NOT_LINKED, SIGNED_IN));
+    }
+
+    /** And once Anisette has been dealt with, the iCloud offer arrives. */
+    @Test
+    public void deferringForAnisetteDoesNotSpendTheOffer() {
+        final UserSettings updating = UserSettings.builder()
+                .anisetteServerUrl("https://someone-elses-server.example")
+                .build();
+
+        assertFalse(updating.shouldOfferICloud(NOT_LINKED, SIGNED_IN));
+
+        // What the Anisette dialog does when it is shown.
+        updating.setAnisetteUpgradeOffered(true);
+
+        assertTrue("the deferred offer has to come back, not be silently spent",
+                updating.shouldOfferICloud(NOT_LINKED, SIGNED_IN));
+    }
+
+    // --- and nobody else ------------------------------------------------------------------------
+
+    /**
+     * <b>Dismissing it once is final.</b>
+     *
+     * <p>Somebody who is happy importing zips should never be bothered again. The flag is set
+     * when the dialog is shown rather than when a button is pressed, so this covers declining,
+     * dismissing and having the screen torn down mid-dialog alike.
+     */
+    @Test
+    public void somebodyWhoSaidNoIsNeverAskedAgain() {
+        final UserSettings declined = UserSettings.builder()
+                .anisetteMode(UserSettings.ANISETTE_LOCAL)
+                .icloudOfferMade(true)
+                .build();
+
+        assertFalse("a dismissed one-time offer must stay dismissed",
+                declined.shouldOfferICloud(NOT_LINKED, SIGNED_IN));
+    }
+
+    /**
+     * <b>Somebody already reading their account is not asked.</b>
+     *
+     * <p>Even if the flag was somehow never written - a crash between showing the dialog and
+     * saving, say - the question does not apply to them, and asking would read as the app
+     * having lost track of what it is already doing.
+     */
+    @Test
+    public void somebodyAlreadyConnectedIsNotAsked() {
+        final UserSettings connected = UserSettings.builder()
+                .anisetteMode(UserSettings.ANISETTE_LOCAL)
+                .build();
+
+        assertFalse("an account is already connected; there is nothing to offer",
+                connected.shouldOfferICloud(LINKED, SIGNED_IN));
+    }
+
+    /** Both reasons at once is still no, which is the ordinary state after the first run. */
+    @Test
+    public void connectedAndAlreadyAskedIsStillNo() {
+        final UserSettings settled = UserSettings.builder()
+                .anisetteMode(UserSettings.ANISETTE_LOCAL)
+                .icloudOfferMade(true)
+                .build();
+
+        assertFalse(settled.shouldOfferICloud(LINKED, SIGNED_IN));
+    }
+}


### PR DESCRIPTION
Reading tags straight out of the Apple account is the feature that removes the Mac from the
story: tags arrive on their own, new ones appear without another export, and renaming writes
back. It lives behind a Settings item that somebody who has just signed in has no reason to open,
so most people never find it.

This offers it once, after signing in, to exactly the two groups it helps.

## Who gets asked

Somebody **setting the app up from scratch**, and somebody **updating from an earlier version**.
Both are picked out by the same condition, with no migration code and no version check: no
account connected, and no record of having been asked. An upgrader simply has no flag, because
the flag did not exist when they last ran the app.

**Dismissing it is final.** The flag is written when the dialog is *shown* rather than when a
button is pressed, so declining, swiping it away, or having the screen torn down all mean the
same thing. Somebody happy importing zips should never be bothered again — a prompt that returns
is one people learn to close without reading, which costs it any value it had.

**It waits for the Anisette offer.** Somebody updating qualifies for both at the same moment, and
two dialogs stacked on the map is exactly how that learned dismissal starts. Anisette goes first
because it is about the session continuing to work at all; this one is skipped while that is
outstanding and comes back on the next launch, because nothing marks it made in the meantime.

## The deferral did not work, and the tests are what found out

The rule was right. The moment it was consulted was not:

```
AnisetteUpgradeDialog: offering the move to local Anisette
ICloudSetupOffer:      offering to connect an iCloud account
```

Both, at once, on the map. `AnisetteUpgradeDialog.offerIfDue` marks itself as offered by mutating
the settings object — deliberately, so that dismissing counts as an answer — and that is the same
object `shouldOfferICloud` then reads. By the time the iCloud offer asked whether the Anisette one
was due, the answer was always no.

Fixed by asking before the dialog runs rather than after. `UserSettings.shouldOfferICloud` is
unchanged and still correct on its own terms, **which is why all nine JVM tests passed** — they
exercise the rule in isolation, where nothing mutates underneath it. Only driving the real screen
caught it.

## Tests

Nine JVM cases over the decision, and six Espresso cases over the two real journeys — including
that the offer never returns once seen, which is asserted by reopening the map rather than by
reading the flag back: a stored flag nothing consults would look identical in the database and
still nag.

Verified the deferral test catches the bug — putting the guard back out turns exactly that one
red, and nothing else.

### Three mistakes in my own tests, since they are the interesting part

- **They took over ten minutes.** Three assertions asked `inRoot(isDialog())` whether a dialog was
  *absent*, inside `Eventually`. Espresso's root picker retries internally before admitting there
  is no dialog, so the "no" answer is the slow one, and retrying it multiplies that. `AGENTS.md`
  documents this exact trap — it cost `UnlinkTheAccountSettingTest` 6m 33s once already. Reading
  the stored flag instead takes the class to **86 seconds**.
- **No dialog throws `NoMatchingRootException`, not `NoMatchingViewException`.** With nothing up
  there is no dialog *root* to search, so Espresso gives up a step earlier than the obvious
  exception and the helper let it through as a failure.
- **The arrange helper reset one field of four.** The condition reads four, and these are the real
  device's settings, which survive between tests — so one test left `anisetteUpgradeOffered` true
  behind it and the next ran with the Anisette question already answered. It failed for a reason
  unrelated to its subject, and would have passed or failed depending on the order tests ran in.

## The map fixture records the offer as already made

Same reason it already records the Anisette one: a hand-written session with no keychain
membership is precisely who this offer is for, so without it every test built on `AMapWithTagsOnIt`
opens behind a dialog and Espresso's default root stops being the map.

A test that is *about* the offer arranges its own state instead.

## Not in here

The wording says the account route is available; it does not yet explain what the app registers as
on the user's Apple device list, or that removing that entry breaks the connection. That is worth
saying somewhere the user will read it, and it belongs with the connect screen rather than with a
one-line offer.


## And four test classes that were loading Apple's real ADI library

Not strictly part of this feature, but this branch is where three whole-suite aborts got
diagnosed, so the fix travels with it.

The trigger is a session that cannot be restored: `MapsActivity` asks for Anisette on one thread,
the restore fails, the app sends the user to the login screen, and *that* asks for Anisette on
another. `LocalAnisette.ensureReady()` is `synchronized` — on the instance — and
`AppDependencies` hands out a new instance per call, so there is no mutual exclusion. Both
threads unpack the same `.so` files and then `dlopen` them:

```
2419  AdiLibraryFetcher: libstoreservicescore.so: 2.39 MB unpacked
2570  AdiLibraryFetcher: libstoreservicescore.so: 2.39 MB unpacked
```

A native crash takes the instrumentation process with it, so a run does not fail — it *stops*,
and the tests it names are whichever happened to be in flight. That is why this has gone
undiagnosed: the names were never the cause. The logcat artefact added in #130 is what caught it.

Faked in the four classes that drive an activity without going through the map fixture, which
already got this. Worth doing on its own terms regardless: these tests were *downloading* Apple's
libraries mid-suite — `downloaded 2.6 MB of 142 MB` — a network dependency in tests that are not
about Anisette.

**This is a workaround, not the fix.** The app still re-initialises ADI on every Anisette request,
and can still do it from two threads at once. That is
[#135](https://github.com/parawanderer/OpenTagViewer/issues/135), which now carries the full
analysis and is the next thing being worked on.

First fully clean local suite of the day: **575 tests, no failures, no abort.**

---

🤖 Written by [Claude Code](https://claude.com/claude-code)
