### PR TITLE
Load Apple's ADI library once per process, instead of once per caller

### DIFF
--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/LocalAnisette.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/LocalAnisette.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.util.Log;
 
 import dev.wander.android.opentagviewer.db.repo.model.UserSettings;
+import dev.wander.android.opentagviewer.util.LoadedOnce;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -64,6 +65,31 @@ public final class LocalAnisette implements AnisetteSource {
             "libc++_shared.so", "libstoreservicescore.so");
 
     private static final List<String> STUBS = Arrays.asList("CoreFoundation", "mediaplatform");
+
+    /**
+     * Apple's library and the identity it was initialised with - <b>one per process</b>.
+     *
+     * <p><b>Static, because what it holds is.</b> The libraries land at one path, are loaded into
+     * one process, and ADI keeps one lot of state. The old guard was {@code synchronized} on a
+     * {@code LocalAnisette}, and {@code AppDependencies} builds a new one for every caller - so
+     * two callers held two locks and proceeded together, unpacking the same {@code .so} and
+     * {@code dlopen}-ing it. That segfaults. See issue #135.
+     *
+     * <p>{@link LoadedOnce} covers the download and the unpack as well as the load, because the
+     * race starts at the file writes rather than at ADI.
+     */
+    private static final LoadedOnce<ApplesLibrary> APPLES_LIBRARY = new LoadedOnce<>();
+
+    /** Apple's library and the identity it was initialised with, which travel together. */
+    private static final class ApplesLibrary {
+        private final AdiLibrary adi;
+        private final AdiDeviceIdentity identity;
+
+        ApplesLibrary(final AdiLibrary adi, final AdiDeviceIdentity identity) {
+            this.adi = adi;
+            this.identity = identity;
+        }
+    }
 
     /**
      * Every library that has to be present before any of this can run.
@@ -126,12 +152,26 @@ public final class LocalAnisette implements AnisetteSource {
         }
 
         try {
-            final AdiLibraryManifest manifest = AdiLibraryManifest.load(this.context);
-            final File libraryDir = libraryDirectory(this.context, this.abi);
+            // **Once per process, one thread at a time.** Every caller of
+            // AppDependencies.anisette gets a *new* LocalAnisette, so the instance lock this
+            // used to rely on excluded nothing - and two threads getting here together is
+            // ordinary: the map restores a session on one, the restore fails, and the login
+            // screen it redirects to asks on another. They were unpacking the same .so files to
+            // the same paths and dlopening them, which segfaults. See issue #135.
+            //
+            // The download and the unpack are inside, not just the load, because the race starts
+            // at the file writes.
+            final ApplesLibrary loaded = APPLES_LIBRARY.get(() -> {
+                final AdiLibraryManifest manifest = AdiLibraryManifest.load(this.context);
+                final File libraryDir = libraryDirectory(this.context, this.abi);
 
-            download(manifest, libraryDir);
-            verify(manifest, libraryDir);
-            load(libraryDir);
+                download(manifest, libraryDir);
+                verify(manifest, libraryDir);
+                return load(libraryDir);
+            });
+
+            this.adi = loaded.adi;
+            this.identity = loaded.identity;
 
             this.unavailableReason = null;
             return true;
@@ -171,7 +211,29 @@ public final class LocalAnisette implements AnisetteSource {
         }
     }
 
-    private void load(File libraryDir) throws Exception {
+    /**
+     * Load Apple's library and initialise it - <b>once per process, not once per instance</b>.
+     *
+     * <p><b>Everything below the first line happens exactly once.</b> A shared object is loaded
+     * into a process, not into an object, and ADI keeps its state inside that library. The old
+     * code guarded this with {@code this.adi != null} on an instance that
+     * {@code AppDependencies} creates fresh for every caller, so the guard never fired and each
+     * caller re-ran the lot: another {@code dlopen}, another {@code ADILoadLibraryWithPath},
+     * another {@code ADISetProvisioningPath}, against a library already holding all of it.
+     *
+     * <p><b>Only ever called from inside {@link #APPLES_LIBRARY}</b>, which is what makes "once"
+     * true - see {@code ensureReady}.
+     *
+     * <p>Identity is cached with the library rather than re-derived, and not only to save the
+     * read: {@code loadOrCreateIdentity} *creates* one when there is none, so two threads
+     * arriving on a fresh install could mint two different identities and register the app twice
+     * on the user's Apple account. Rule 11 is emphatic that there is one identity.
+     *
+     * <p><b>If {@code ADIProvisioningErase} is ever wired up, it has to clear these.</b> Nothing
+     * calls it today, which is the only reason there is no invalidation here; resetting Anisette
+     * against a cached, already-initialised library would appear to work and change nothing.
+     */
+    private ApplesLibrary load(File libraryDir) throws Exception {
         for (final String stub : STUBS) {
             System.loadLibrary(stub);
         }
@@ -184,8 +246,11 @@ public final class LocalAnisette implements AnisetteSource {
         new AdiProvisioning(deviceIdentity, library)
                 .provisionIfNeeded(AdiProvisioning.ANONYMOUS_DS_ID);
 
-        this.adi = library;
-        this.identity = deviceIdentity;
+        // Returned rather than assigned: LoadedOnce caches only on success, so a throw above
+        // leaves nothing behind and the next caller tries again. A half-initialised library in
+        // the cache would be handed to everyone after it, and would read as Apple rejecting the
+        // app rather than as a bad load.
+        return new ApplesLibrary(library, deviceIdentity);
     }
 
     /**

--- a/app/src/main/java/dev/wander/android/opentagviewer/util/LoadedOnce.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/util/LoadedOnce.java
@@ -1,0 +1,76 @@
+package dev.wander.android.opentagviewer.util;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+/**
+ * Something expensive and unrepeatable, built at most once however many threads ask.
+ *
+ * <p><b>Written because getting this wrong crashed the app, natively.</b> Apple's ADI library is
+ * loaded into the process, unpacked to a fixed path, and initialised with state it keeps inside
+ * itself - so building it twice is not merely wasteful, and building it twice *concurrently*
+ * meant two threads writing the same {@code .so} and then {@code dlopen}-ing it. The guard that
+ * was supposed to prevent it was {@code synchronized} on an object the caller created fresh every
+ * time, which excludes nothing at all. See issue #135.
+ *
+ * <p><b>The rule lives here rather than inline so it can be tested.</b> Exercising it in place
+ * means downloading Apple's libraries and running their native code, which the instrumented suite
+ * deliberately does not do - so inline, the one property that matters would be verified by
+ * reading it. Here it is a handful of lines with a JVM test that runs threads at it.
+ *
+ * <p>Two properties, and the second is the one that is easy to lose:
+ *
+ * <ul>
+ *   <li><b>The supplier runs at most once</b>, whatever the contention.</li>
+ *   <li><b>A failure is not remembered.</b> If the supplier throws, nothing is cached and the
+ *       next caller tries again. Caching the failure would turn one flat network moment into an
+ *       app that never loads Anisette again until it is restarted.</li>
+ * </ul>
+ *
+ * <p>Deliberately not double-checked locking, and deliberately not {@code volatile}: the whole
+ * point is that every read happens under the lock, and a field that looks safe to read outside
+ * one invites exactly the unsynchronised access this exists to stop. Contention here is a handful
+ * of calls over the life of a process.
+ */
+public final class LoadedOnce<T> {
+
+    /** What a caller does to build the value. Allowed to fail, unlike {@code Supplier}. */
+    public interface Build<T> {
+        T make() throws Exception;
+    }
+
+    @Nullable
+    private T value;
+
+    /**
+     * The value, building it if this is the first ask.
+     *
+     * @param build run only when there is nothing cached yet, and only by one thread at a time.
+     * @throws Exception whatever {@code build} threw, with nothing cached.
+     */
+    public synchronized T get(final Build<T> build) throws Exception {
+        if (this.value == null) {
+            // Assigned only after `make` returns. A half-built value published here would be
+            // handed to every later caller, and the failure would surface far from its cause.
+            this.value = build.make();
+        }
+        return this.value;
+    }
+
+    /** Whether anything has been built yet. */
+    public synchronized boolean isLoaded() {
+        return this.value != null;
+    }
+
+    /**
+     * Throw away what was built, so the next ask builds again.
+     *
+     * <p>Nothing in the app calls this yet. It is here because the thing this holds - an
+     * initialised ADI - has a reset in Apple's API ({@code ADIProvisioningErase}), and wiring
+     * that up without clearing this would appear to work and change nothing.
+     */
+    @VisibleForTesting
+    public synchronized void forget() {
+        this.value = null;
+    }
+}

--- a/app/src/test/java/dev/wander/android/opentagviewer/util/LoadedOnceTest.java
+++ b/app/src/test/java/dev/wander/android/opentagviewer/util/LoadedOnceTest.java
@@ -1,0 +1,160 @@
+package dev.wander.android.opentagviewer.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+/**
+ * Building something at most once, however many threads want it.
+ *
+ * <p><b>The rule that stops the app crashing natively.</b> Apple's ADI library is loaded into the
+ * process and initialised with state it keeps inside itself, so two threads building it at once
+ * meant two writes of the same {@code .so} and two {@code dlopen}s - a segfault that took whole
+ * test runs down and named arbitrary tests on the way. Issue #135.
+ *
+ * <p>Tested here rather than in place because in place means downloading Apple's libraries and
+ * running their native code, which the suite deliberately avoids. So the property is pulled out
+ * to where threads can actually be run at it.
+ */
+public class LoadedOnceTest {
+
+    @Test
+    public void thefirstAskBuildsIt() throws Exception {
+        final LoadedOnce<String> once = new LoadedOnce<>();
+
+        assertFalse("nothing should be built before anybody asks", once.isLoaded());
+        assertEquals("built", once.get(() -> "built"));
+        assertTrue(once.isLoaded());
+    }
+
+    @Test
+    public void latercallersGetTheSameThingWithoutBuildingIt() throws Exception {
+        final LoadedOnce<Object> once = new LoadedOnce<>();
+        final AtomicInteger builds = new AtomicInteger();
+
+        final Object first = once.get(() -> {
+            builds.incrementAndGet();
+            return new Object();
+        });
+        final Object second = once.get(() -> {
+            builds.incrementAndGet();
+            return new Object();
+        });
+
+        assertSame("the second ask must not build a second one", first, second);
+        assertEquals(1, builds.get());
+    }
+
+    /**
+     * <b>The one that matters: twenty threads, one build.</b>
+     *
+     * <p>All of them released at the same instant, because a loop that calls twenty times in
+     * sequence would pass against a completely unsynchronised implementation - which is exactly
+     * the implementation this replaces.
+     */
+    @Test
+    public void twentyThreadsAtOnceStillBuildItOnce() throws Exception {
+        final LoadedOnce<Object> once = new LoadedOnce<>();
+        final AtomicInteger builds = new AtomicInteger();
+        final CountDownLatch go = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(20);
+        final List<Object> got = new ArrayList<>();
+
+        for (int i = 0; i < 20; i++) {
+            new Thread(() -> {
+                try {
+                    go.await();
+                    final Object value = once.get(() -> {
+                        builds.incrementAndGet();
+                        // Long enough that an unsynchronised version is certain to overlap
+                        // rather than merely likely to.
+                        Thread.sleep(20);
+                        return new Object();
+                    });
+                    synchronized (got) {
+                        got.add(value);
+                    }
+                } catch (final Exception e) {
+                    fail("a caller failed: " + e);
+                } finally {
+                    done.countDown();
+                }
+            }).start();
+        }
+
+        go.countDown();
+        assertTrue("threads did not finish", done.await(30, java.util.concurrent.TimeUnit.SECONDS));
+
+        assertEquals("it was built more than once under contention", 1, builds.get());
+        assertEquals(20, got.size());
+        for (final Object value : got) {
+            assertSame("callers got different values", got.get(0), value);
+        }
+    }
+
+    /**
+     * <b>A failure is not remembered.</b>
+     *
+     * <p>Caching the failure would turn one flat network moment into an app that never loads
+     * Anisette again until it is restarted - and the caller's fallback is a remote server, so
+     * nothing would look broken enough to investigate.
+     */
+    @Test
+    public void afailedBuildIsRetriedRatherThanRemembered() throws Exception {
+        final LoadedOnce<String> once = new LoadedOnce<>();
+
+        try {
+            once.get(() -> {
+                throw new IllegalStateException("no network");
+            });
+            fail("the failure should have reached the caller");
+        } catch (final IllegalStateException expected) {
+            // what the caller has to see
+        }
+
+        assertFalse("a failure must not count as being loaded", once.isLoaded());
+        assertEquals("the next ask has to try again", "second time lucky",
+                once.get(() -> "second time lucky"));
+    }
+
+    /** And once it has succeeded, an earlier failure is ancient history. */
+    @Test
+    public void asuccessAfterAFailureIsKept() throws Exception {
+        final LoadedOnce<String> once = new LoadedOnce<>();
+
+        try {
+            once.get(() -> {
+                throw new IllegalStateException("no network");
+            });
+        } catch (final IllegalStateException ignored) {
+            // expected
+        }
+
+        once.get(() -> "loaded");
+
+        assertEquals("loaded", once.get(() -> {
+            throw new AssertionError("must not build again");
+        }));
+    }
+
+    /** Forgetting is what a future ADIProvisioningErase would need. */
+    @Test
+    public void forgettingMakesTheNextAskBuildAgain() throws Exception {
+        final LoadedOnce<String> once = new LoadedOnce<>();
+
+        once.get(() -> "first");
+        once.forget();
+
+        assertFalse(once.isLoaded());
+        assertEquals("second", once.get(() -> "second"));
+    }
+}


### PR DESCRIPTION
Three whole-suite aborts today, each naming different tests, all the same native crash. The
logcat artefact added in #130 is what made it findable.

```
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), tid RxCachedThreadS
  libstoreservicescore.so
  <- NativeAdi.callWithPath <- AdiLibrary.initialise <- LocalAnisette.load
  <- LocalAnisette.ensureReady <- AnisetteStatus.of
```

## The guard that guarded nothing

```java
public synchronized boolean ensureReady() {
    if (this.adi != null) {
        return true;
    }
```

That reads like "load it once". It is not, because of one line elsewhere:

```java
anisetteFactory = LocalAnisette::new;   // AppDependencies
```

Every caller gets a **fresh instance** — so its `adi` field is always null, and its lock is
always uncontended. The guard never fired and the `synchronized` excluded nothing, while the
thing being guarded — a shared object loaded into the process, and ADI's own internal state — is
per-process.

## Two at once is the ordinary case, not a corner

It is what an expired session does:

1. `MapsActivity` starts restoring and asks for Anisette on an Rx thread.
2. The restore fails, so the app sends the user to the login screen.
3. `AppleLoginActivity` calls `AnisetteStatus.of(AppDependencies.anisette(...))` — while the
   first is still working.

Both then unpack the same files to the same path before loading them:

```
2419  AdiLibraryFetcher: libstoreservicescore.so: 2.39 MB unpacked
2570  AdiLibraryFetcher: libstoreservicescore.so: 2.39 MB unpacked
```

## The fix

Apple's library is held in a process-wide `LoadedOnce`, and the lock covers the **download and
unpack** as well as the initialise — the race starts at the file writes, not at ADI.

Two things surfaced while writing it:

- **The identity is cached with the library.** `loadOrCreateIdentity` *creates* one when there is
  none, so two threads on a fresh install could mint two different identities and register this
  app **twice** on somebody's Apple account. Rule 11 is emphatic that there is one identity;
  nothing had noticed this route to breaking it.
- **A failed load must not be cached.** One flat network moment cannot mean Anisette never loads
  again until restart — and because the fallback is a remote server, nothing would look broken
  enough to investigate.

## Making it testable, which inline it was not

Exercising this in place means downloading Apple's libraries and running their native code, which
the instrumented suite deliberately avoids. Left inline, the one property that matters would have
been verified by reading it.

So the rule is a small class, `LoadedOnce`, with a JVM test that releases **twenty threads at
once** and asserts the supplier ran exactly once — plus that a failure is retried rather than
remembered, and that `forget()` works, which a future `ADIProvisioningErase` will need.

Verified it catches the real bug: dropping `synchronized` from `get()` — literally the shape
`LocalAnisette` had — turns exactly that test red and nothing else.

## Evidence the app is fixed, not just the tests

The iCloud PR removed the *trigger* from four test classes by faking Anisette. That was a
workaround and was described as one.

**This branch has none of those fakes.** The classes that were aborting runs still load Apple's
real library here — and the suite completes: **569 tests, no failures, no abort**, where three
runs earlier today stopped at 335, 374 and 489.

Not proof that every abort had this cause, but it is the only one anybody has a stack trace for,
and the trigger is an ordinary user state rather than a test artefact.

Closes #135

---

🤖 Written by [Claude Code](https://claude.com/claude-code)
