### PR TITLE
Say what this app registers as on the user's Apple account

### DIFF
--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/FetchFromICloudFlowTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/FetchFromICloudFlowTest.java
@@ -3,6 +3,7 @@ package dev.wander.android.opentagviewer;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -12,9 +13,21 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.util.Log;
+import android.view.View;
+
+import androidx.lifecycle.Lifecycle;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.google.android.material.color.MaterialColors;
+
+import java.io.File;
+import java.io.FileOutputStream;
 
 import org.junit.After;
 import org.junit.Test;
@@ -22,6 +35,7 @@ import org.junit.runner.RunWith;
 
 import java.util.List;
 
+import dev.wander.android.opentagviewer.anisette.AdiDeviceIdentity;
 import dev.wander.android.opentagviewer.db.AccountBeaconsForTests;
 import dev.wander.android.opentagviewer.python.AppDependencies;
 import dev.wander.android.opentagviewer.python.icloud.FakeICloudService;
@@ -124,6 +138,143 @@ public class FetchFromICloudFlowTest {
         Eventually.check(() -> onView(withText(containsString("Bike")))
                 .check(matches(isDisplayed())));
         TestPace.afterAStep();
+    }
+
+    /**
+     * <b>And the results tell them what is now sitting on their Apple account.</b>
+     *
+     * <p>Connecting registered this app as a device. Apple will show that row next to "If you do
+     * not recognise this device" with a Remove button, and removing it breaks the connection this
+     * screen just made - hours later, somewhere else, with nothing linking the two.
+     *
+     * <p>{@code WhatWeRegisterAsIsLegibleTest} covers whether the card can be read. This covers
+     * the part that test cannot see: that it is on the screen the user actually arrives at, below
+     * the tags and reachable by scrolling. A card that inflates perfectly into a screen nobody
+     * routes to would pass there and be worth nothing.
+     */
+    @Test
+    public void theresultsSayWhatIsNowOnTheAppleAccount() {
+        this.open(FakeICloudService.withTags().alsoSkipping("My MacBook", "My iPhone"));
+
+        this.chooseTheFirstDevice();
+        this.typeThePasscode();
+
+        Eventually.check(() -> onView(withId(R.id.icloud_results_container))
+                .check(matches(isDisplayed())));
+        TestPace.afterAStep();
+
+        // The tags are not the last word: what this app put on the account comes after them.
+        Eventually.check(() -> onView(withId(R.id.icloud_primary_button))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.icloud_primary_button)).perform(click());
+        TestPace.afterAStep();
+
+        Eventually.check(() -> onView(withId(R.id.icloud_registered_container))
+                .check(matches(isDisplayed())));
+
+        // **The tile has to describe the machine the app actually registers as.** Read from the
+        // same profile the identity is built from rather than written out here, because a literal
+        // would keep passing after the profile changed - and the failure it would hide is a
+        // screen telling somebody to look for a device that is not on their account. Rule 11.
+        final AdiDeviceIdentity.Hardware hardware = AdiDeviceIdentity.Hardware.DEFAULT;
+
+        onView(withId(R.id.icloud_registered_device_name))
+                .check(matches(withText(hardware.deviceListName())));
+        // Model and OS share a line, and the serial sits behind a translated label, so these are
+        // containment checks - the surrounding wording is the locale's business, the values are
+        // not.
+        onView(withId(R.id.icloud_registered_device_model))
+                .check(matches(withText(containsString(hardware.marketingName()))));
+        onView(withId(R.id.icloud_registered_device_model))
+                .check(matches(withText(containsString(hardware.osVersion()))));
+        onView(withId(R.id.icloud_registered_device_serial))
+                .check(matches(withText(containsString(AdiDeviceIdentity.APP_SERIAL))));
+        TestPace.afterAStep();
+
+        onView(withId(R.id.icloud_registered_body)).perform(scrollTo());
+        onView(withId(R.id.icloud_registered_body))
+                .check(matches(withText(containsString(AdiDeviceIdentity.APP_SERIAL))));
+
+        // The serial reaches the sentence as well as the tile. The resource holds a ^1 slot, and
+        // a template that lost it expands to a sentence about "the serial" that never says which.
+        onView(withId(R.id.icloud_registered_link))
+                .check(matches(withText(containsString("account.apple.com"))));
+
+        // **The only picture of this page assembled.** WhatWeRegisterAsIsLegibleTest inflates the
+        // layout without an activity, so the tile is blank and the slots unexpanded there - the
+        // chip and the link styling exist only once something has filled them in.
+        this.writeShotOf(R.id.icloud_registered_container, "registered_page");
+        TestPace.afterAStep();
+    }
+
+    private void writeShotOf(final int id, final String name) {
+        final String dir = InstrumentationRegistry.getArguments()
+                .getString("additionalTestOutputDir");
+        if (dir == null) {
+            return;
+        }
+
+        this.scenario.onActivity(activity -> {
+            try {
+                final View view = activity.findViewById(id);
+                final Bitmap bitmap = Bitmap.createBitmap(
+                        view.getWidth(), view.getHeight(), Bitmap.Config.ARGB_8888);
+
+                // The container is transparent; without this the PNG is the page drawn on black.
+                final Canvas canvas = new Canvas(bitmap);
+                canvas.drawColor(MaterialColors.getColor(
+                        view, com.google.android.material.R.attr.colorSurface));
+                view.draw(canvas);
+
+                try (FileOutputStream out =
+                             new FileOutputStream(new File(new File(dir), name + ".png"))) {
+                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
+                }
+            } catch (final Exception e) {
+                // A screenshot explains a failure; it is never the reason for one.
+                Log.w("FetchFromICloudFlowTest", "could not write " + name, e);
+            }
+        });
+    }
+
+    /**
+     * <b>And that page is the end of the flow, not a detour off it.</b>
+     *
+     * <p>It was reached by a button that used to say Done and now says Next, so the risk is a
+     * screen nobody can leave: the step is new, and the button it inherits is the one that used
+     * to close the activity.
+     */
+    @Test
+    public void thedeviceNoteIsTheLastStepAndCloses() {
+        this.open(FakeICloudService.withTags());
+
+        this.chooseTheFirstDevice();
+        this.typeThePasscode();
+
+        Eventually.check(() -> onView(withId(R.id.icloud_results_container))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.icloud_primary_button)).perform(click());
+
+        Eventually.check(() -> onView(withId(R.id.icloud_registered_container))
+                .check(matches(isDisplayed())));
+        TestPace.afterAStep();
+
+        // Asking the activity, not Espresso: a click that closed the screen and a click that
+        // missed both leave onView throwing, and only one of them is a failure.
+        Eventually.perform("the done button", this::isFinishing,
+                () -> onView(withId(R.id.icloud_primary_button)).perform(click()));
+    }
+
+    /**
+     * Whether the screen has gone.
+     *
+     * <p>Asked of the scenario, not of the activity. {@code onActivity} throws
+     * {@code "Cannot run onActivity since Activity has been destroyed already"} - so the obvious
+     * spelling of this fails precisely when the answer is yes, and a test waiting for the screen
+     * to close cannot use it to find out that the screen closed.
+     */
+    private boolean isFinishing() {
+        return this.scenario.getState() == Lifecycle.State.DESTROYED;
     }
 
     /** The passcode goes to the device that was actually chosen, not the first in the list. */

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/SignInThenGetTagsJourneyTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/SignInThenGetTagsJourneyTest.java
@@ -151,6 +151,13 @@ public class SignInThenGetTagsJourneyTest {
         TestPace.afterAStep();
         onView(withId(R.id.icloud_primary_button)).perform(click());
 
+        // **The tags are not the last step.** What this app registered as on the Apple account
+        // comes after them, so the results button says Next and this one says Done.
+        Eventually.check(() -> onView(withId(R.id.icloud_registered_container))
+                .check(matches(isDisplayed())));
+        TestPace.afterAStep();
+        onView(withId(R.id.icloud_primary_button)).perform(click());
+
         // Back on the device list, which rebuilt itself when the fetch reported tags.
         Eventually.check(() -> onView(withId(R.id.my_devices_list))
                 .check(matches(isDisplayed())));

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/TheWholeAppJourneyTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/TheWholeAppJourneyTest.java
@@ -375,6 +375,13 @@ public class TheWholeAppJourneyTest {
         TestPace.afterAStep();
         onView(withId(R.id.icloud_primary_button)).perform(click());
 
+        // **The tags are not the last step.** What this app registered as on the Apple account
+        // comes after them, so the results button says Next and this one says Done.
+        Eventually.check(() -> onView(withId(R.id.icloud_registered_container))
+                .check(matches(isDisplayed())));
+        TestPace.afterAStep();
+        onView(withId(R.id.icloud_primary_button)).perform(click());
+
         // Back on the device list, which rebuilt itself when the fetch reported tags.
         Eventually.check(() -> onView(withId(R.id.my_devices_list))
                 .check(matches(isDisplayed())));

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/python/IdentityBridgeTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/python/IdentityBridgeTest.java
@@ -16,6 +16,7 @@ import com.chaquo.python.android.AndroidPlatform;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import dev.wander.android.opentagviewer.anisette.AdiDeviceIdentity;
 import dev.wander.android.opentagviewer.anisette.AdiDeviceIdentity.Hardware;
 import dev.wander.android.opentagviewer.anisette.FakeAnisetteSource;
 
@@ -59,6 +60,24 @@ public class IdentityBridgeTest {
     private static PyObject profileFor(Hardware hardware) {
         return identity().callAttr(
                 "hardwareProfile", FakeAnisetteSource.ready().claiming(hardware));
+    }
+
+    /**
+     * <b>The serial Java shows the user is the serial Python sends Apple.</b>
+     *
+     * <p>Python owns {@code APP_SERIAL}; {@code AdiDeviceIdentity.APP_SERIAL} is a copy, so that
+     * the screen naming the device-list entry does not have to start CPython to draw a label. Two
+     * copies of one value is what rule 11 is about, and this is the pin that stops them drifting.
+     *
+     * <p>The failure it prevents is quiet and nasty: the app registers under one serial and the
+     * screen tells the user to look for another, so the row they find looks like somebody else's
+     * device - which is the exact belief that gets it removed.
+     */
+    @Test
+    public void theserialOnScreenIsTheSerialOnTheWire() {
+        assertEquals("Java shows a serial Python never sends",
+                identity().get("APP_SERIAL").toString(),
+                AdiDeviceIdentity.APP_SERIAL);
     }
 
     /**

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/icloud/WhatWeRegisterAsIsLegibleTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/icloud/WhatWeRegisterAsIsLegibleTest.java
@@ -1,0 +1,353 @@
+package dev.wander.android.opentagviewer.ui.icloud;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Typeface;
+import android.text.Spanned;
+import android.text.style.StyleSpan;
+import android.util.Log;
+import android.util.TypedValue;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import dev.wander.android.opentagviewer.R;
+
+/**
+ * The page telling somebody what this app puts on their Apple account.
+ *
+ * <p><b>It exists because of what Apple shows next to it.</b> Connecting registers this app as a
+ * device, and the account's device list renders that entry beside the words "If you do not
+ * recognise this device", with a Remove button. An unexplained row is a row people remove - and
+ * removing it breaks a connection that was working, hours later, with nothing linking the two.
+ * So the page has to be read, which means it has to be legible.
+ *
+ * <p><b>Contrast is a number, not an opinion.</b> The tile sits on a tinted surface rather than
+ * the page background, so its text is not covered by whatever contrast the rest of the screen
+ * has: a body colour that is fine on {@code colorSurface} can fail on
+ * {@code colorSurfaceContainerLow}, and can fail in only one of the two themes. Both are checked.
+ *
+ * <p>What this <b>cannot</b> see is the tile's contents: the model, OS and serial are set by
+ * {@code FetchFromICloudActivity} from the identity the app actually registers under, so that
+ * they cannot describe a different machine than the one on the account. Asserted there, driving
+ * the real screen.
+ *
+ * <p>Screenshots are written alongside and are <b>not</b> the assertion - they explain what a
+ * failure looks like. See {@code .claude/skills/device-screenshots/}.
+ */
+@RunWith(AndroidJUnit4.class)
+public class WhatWeRegisterAsIsLegibleTest {
+
+    private static final String TAG = "RegisteredNoteTest";
+
+    /** WCAG AA for body text. This page is long enough that people have to actually read it. */
+    private static final double READABLE = 4.5d;
+
+    private static final int WIDTH_PX = 1000;
+
+    private static File outputDir;
+
+    @BeforeClass
+    public static void resolveOutputDir() {
+        final String fromAgp = InstrumentationRegistry.getArguments()
+                .getString("additionalTestOutputDir");
+
+        outputDir = fromAgp != null
+                ? new File(fromAgp)
+                : getInstrumentation().getTargetContext().getExternalFilesDir("registered-note");
+
+        if (outputDir != null && !outputDir.exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            outputDir.mkdirs();
+        }
+        Log.i(TAG, "Writing screenshots to " + outputDir);
+    }
+
+    /**
+     * <b>It inflates, and every part the activity fills in is really there.</b>
+     *
+     * <p>A renamed id still compiles. The screen would come up with the tile present and blank -
+     * on a step most people see once per connect and read once, ever.
+     */
+    @Test
+    public void thepageInflatesWithEveryPartTheActivityFillsIn() {
+        final View note = inflateNote(dayTheme());
+
+        for (final int id : new int[]{
+                R.id.icloud_registered_lead,
+                R.id.icloud_registered_icon,
+                R.id.icloud_registered_device_name,
+                R.id.icloud_registered_device_model,
+                R.id.icloud_registered_device_serial,
+                R.id.icloud_registered_body,
+                R.id.icloud_registered_link,
+        }) {
+            assertNotNull("a view the activity looks up is not in the layout: "
+                    + note.getResources().getResourceEntryName(id), note.findViewById(id));
+        }
+    }
+
+    /**
+     * <b>It names the serial, and does not claim the entry is called "OpenTagViewer".</b>
+     *
+     * <p>It is not. Apple synthesises the row's title from the claimed model and ignores the name
+     * the app sends, so the entry reads {@code MacBookPro} - confirmed on a real account. The copy
+     * said "it appears in your device list as OpenTagViewer" until somebody looked, which would
+     * have sent people hunting for a row that does not exist and mistrusting the one that does.
+     *
+     * <p>Which leaves the serial carrying the whole identification, so it has to be printed.
+     */
+    @Test
+    public void itnamesTheSerialAndNotAnAppNameAppleDiscards() {
+        final View note = inflateNote(dayTheme());
+        final String body = textOf(note, R.id.icloud_registered_body);
+
+        // **The slot, not the serial.** The serial is dropped in at runtime as a code chip, so
+        // what the resource holds is the template. A translation that loses "^1" does not throw
+        // and does not fail anything - expandTemplate simply finds nothing to replace, and that
+        // locale's copy talks about "the serial" without ever giving it.
+        assertTrue("the body has no ^1 slot, so nothing puts the serial into the sentence that is"
+                + " about the serial", body.contains("^1"));
+
+        assertFalse("Apple ignores the name this app sends and titles the row from the model, so"
+                        + " promising it appears as \"OpenTagViewer\" sends people looking for a"
+                        + " row that is not there",
+                body.contains("OpenTagViewer"));
+    }
+
+    /**
+     * <b>The "do not remove it" sentence is actually bold, and bold only where it should be.</b>
+     *
+     * <p>The emphasis is the point of the sentence, and it lives in the resource as {@code <b>} -
+     * markup that survives a great many ways of not surviving. An escaped angle bracket, a
+     * translation whose tags were dropped, a {@code setText} that passed {@code toString()}: each
+     * renders the words unemphasised, all ten locales at once, with nothing failing anywhere.
+     *
+     * <p>The second half is what keeps this honest. Asserting only that <i>something</i> is bold
+     * would pass just as well if the whole paragraph were - which is the same as none of it being
+     * bold, since emphasis is a contrast and not a property.
+     */
+    @Test
+    public void thewarningIsEmphasisedAndNotJustWorded() {
+        final View note = inflateNote(dayTheme());
+        final CharSequence body =
+                ((TextView) note.findViewById(R.id.icloud_registered_body)).getText();
+
+        assertTrue("the body carries no markup at all, so <b> was lost on the way to the screen",
+                body instanceof Spanned);
+
+        final Spanned spanned = (Spanned) body;
+
+        int boldTo = -1;
+        for (final StyleSpan span : spanned.getSpans(0, spanned.length(), StyleSpan.class)) {
+            if ((span.getStyle() & Typeface.BOLD) != 0) {
+                boldTo = Math.max(boldTo, spanned.getSpanEnd(span));
+            }
+        }
+
+        assertTrue("nothing in the body is bold", boldTo > 0);
+        assertTrue("the whole body is bold, which emphasises nothing - the warning is the first"
+                + " sentence, not the page", boldTo < spanned.length());
+    }
+
+    /**
+     * <b>And the warning stands alone, with a blank line under it.</b>
+     *
+     * <p>It is the one sentence on this page that has to be read by somebody skimming, so it gets
+     * its own paragraph rather than a bold run at the head of a block of text. A single newline
+     * here reads as a wrapped line and puts it back in the paragraph.
+     */
+    @Test
+    public void thewarningHasAParagraphToItself() {
+        final View note = inflateNote(dayTheme());
+        final String body = textOf(note, R.id.icloud_registered_body);
+
+        final int firstBreak = body.indexOf('\n');
+        assertTrue("there is no line break after the warning at all", firstBreak > 0);
+        assertTrue("the warning is followed by one newline rather than a blank line, so it reads"
+                        + " as part of the paragraph under it",
+                body.startsWith("\n\n", firstBreak));
+    }
+
+    /**
+     * <b>And it arrives as paragraphs, not as one wall of text.</b>
+     *
+     * <p>This is a resource-file trap rather than a styling preference. A real newline typed into
+     * {@code strings.xml} is whitespace, and Android collapses it - only the literal escape
+     * {@code \n} survives to the screen. Both look identical in the XML, in the diff and in a
+     * translation JSON, so this shipped once as a single nine-line block and nothing said so;
+     * it was caught by looking at the render. Ten locales get this wrong or right together, so
+     * asserting on the default one is enough.
+     */
+    @Test
+    public void itreadsAsParagraphsRatherThanOneBlock() {
+        final View note = inflateNote(dayTheme());
+
+        assertTrue("the body has no line break in it, so the paragraph splits were written as"
+                        + " real newlines and Android collapsed them into spaces - they have to be"
+                        + " the literal escape to survive",
+                textOf(note, R.id.icloud_registered_body).contains("\n"));
+    }
+
+    /** Readable on the tinted tile and the page around it, in daylight. */
+    @Test
+    public void thepageIsReadableInTheDayTheme() {
+        assertReadable(dayTheme(), "day");
+    }
+
+    /**
+     * And at night, which is the half that goes unlooked at.
+     *
+     * <p>The tile's tint and the text colour both come from the theme, so they move together -
+     * and a pair clearing 4.5:1 in one mode can miss in the other.
+     */
+    @Test
+    public void thepageIsReadableInTheNightTheme() {
+        assertReadable(nightTheme(), "night");
+    }
+
+    // --- the work -------------------------------------------------------------------------------
+
+    private void assertReadable(final Context context, final String label) {
+        final View note = inflateNote(context);
+
+        final int tile = resolve(
+                context, com.google.android.material.R.attr.colorSurfaceContainerLow);
+        final int page = resolve(context, com.google.android.material.R.attr.colorSurface);
+
+        writeShot(note, "registered_note-" + label);
+
+        // On the tile: the serial is the field somebody compares character by character.
+        assertContrast(label, note, R.id.icloud_registered_device_name, tile);
+        assertContrast(label, note, R.id.icloud_registered_device_model, tile);
+        assertContrast(label, note, R.id.icloud_registered_device_serial, tile);
+
+        // On the page behind it.
+        assertContrast(label, note, R.id.icloud_registered_lead, page);
+        assertContrast(label, note, R.id.icloud_registered_body, page);
+        assertContrast(label, note, R.id.icloud_registered_link, page);
+    }
+
+    private void assertContrast(
+            final String label, final View note, final int id, final int background) {
+        final TextView text = note.findViewById(id);
+        final double ratio = contrastRatio(text.getCurrentTextColor(), background);
+
+        assertTrue(label + ": " + note.getResources().getResourceEntryName(id) + " is "
+                        + round(ratio) + ":1, under the " + READABLE + ":1 needed to read it",
+                ratio >= READABLE);
+    }
+
+    private static String textOf(final View note, final int id) {
+        return ((TextView) note.findViewById(id)).getText().toString();
+    }
+
+    /**
+     * The page, inflated on its own.
+     *
+     * <p>The shipping layout, not a copy - {@code activity_fetch_from_icloud} includes this same
+     * file, so there is nothing here that can drift from what the user sees. Inflating the whole
+     * screen instead is not an option: it holds a {@code CircularProgressIndicator}, which will
+     * not inflate outside an activity, and this would have been untestable for a reason having
+     * nothing to do with it.
+     */
+    private View inflateNote(final Context context) {
+        final View note = LayoutInflater.from(context)
+                .inflate(R.layout.icloud_registered_note, null, false);
+
+        assertNotNull("the layout did not inflate", note);
+
+        note.measure(
+                View.MeasureSpec.makeMeasureSpec(WIDTH_PX, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
+        note.layout(0, 0, note.getMeasuredWidth(), note.getMeasuredHeight());
+
+        assertTrue("it measured to nothing, so nobody would see it",
+                note.getMeasuredHeight() > 0);
+
+        return note;
+    }
+
+    private void writeShot(final View view, final String name) {
+        if (outputDir == null) {
+            return;
+        }
+        try {
+            final Bitmap bitmap = Bitmap.createBitmap(
+                    view.getMeasuredWidth(), view.getMeasuredHeight(), Bitmap.Config.ARGB_8888);
+            view.draw(new Canvas(bitmap));
+
+            try (FileOutputStream out = new FileOutputStream(new File(outputDir, name + ".png"))) {
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
+            }
+        } catch (final Exception e) {
+            // A screenshot explains a failure; it is never the reason for one.
+            Log.w(TAG, "could not write " + name, e);
+        }
+    }
+
+    private static double round(final double value) {
+        return Math.round(value * 100d) / 100d;
+    }
+
+    private static Context dayTheme() {
+        return new ContextThemeWrapper(
+                getInstrumentation().getTargetContext(), R.style.Theme_OpenTagViewer);
+    }
+
+    private static Context nightTheme() {
+        final Context base = getInstrumentation().getTargetContext();
+
+        final Configuration night = new Configuration(base.getResources().getConfiguration());
+        night.uiMode = (night.uiMode & ~Configuration.UI_MODE_NIGHT_MASK)
+                | Configuration.UI_MODE_NIGHT_YES;
+
+        return new ContextThemeWrapper(
+                base.createConfigurationContext(night), R.style.Theme_OpenTagViewer);
+    }
+
+    private static int resolve(final Context context, final int attr) {
+        final TypedValue value = new TypedValue();
+        assertTrue("the theme cannot resolve a colour the layout uses",
+                context.getTheme().resolveAttribute(attr, value, true));
+        return value.data;
+    }
+
+    private static double relativeLuminance(final int colour) {
+        final double[] channel = {
+                ((colour >> 16) & 0xff) / 255d,
+                ((colour >> 8) & 0xff) / 255d,
+                (colour & 0xff) / 255d,
+        };
+        for (int i = 0; i < channel.length; i++) {
+            channel[i] = channel[i] <= 0.04045d
+                    ? channel[i] / 12.92d
+                    : Math.pow((channel[i] + 0.055d) / 1.055d, 2.4d);
+        }
+        return 0.2126d * channel[0] + 0.7152d * channel[1] + 0.0722d * channel[2];
+    }
+
+    private static double contrastRatio(final int a, final int b) {
+        final double la = relativeLuminance(a);
+        final double lb = relativeLuminance(b);
+        return (Math.max(la, lb) + 0.05d) / (Math.min(la, lb) + 0.05d);
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/mydevices/TheMapIsToldWhatChangedTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/mydevices/TheMapIsToldWhatChangedTest.java
@@ -117,6 +117,11 @@ public class TheMapIsToldWhatChangedTest {
                 .check(matches(isDisplayed())));
         onView(withId(R.id.icloud_primary_button)).perform(click());
 
+        // What this app registered as on the Apple account, which the results step now leads to.
+        Eventually.check(() -> onView(withId(R.id.icloud_registered_container))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.icloud_primary_button)).perform(click());
+
         // The list rebuilds itself here - which is what used to lose the flag.
         Eventually.check(() -> onView(withId(R.id.my_devices_list))
                 .check(matches(isDisplayed())));

--- a/app/src/main/java/dev/wander/android/opentagviewer/FetchFromICloudActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/FetchFromICloudActivity.java
@@ -4,9 +4,17 @@ import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 
 import android.content.Intent;
+import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Bundle;
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.TextUtils;
+import android.text.style.ForegroundColorSpan;
+import android.text.style.StyleSpan;
+import android.text.style.UnderlineSpan;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.View;
 import android.text.format.DateFormat;
 import android.widget.Button;
@@ -24,8 +32,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
+import dev.wander.android.opentagviewer.anisette.AdiDeviceIdentity;
+import dev.wander.android.opentagviewer.anisette.LocalAnisette;
 import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
+import dev.wander.android.opentagviewer.db.repo.model.UserAuthData;
 import dev.wander.android.opentagviewer.db.repo.BeaconRepository;
+import dev.wander.android.opentagviewer.db.repo.UserAuthRepository;
 import dev.wander.android.opentagviewer.db.repo.KeychainMembershipRepository;
 import dev.wander.android.opentagviewer.db.room.OpenTagViewerDatabase;
 import dev.wander.android.opentagviewer.python.AppDependencies;
@@ -38,6 +50,7 @@ import dev.wander.android.opentagviewer.python.icloud.ICloudService;
 import dev.wander.android.opentagviewer.python.icloud.KeychainMembership;
 import dev.wander.android.opentagviewer.python.PythonLock;
 import dev.wander.android.opentagviewer.python.icloud.RecoverableDevice;
+import dev.wander.android.opentagviewer.ui.CodeChipSpan;
 import dev.wander.android.opentagviewer.ui.RecoverableDeviceIcon;
 import dev.wander.android.opentagviewer.ui.login.StepTransition;
 import dev.wander.android.opentagviewer.ui.login.StepTransition.Direction;
@@ -64,6 +77,18 @@ public class FetchFromICloudActivity extends AppCompatActivity {
     private static final String TAG = FetchFromICloudActivity.class.getSimpleName();
 
     /**
+     * Where the user can see the device list this app is now in.
+     *
+     * <p>The root, not a deep link into the devices section. Apple has moved this page twice -
+     * it was {@code appleid.apple.com} - and a dead deep link on a screen telling somebody to go
+     * and look is worse than one extra click.
+     */
+    private static final String APPLE_ACCOUNT_URL = "https://account.apple.com";
+
+    /** The same place, as it is printed on screen - no scheme, because nobody reads one. */
+    private static final String APPLE_ACCOUNT_DOMAIN = "account.apple.com";
+
+    /**
      * The mutually exclusive steps, listed once.
      *
      * <p>So showing one is "show this" rather than every caller remembering to hide the other
@@ -76,6 +101,7 @@ public class FetchFromICloudActivity extends AppCompatActivity {
             R.id.icloud_no_tags_container,
             R.id.icloud_retry_container,
             R.id.icloud_results_container,
+            R.id.icloud_registered_container,
     };
 
     /** Set when the screen should leave and let the caller open the file picker instead. */
@@ -486,6 +512,139 @@ public class FetchFromICloudActivity extends AppCompatActivity {
         this.showOnly(R.id.icloud_results_container, R.string.icloud_results_title, Direction.FORWARD);
     }
 
+    /**
+     * What this app now is on the user's Apple account, and why to leave it alone.
+     *
+     * <p><b>A replica of the row, not a description of one.</b> Apple synthesises the entry from
+     * the claimed model and ignores the name the app sends, so what the user will scroll past is
+     * titled {@code MacBookPro} - not "OpenTagViewer". The tile is built from the same
+     * {@link AdiDeviceIdentity.Hardware} the app registers under, because a screen that described
+     * a different machine than the one on the account would send somebody hunting for a row that
+     * is not there, and possibly deleting one that is.
+     *
+     * <p>Shown on every connect. The entries accumulate - each fresh install adds another, all
+     * with this same title and model - so the person who saw this a year ago is precisely the one
+     * who has since forgotten which row it was.
+     */
+    private void showWhatWeRegisteredAs() {
+        final AdiDeviceIdentity.Hardware hardware = LocalAnisette.profileToShow(this);
+
+        this.<TextView>findViewById(R.id.icloud_registered_device_name)
+                .setText(hardware.deviceListName());
+
+        // The model and OS are transcriptions of what Apple prints - it prints "macOS 13.1"
+        // whatever language the account is in - so only the bracketing is localised.
+        this.<TextView>findViewById(R.id.icloud_registered_device_model)
+                .setText(this.getString(R.string.icloud_registered_model_and_os,
+                        hardware.marketingName(),
+                        hardware.osName() + " " + hardware.osVersion()));
+
+        this.<TextView>findViewById(R.id.icloud_registered_device_serial).setText(
+                TextUtils.expandTemplate(
+                        this.getText(R.string.icloud_registered_serial_label),
+                        this.serialAsCode()));
+
+        // The icon follows the claim, or the tile says Mac beside a picture of a phone.
+        this.<ImageView>findViewById(R.id.icloud_registered_icon).setImageResource(
+                hardware == AdiDeviceIdentity.Hardware.IPHONE
+                        ? R.drawable.smartphone_24px : R.drawable.laptop_24px);
+
+        // The same chip in the prose. It is the value the sentence is about, and it reads as a
+        // typo in body text - "0PENTAGVIEWR" has a zero for an O and no vowel in VIEWR.
+        // Read from the resource rather than from the view: the view may already hold an expanded
+        // copy from a previous visit to this step, and expanding twice leaves the ^1 gone and the
+        // chip applied to nothing.
+        this.<TextView>findViewById(R.id.icloud_registered_body).setText(
+                TextUtils.expandTemplate(
+                        this.getText(R.string.icloud_registered_body), this.serialAsCode()));
+
+        this.fillInTheAccountName();
+        this.setUpTheAccountLink();
+
+        this.showOnly(R.id.icloud_registered_container, R.string.icloud_registered_title,
+                Direction.FORWARD);
+    }
+
+    /** The serial, as a chip, ready to drop into a sentence or a label. */
+    private CharSequence serialAsCode() {
+        return CodeChipSpan.applyTo(
+                AdiDeviceIdentity.APP_SERIAL, AdiDeviceIdentity.APP_SERIAL, this.codeChip());
+    }
+
+    private CodeChipSpan codeChip() {
+        return new CodeChipSpan(
+                this.getResources().getDisplayMetrics().density,
+                this.colour(com.google.android.material.R.attr.colorSurfaceContainerHighest),
+                this.colour(com.google.android.material.R.attr.colorOnSurface));
+    }
+
+    /**
+     * "See your devices at <u>account.apple.com</u>", with only the address looking tappable.
+     *
+     * <p>The address is inserted rather than translated - it is a domain - and it carries the
+     * three marks that say "link" without an icon: the accent colour, an underline and a heavier
+     * weight. The words around it stay body text, so the line reads as a sentence that contains a
+     * link rather than as a button whose label happens to be a sentence.
+     */
+    private void setUpTheAccountLink() {
+        final SpannableString address = new SpannableString(APPLE_ACCOUNT_DOMAIN);
+        address.setSpan(new ForegroundColorSpan(this.colour(
+                        com.google.android.material.R.attr.colorPrimary)),
+                0, address.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        address.setSpan(new UnderlineSpan(),
+                0, address.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        address.setSpan(new StyleSpan(Typeface.BOLD),
+                0, address.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+        final TextView link = this.findViewById(R.id.icloud_registered_link);
+        link.setText(TextUtils.expandTemplate(
+                this.getText(R.string.icloud_registered_link), address));
+        link.setOnClickListener(v -> WebLink.open(this, APPLE_ACCOUNT_URL));
+    }
+
+    private int colour(final int attr) {
+        final TypedValue value = new TypedValue();
+        this.getTheme().resolveAttribute(attr, value, true);
+        return value.data;
+    }
+
+    /**
+     * The account the entry is on, named if the session carries it.
+     *
+     * <p><b>Hidden rather than blank when it does not.</b> A stored session need not carry an
+     * account block - Settings already handles that case rather than crashing on it - and
+     * "%1$s lists this app" with an empty {@code %1$s} reads as a bug. The tile below says the
+     * same thing without it; the email only makes it concrete for somebody with more than one
+     * Apple account.
+     */
+    private void fillInTheAccountName() {
+        final TextView lead = this.findViewById(R.id.icloud_registered_lead);
+        lead.setVisibility(GONE);
+
+        var async = new UserAuthRepository(
+                UserAuthDataStore.getInstance(this.getApplicationContext()),
+                new AppCryptographyUtil())
+                .getUserAuth()
+                .filter(Optional::isPresent)
+                .map(auth -> auth.get().getUser())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        user -> {
+                            // Both halves can be absent on a session that deserialised without an
+                            // account block - the same case Settings guards, for the same reason.
+                            final UserAuthData.UserAccountInfo info = user.getAccount() == null
+                                    ? null : user.getAccount().getInfo();
+                            final String email = info == null ? null : info.getAccountName();
+
+                            if (email == null || email.isBlank()) {
+                                return;
+                            }
+                            lead.setText(this.getString(R.string.icloud_registered_lead, email));
+                            lead.setVisibility(VISIBLE);
+                        },
+                        error -> Log.w(TAG, "No account name for the device note", error));
+    }
+
     /** Whatever went wrong, on the screen written for it. */
     private void showFailure(final Throwable error) {
         final ICloudFailure failure = error instanceof ICloudException
@@ -676,6 +835,9 @@ public class FetchFromICloudActivity extends AppCompatActivity {
         if (stepId == R.id.icloud_passcode_container) {
             this.setPrimaryButton(R.string.icloud_unlock_action, this::submitPasscode);
         } else if (stepId == R.id.icloud_results_container) {
+            // Not the last step any more - what this app put on their account comes after.
+            this.setPrimaryButton(R.string.icloud_results_next, this::showWhatWeRegisteredAs);
+        } else if (stepId == R.id.icloud_registered_container) {
             this.setPrimaryButton(R.string.icloud_results_done, this::finish);
         } else if (stepId == R.id.icloud_no_tags_container) {
             this.setPrimaryButton(R.string.icloud_import_from_file, this::leaveForFileImport);

--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/AdiDeviceIdentity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/AdiDeviceIdentity.java
@@ -67,9 +67,23 @@ public final class AdiDeviceIdentity {
      * which is what the exporter uses - so the app and the working program now introduce
      * themselves to Apple as the same machine.
      */
+    /**
+     * The serial Apple prints against this app's entry in the user's device list.
+     *
+     * <p><b>Python owns it</b> - {@code identity.APP_SERIAL} is what actually goes to Apple, and
+     * this is a copy for the screen that shows the user what to look for. A copy at all only
+     * because a UI thread should not have to start CPython to render a label.
+     *
+     * <p>Two copies of one value is exactly what rule 11 warns about, so they are pinned
+     * together: {@code IdentityBridgeTest} fails if they ever differ. A screen naming a serial
+     * Apple never saw is worse than naming none, because the user would go looking for it,
+     * not find it, and conclude the row in front of them belongs to somebody else.
+     */
+    public static final String APP_SERIAL = "0PENTAGVIEWR";
+
     public static AdiDeviceIdentity generate() {
         final SecureRandom random = new SecureRandom();
-        final Hardware hardware = Hardware.LEGACY_MAC;
+        final Hardware hardware = Hardware.DEFAULT;
 
         return new AdiDeviceIdentity(
                 UUID.randomUUID().toString().toUpperCase(Locale.ROOT),
@@ -114,6 +128,7 @@ public final class AdiDeviceIdentity {
          * not have it.
          */
         LEGACY_MAC(
+                "MacBook Pro 13\"",
                 "MacBookPro13,2", "macOS", "13.1", "22C65",
                 "1404.0.5", "22.3.0",
                 "com.apple.dt.Xcode/3594.4.19") {
@@ -161,6 +176,7 @@ public final class AdiDeviceIdentity {
          * claim on its own, unnamed and unserialled, would be worse than the Mac it replaces.
          */
         IPHONE(
+                "iPhone 14 Pro",
                 "iPhone15,2", "iPhone OS", "17.4", "21E219",
                 "1494.0.7", "23.4.0",
                 "com.apple.akd/1.0") {
@@ -207,6 +223,17 @@ public final class AdiDeviceIdentity {
          */
         public abstract String localUserHeader(String localUserUuid);
 
+        /**
+         * What an install with nothing stored will claim to be.
+         *
+         * <p>Named rather than written twice. {@link #generate()} decides it and the screen that
+         * tells the user what their Apple account now lists reads it, and those two disagreeing
+         * would put one machine on screen and register another - which is the failure rule 11 is
+         * about, arriving in the one place the user can actually see it.
+         */
+        public static final Hardware DEFAULT = LEGACY_MAC;
+
+        private final String marketingName;
         private final String model;
         private final String osName;
         private final String osVersion;
@@ -215,8 +242,10 @@ public final class AdiDeviceIdentity {
         private final String darwin;
         private final String authKitApp;
 
-        Hardware(String model, String osName, String osVersion, String osBuild,
+        Hardware(String marketingName,
+                 String model, String osName, String osVersion, String osBuild,
                  String cfnetwork, String darwin, String authKitApp) {
+            this.marketingName = marketingName;
             this.model = model;
             this.osName = osName;
             this.osVersion = osVersion;
@@ -240,6 +269,34 @@ public final class AdiDeviceIdentity {
 
         public String model() {
             return this.model;
+        }
+
+        /**
+         * The model as Apple prints it in the device list - {@code MacBook Pro 13"}.
+         *
+         * <p><b>Observed, not derived.</b> Confirmed against a real account in macOS Settings &gt;
+         * Apple Account &gt; My Devices, where {@code MacBookPro13,2} renders exactly this. It is
+         * a constant per profile rather than a lookup because there are two profiles and Apple's
+         * naming is not a formula - guessing "(13-inch, 2016)" from the identifier, which is the
+         * obvious guess, gets it wrong.
+         */
+        public String marketingName() {
+            return this.marketingName;
+        }
+
+        /**
+         * The row's title, which Apple synthesises and which is <b>not</b> this app's name.
+         *
+         * <p>{@code MacBookPro13,2} appears titled {@code MacBookPro}: the identifier with its
+         * version dropped. The app does send a name; Apple ignores it, and setting one properly
+         * needs a registration endpoint this app deliberately does not implement.
+         *
+         * <p><b>So the name cannot be what a user matches on, and the serial has to be.</b> Every
+         * install of this app produces a row with this same title and model, which is why
+         * {@code 0PENTAGVIEWR} carries the whole weight of telling it apart - rule 11.
+         */
+        public String deviceListName() {
+            return this.model.replaceAll("\\d+,\\d+$", "");
         }
 
         public String osName() {

--- a/app/src/main/java/dev/wander/android/opentagviewer/anisette/LocalAnisette.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/anisette/LocalAnisette.java
@@ -300,6 +300,26 @@ public final class LocalAnisette implements AnisetteSource {
     }
 
     /**
+     * Which machine this install presents as, for showing the user - and nothing else.
+     *
+     * <p><b>Read-only on purpose.</b> {@link #loadOrCreateIdentity()} writes an identity when
+     * there is none, because a caller that needs one needs it to persist. A screen describing the
+     * install must not have that side effect: opening it on a device that has never signed in
+     * would mint and store an identity, and the profile chosen for a fresh install is then fixed
+     * by having looked at a page. Nothing stored means nothing stored, and the answer is the
+     * default that {@link AdiDeviceIdentity#generate()} would pick.
+     *
+     * <p>Touches no native library, so it is safe on the main thread - see
+     * {@code ensureReady}, which is the expensive one.
+     */
+    public static AdiDeviceIdentity.Hardware profileToShow(final Context context) {
+        return hardwareFrom(
+                context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
+                        .getString(KEY_HARDWARE, null),
+                AdiDeviceIdentity.Hardware.DEFAULT);
+    }
+
+    /**
      * The stored profile, or {@code fallback} when there is nothing usable stored.
      *
      * <p>An unrecognised name falls back rather than throwing. A profile removed in a later

--- a/app/src/main/java/dev/wander/android/opentagviewer/ui/CodeChipSpan.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/ui/CodeChipSpan.java
@@ -1,0 +1,127 @@
+package dev.wander.android.opentagviewer.ui;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.Typeface;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+import android.text.style.ReplacementSpan;
+
+import androidx.annotation.NonNull;
+
+/**
+ * A value rendered as inline code - monospace, on a tinted rounded chip.
+ *
+ * <p><b>For the one string in this app that people compare character by character.</b> The serial
+ * {@code 0PENTAGVIEWR} is the only field distinguishing this app's entry in an Apple device list
+ * from real hardware, and it is deliberately near-miss shaped: a zero where an O belongs, and no
+ * vowel in VIEWR. In body text it reads as a typo. Set as code it reads as a value to be matched,
+ * which is what somebody is about to do with it.
+ *
+ * <p>Written as a span rather than as markup because there is no markup for it. Android's string
+ * resources carry {@code <b>}, {@code <i>} and {@code <u>}; a chip needs a measured background,
+ * which nothing in a resource can express. It is applied where the text is built.
+ *
+ * <p><b>A {@link ReplacementSpan}, so the chip cannot be split across two lines.</b> If it does
+ * not fit on the rest of the line it moves to the next one whole. That is the right trade for
+ * short values and the wrong one for long ones - the text does not wrap inside a chip, so a
+ * sentence-length argument here would run off the edge.
+ */
+public class CodeChipSpan extends ReplacementSpan {
+
+    /** Breathing room either side of the text, in pixels. */
+    private final float horizontalPadding;
+
+    /** How far the chip is drawn above and below the text, in pixels. */
+    private final float verticalPadding;
+
+    private final float cornerRadius;
+
+    private final int backgroundColour;
+
+    private final int textColour;
+
+    public CodeChipSpan(final float density, final int backgroundColour, final int textColour) {
+        this.horizontalPadding = 5f * density;
+        this.verticalPadding = 2f * density;
+        this.cornerRadius = 4f * density;
+        this.backgroundColour = backgroundColour;
+        this.textColour = textColour;
+    }
+
+    /**
+     * Wrap one run of an existing string in a chip.
+     *
+     * <p>Returns the text unchanged when {@code value} is not in it, rather than throwing. The
+     * caller is a screen: a chip that failed to apply is a cosmetic loss, and a crash on a page
+     * whose whole job is to be read is not a trade worth making.
+     */
+    public static CharSequence applyTo(
+            final CharSequence text, final String value, final CodeChipSpan span) {
+        final int start = text.toString().indexOf(value);
+        if (start < 0) {
+            return text;
+        }
+
+        final SpannableStringBuilder out = new SpannableStringBuilder(text);
+        out.setSpan(span, start, start + value.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        return out;
+    }
+
+    @Override
+    public int getSize(@NonNull final Paint paint, final CharSequence text,
+                       final int start, final int end, final Paint.FontMetricsInt fontMetrics) {
+        // The metrics the line is laid out with have to come from the same typeface the text is
+        // drawn in, or a monospace run measured as the body font clips its own last character.
+        final Paint measuring = this.chipPaint(paint);
+
+        if (fontMetrics != null) {
+            final Paint.FontMetricsInt monospace = measuring.getFontMetricsInt();
+            fontMetrics.ascent = Math.min(fontMetrics.ascent, monospace.ascent);
+            fontMetrics.descent = Math.max(fontMetrics.descent, monospace.descent);
+            fontMetrics.top = Math.min(fontMetrics.top, monospace.top);
+            fontMetrics.bottom = Math.max(fontMetrics.bottom, monospace.bottom);
+        }
+
+        return Math.round(
+                measuring.measureText(text, start, end) + (this.horizontalPadding * 2f));
+    }
+
+    @Override
+    public void draw(@NonNull final Canvas canvas, final CharSequence text,
+                     final int start, final int end, final float x,
+                     final int top, final int y, final int bottom,
+                     @NonNull final Paint paint) {
+        final Paint chip = this.chipPaint(paint);
+        final Paint.FontMetrics metrics = chip.getFontMetrics();
+
+        final RectF box = new RectF(
+                x,
+                y + metrics.ascent - this.verticalPadding,
+                x + chip.measureText(text, start, end) + (this.horizontalPadding * 2f),
+                y + metrics.descent + this.verticalPadding);
+
+        final Paint background = new Paint(Paint.ANTI_ALIAS_FLAG);
+        background.setColor(this.backgroundColour);
+        canvas.drawRoundRect(box, this.cornerRadius, this.cornerRadius, background);
+
+        chip.setColor(this.textColour);
+        canvas.drawText(text, start, end, x + this.horizontalPadding, y, chip);
+    }
+
+    /**
+     * The body paint, in monospace, slightly smaller.
+     *
+     * <p>Monospace runs visually larger than the proportional body face at the same size, so
+     * matching the number would leave the chip looking like a heading. A copy each time rather
+     * than a mutated {@code paint}: the one handed in belongs to the layout, and changing its
+     * typeface leaks into the rest of the line.
+     */
+    private Paint chipPaint(final Paint paint) {
+        final Paint chip = new Paint(paint);
+        chip.setTypeface(Typeface.MONOSPACE);
+        chip.setTextSize(paint.getTextSize() * 0.92f);
+        return chip;
+    }
+}

--- a/app/src/main/res/layout/activity_fetch_from_icloud.xml
+++ b/app/src/main/res/layout/activity_fetch_from_icloud.xml
@@ -330,6 +330,36 @@
 
         </LinearLayout>
 
+        <!--
+          **What the user will find on their Apple account, said before they find it.**
+
+          Connecting registers this app as a device, and Apple shows that entry next to the words
+          "If you do not recognise this device" with a Remove button beside it. An unexplained row
+          is one people remove - and removing it is what breaks a connection that was working,
+          hours later, with nothing to connect the two.
+
+          **Its own step, after the tags rather than under them.** It was a card at the foot of the
+          results, below the thing the user actually came for, which is where a paragraph goes to
+          be scrolled past. This is not optional reading: the cost of missing it is landing back on
+          the login screen weeks later for no visible reason.
+
+          Shown on every connect, not once. Nothing about it stops being true, and the entries
+          accumulate - each fresh install adds another - so a person who saw it once a year ago is
+          exactly the person who has since forgotten.
+        -->
+        <LinearLayout
+            android:id="@+id/icloud_registered_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="gone">
+
+            <include layout="@layout/icloud_registered_note" />
+
+        </LinearLayout>
+
     </LinearLayout>
 
     </ScrollView>

--- a/app/src/main/res/layout/icloud_registered_note.xml
+++ b/app/src/main/res/layout/icloud_registered_note.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  What the user will find on their Apple account, shown the way they will find it.
+
+  **A replica of the row, not a description of it.** Connecting registers this app as a device,
+  and Apple renders that entry from the claimed model: title "MacBookPro", model "MacBook Pro 13"",
+  macOS 13.1, serial 0PENTAGVIEWR - confirmed against a real account in macOS Settings > Apple
+  Account > My Devices. The app does send a name and Apple ignores it, so nothing here says
+  "OpenTagViewer", because that is not what the user will be looking at.
+
+  The tile is deliberately the same shape as icloud_device_tile above it. Somebody has just picked
+  a real device out of a list that looks like this; the point is that they can match this one
+  against a list that also looks like this.
+
+  Its own file so it can be inflated and checked without an activity - see
+  WhatWeRegisterAsIsLegibleTest.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/icloud_registered_note"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/icloud_registered_lead"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:textSize="14sp"
+        tools:text="shane@wander.dev lists this app as one of your devices:" />
+
+    <!--
+      The replica. Quiet lines under a bold title, in the order Apple stacks them, so matching it
+      against the real list is reading rather than translating.
+    -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:background="@drawable/layout_rounded"
+        android:backgroundTint="?attr/colorSurfaceContainerLow"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <ImageView
+            android:id="@+id/icloud_registered_icon"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_marginEnd="16dp"
+            android:contentDescription="@null"
+            android:src="@drawable/laptop_24px"
+            app:tint="?attr/colorOnSecondaryContainer" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/icloud_registered_device_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/nunito_medium"
+                android:textColor="?attr/colorOnSurface"
+                android:textSize="16sp"
+                tools:text="MacBookPro" />
+
+            <!-- Model and OS together: one fact about the machine, not two. -->
+            <TextView
+                android:id="@+id/icloud_registered_device_model"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="3dp"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:textSize="13sp"
+                tools:text="MacBook Pro 13&quot; (macOS 13.1)" />
+
+            <!--
+              **The only field that tells this entry from a real Mac**, so it is labelled and set
+              as code rather than left as a third grey line. Every install of this app produces
+              the same title and the same model; only this differs from real hardware, and it is
+              near-miss shaped - a zero for an O - so it is rendered as something to compare.
+            -->
+            <TextView
+                android:id="@+id/icloud_registered_device_serial"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="5dp"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:textSize="13sp"
+                tools:text="Serial Number: 0PENTAGVIEWR" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/icloud_registered_body"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:lineSpacingExtra="3dp"
+        android:text="@string/icloud_registered_body"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:textSize="14sp" />
+
+    <!--
+      Opened through WebLink, which says so rather than doing nothing when the device has no
+      browser. 48dp of touch target, which is why the padding is here and not a margin.
+
+      **The sentence is body text and only the address is a link.** Colouring the whole line
+      makes the words "See your devices at" look tappable too, and then nothing on the line
+      indicates where it goes. The address gets the colour, the underline and the weight - the
+      three things that say "link" without an icon - and the text around it stays prose. Set in
+      code, because the styled run is the part that must not be translated.
+    -->
+    <TextView
+        android:id="@+id/icloud_registered_link"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="48dp"
+        android:paddingVertical="8dp"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:textSize="14sp"
+        tools:text="See your devices at account.apple.com" />
+
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -268,4 +268,11 @@ Du kannst sie später wieder verknüpfen. Dafür brauchst du den Gerätecode dei
 Du kannst das jetzt einrichten oder jederzeit später in den Einstellungen.</string>
     <string name="icloud_offer_set_up_now">Jetzt einrichten</string>
     <string name="icloud_offer_not_now">Jetzt nicht</string>
+    <string name="icloud_registered_title">Diese App ist ein Gerät in deinem Apple-Account</string>
+    <string name="icloud_registered_body"><b>Entferne diesen Eintrag nicht.</b>\n\nApple zeigt ihn neben „Wenn du dieses Gerät nicht erkennst“ an, sodass er wie etwas zum Aufräumen wirkt. Wird er entfernt, kann diese App deine Tags nicht mehr lesen – im besten Fall musst du dich erneut anmelden und einen Bestätigungscode eingeben, im schlimmsten Fall wirst du ganz abgemeldet.\n\nApple vergibt den Namen des Eintrags selbst, deshalb ist die Seriennummer ^1 das Einzige, was ihn von einem echten Mac unterscheidet. Jede Neuinstallation fügt einen weiteren hinzu.</string>
+    <string name="icloud_registered_lead">%1$s führt diese App als eines deiner Geräte:</string>
+    <string name="icloud_registered_link">Deine Geräte ansehen auf ^1</string>
+    <string name="icloud_results_next">Weiter</string>
+    <string name="icloud_registered_serial_label">Seriennummer: ^1</string>
+    <string name="icloud_registered_model_and_os">%1$s (%2$s)</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -268,4 +268,11 @@ You can link again later. That needs your Apple device passcode.</string>
 You can set this up now, or any time later from Settings.</string>
     <string name="icloud_offer_set_up_now">Set up now</string>
     <string name="icloud_offer_not_now">Not now</string>
+    <string name="icloud_registered_title">This app is a device on your Apple account</string>
+    <string name="icloud_registered_body"><b>Do not remove this entry.</b>\n\nApple shows it beside “If you do not recognise this device”, so it looks like something to tidy up. Removing it stops this app reading your tags — at best you will have to sign in and enter a verification code again, and it can sign you out completely.\n\nApple names the entry itself, so the serial ^1 is the only thing that tells it apart from a real Mac. Every fresh install adds another one.</string>
+    <string name="icloud_registered_lead">%1$s lists this app as one of your devices:</string>
+    <string name="icloud_registered_link">See your devices at ^1</string>
+    <string name="icloud_results_next">Next</string>
+    <string name="icloud_registered_serial_label">Serial Number: ^1</string>
+    <string name="icloud_registered_model_and_os">%1$s (%2$s)</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -268,4 +268,11 @@ Vous pourrez réassocier votre compte plus tard. Le code de votre appareil Apple
 Vous pouvez configurer cela maintenant, ou à tout moment depuis les réglages.</string>
     <string name="icloud_offer_set_up_now">Configurer</string>
     <string name="icloud_offer_not_now">Plus tard</string>
+    <string name="icloud_registered_title">Cette app est un appareil de votre compte Apple</string>
+    <string name="icloud_registered_body"><b>Ne supprimez pas cette entrée.</b>\n\nApple l’affiche à côté de « Si vous ne reconnaissez pas cet appareil », ce qui donne l’impression qu’il faut faire le ménage. La supprimer empêche l’app de lire vos balises : au mieux vous devrez vous reconnecter et saisir un code de vérification, au pire vous serez déconnecté complètement.\n\nC’est Apple qui nomme l’entrée, donc le numéro de série ^1 est la seule chose qui la distingue d’un vrai Mac. Chaque nouvelle installation en ajoute une autre.</string>
+    <string name="icloud_registered_lead">%1$s répertorie cette app parmi vos appareils :</string>
+    <string name="icloud_registered_link">Voir vos appareils sur ^1</string>
+    <string name="icloud_results_next">Suivant</string>
+    <string name="icloud_registered_serial_label">Numéro de série : ^1</string>
+    <string name="icloud_registered_model_and_os">%1$s (%2$s)</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -268,4 +268,11 @@
 今すぐ設定することも、後から設定画面で行うこともできます。</string>
     <string name="icloud_offer_set_up_now">今すぐ設定</string>
     <string name="icloud_offer_not_now">今はしない</string>
+    <string name="icloud_registered_title">このアプリは Apple アカウントのデバイスとして登録されています</string>
+    <string name="icloud_registered_body"><b>この項目を削除しないでください。</b>\n\nApple はこれを「このデバイスに心当たりがない場合」の隣に表示するため、片付けるべきもののように見えます。削除すると、このアプリはタグを読み取れなくなります。うまくいっても再度のサインインと確認コードの入力が必要になり、完全にサインアウトされることもあります。\n\n項目の名前は Apple が付けるため、本物の Mac と見分けられるのはシリアル番号 ^1 だけです。インストールし直すたびに、もう一つ増えます。</string>
+    <string name="icloud_registered_lead">%1$s のデバイス一覧に、このアプリが次のように表示されます：</string>
+    <string name="icloud_registered_link">^1 でデバイスを確認できます</string>
+    <string name="icloud_results_next">次へ</string>
+    <string name="icloud_registered_serial_label">シリアル番号：^1</string>
+    <string name="icloud_registered_model_and_os">%1$s（%2$s）</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -268,4 +268,11 @@
 지금 설정하거나, 나중에 설정에서 언제든 설정할 수 있습니다.</string>
     <string name="icloud_offer_set_up_now">지금 설정</string>
     <string name="icloud_offer_not_now">나중에</string>
+    <string name="icloud_registered_title">이 앱은 Apple 계정의 기기로 등록되어 있습니다</string>
+    <string name="icloud_registered_body"><b>이 항목을 삭제하지 마세요.</b>\n\nApple은 이 항목을 “이 기기가 익숙하지 않다면” 문구 옆에 표시하므로 정리해야 할 것처럼 보입니다. 삭제하면 이 앱이 태그를 읽을 수 없게 됩니다. 잘 되어야 다시 로그인하고 확인 코드를 입력해야 하며, 완전히 로그아웃될 수도 있습니다.\n\n항목 이름은 Apple이 직접 정하므로, 실제 Mac과 구별할 수 있는 것은 일련번호 ^1뿐입니다. 새로 설치할 때마다 하나씩 늘어납니다.</string>
+    <string name="icloud_registered_lead">%1$s의 기기 목록에 이 앱이 다음과 같이 표시됩니다:</string>
+    <string name="icloud_registered_link">^1에서 기기를 확인할 수 있습니다</string>
+    <string name="icloud_results_next">다음</string>
+    <string name="icloud_registered_serial_label">일련번호: ^1</string>
+    <string name="icloud_registered_model_and_os">%1$s (%2$s)</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -268,4 +268,11 @@ Je kunt later opnieuw koppelen. Daarvoor heb je de toegangscode van je Apple-app
 Je kunt dit nu instellen, of later altijd nog via Instellingen.</string>
     <string name="icloud_offer_set_up_now">Nu instellen</string>
     <string name="icloud_offer_not_now">Niet nu</string>
+    <string name="icloud_registered_title">Deze app is een apparaat in je Apple-account</string>
+    <string name="icloud_registered_body"><b>Verwijder dit item niet.</b>\n\nApple toont het naast “Als je dit apparaat niet herkent”, waardoor het lijkt of het opgeruimd moet worden. Verwijderen betekent dat deze app je tags niet meer kan lezen — in het beste geval moet je opnieuw inloggen en een verificatiecode invoeren, en je kunt volledig worden uitgelogd.\n\nApple bepaalt zelf de naam van het item, dus het serienummer ^1 is het enige waaraan je het van een echte Mac onderscheidt. Elke nieuwe installatie voegt er één toe.</string>
+    <string name="icloud_registered_lead">%1$s vermeldt deze app als een van je apparaten:</string>
+    <string name="icloud_registered_link">Bekijk je apparaten op ^1</string>
+    <string name="icloud_results_next">Volgende</string>
+    <string name="icloud_registered_serial_label">Serienummer: ^1</string>
+    <string name="icloud_registered_model_and_os">%1$s (%2$s)</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -268,4 +268,11 @@
 Можно настроить сейчас или в любой момент позже в настройках.</string>
     <string name="icloud_offer_set_up_now">Настроить</string>
     <string name="icloud_offer_not_now">Не сейчас</string>
+    <string name="icloud_registered_title">Это приложение — устройство в вашей учётной записи Apple</string>
+    <string name="icloud_registered_body"><b>Не удаляйте эту запись.</b>\n\nApple показывает её рядом со словами «Если вы не узнаёте это устройство», поэтому она выглядит как что-то лишнее. Если удалить её, приложение не сможет читать ваши метки: в лучшем случае придётся войти заново и ввести код проверки, в худшем — вас полностью разлогинит.\n\nИмя записи задаёт сама Apple, поэтому серийный номер ^1 — единственное, что отличает её от настоящего Mac. Каждая новая установка добавляет ещё одну.</string>
+    <string name="icloud_registered_lead">%1$s показывает это приложение среди ваших устройств:</string>
+    <string name="icloud_registered_link">Посмотреть свои устройства на ^1</string>
+    <string name="icloud_results_next">Далее</string>
+    <string name="icloud_registered_serial_label">Серийный номер: ^1</string>
+    <string name="icloud_registered_model_and_os">%1$s (%2$s)</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -268,4 +268,11 @@
 你可以现在设置，也可以随时到设置里再设置。</string>
     <string name="icloud_offer_set_up_now">立即设置</string>
     <string name="icloud_offer_not_now">暂不</string>
+    <string name="icloud_registered_title">此应用是你 Apple 账户中的一台设备</string>
+    <string name="icloud_registered_body"><b>请不要删除这一项。</b>\n\nApple 会把它显示在“如果你不认识这台设备”旁边，看起来像是该清理掉的东西。删除后，此应用将无法再读取你的标签：顺利的话你需要重新登录并输入验证码，也可能被完全退出登录。\n\n条目的名称由 Apple 自行决定，因此序列号 ^1 是唯一能把它和真正的 Mac 区分开的信息。每次重新安装都会再添加一条。</string>
+    <string name="icloud_registered_lead">%1$s 的设备列表中，此应用显示为：</string>
+    <string name="icloud_registered_link">可在 ^1 查看你的设备</string>
+    <string name="icloud_results_next">下一步</string>
+    <string name="icloud_registered_serial_label">序列号：^1</string>
+    <string name="icloud_registered_model_and_os">%1$s（%2$s）</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -268,4 +268,11 @@
 你可以現在設定，也可以隨時到設定裡再設定。</string>
     <string name="icloud_offer_set_up_now">立即設定</string>
     <string name="icloud_offer_not_now">暫不</string>
+    <string name="icloud_registered_title">此 App 是你 Apple 帳戶中的一部裝置</string>
+    <string name="icloud_registered_body"><b>請不要刪除這一項。</b>\n\nApple 會把它顯示在「如果你不認得這部裝置」旁邊，看起來像是該清掉的東西。刪除後，此 App 將無法再讀取你的標籤：順利的話你需要重新登入並輸入驗證碼，也可能被完全登出。\n\n項目的名稱由 Apple 自行決定，因此序號 ^1 是唯一能把它和真正的 Mac 區分開的資訊。每次重新安裝都會再新增一條。</string>
+    <string name="icloud_registered_lead">%1$s 的裝置列表中，此 App 顯示為：</string>
+    <string name="icloud_registered_link">可在 ^1 查看你的裝置</string>
+    <string name="icloud_results_next">下一步</string>
+    <string name="icloud_registered_serial_label">序號：^1</string>
+    <string name="icloud_registered_model_and_os">%1$s（%2$s）</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,4 +300,11 @@ You can link again later. That needs your Apple device passcode.</string>
 You can set this up now, or any time later from Settings.</string>
     <string name="icloud_offer_set_up_now">Set up now</string>
     <string name="icloud_offer_not_now">Not now</string>
+    <string name="icloud_registered_title">This app is a device on your Apple account</string>
+    <string name="icloud_registered_body"><b>Do not remove this entry.</b>\n\nApple shows it beside “If you do not recognise this device”, so it looks like something to tidy up. Removing it stops this app reading your tags — at best you will have to sign in and enter a verification code again, and it can sign you out completely.\n\nApple names the entry itself, so the serial ^1 is the only thing that tells it apart from a real Mac. Every fresh install adds another one.</string>
+    <string name="icloud_registered_lead">%1$s lists this app as one of your devices:</string>
+    <string name="icloud_registered_link">See your devices at ^1</string>
+    <string name="icloud_results_next">Next</string>
+    <string name="icloud_registered_serial_label">Serial Number: ^1</string>
+    <string name="icloud_registered_model_and_os">%1$s (%2$s)</string>
 </resources>

--- a/scripts/add_strings.py
+++ b/scripts/add_strings.py
@@ -77,6 +77,7 @@ other angle bracket is escaped.
 
 from __future__ import annotations
 
+import collections
 import io
 import json
 import re
@@ -503,9 +504,101 @@ def check(locales: list[str]) -> int:
               file=sys.stderr)
         return 1
 
+    if not check_placeholders(root, locales):
+        return 1
+
     print(f"All {len(expected)} translatable strings are present in"
           f" all {len(locales) - 1} translated locale(s).")
     return 0
+
+
+# `%1$s` and friends, and `^1` as TextUtils.expandTemplate reads it.
+PLACEHOLDER = re.compile(r"%\d+\$[a-zA-Z]|\^\d+")
+
+
+def placeholders_in(text: str) -> collections.Counter:
+    return collections.Counter(PLACEHOLDER.findall(text))
+
+
+def check_placeholders(default_root, locales: list[str]) -> bool:
+    """Every locale's version of a string has the same slots as the default's.
+
+    **A dropped placeholder does not fail anywhere on its own.** The XML is valid, the string is
+    present, `--check` above is satisfied, and the app does not throw: `expandTemplate` finds no
+    `^1` and simply substitutes nothing, `getString` finds no `%1$s` and formats nothing. The
+    result is one locale where the sentence about the serial never says the serial - which is
+    only ever noticed by somebody reading that language.
+
+    An *extra* slot is the louder half of the same mistake: `getString` throws
+    `MissingFormatArgumentException` and takes the screen down, in that locale only.
+    """
+    wanted = expected_placeholders(default_root)
+    if not wanted:
+        return True
+
+    failed = False
+    for locale in locales:
+        if locale == DEFAULT_LOCALE:
+            continue
+
+        path = strings_file(locale)
+        if not path.is_file():
+            continue
+
+        for name, missing, extra in placeholder_mismatches(path, wanted):
+            failed = True
+            print(f"\n{path.relative_to(REPO_ROOT)}: {name}", file=sys.stderr)
+            if missing:
+                print(f"  missing {' '.join(sorted(missing.elements()))}", file=sys.stderr)
+            if extra:
+                print(f"  unexpected {' '.join(sorted(extra.elements()))}", file=sys.stderr)
+
+    if failed:
+        print("\nA missing slot silently drops whatever belonged in it, for that locale only."
+              " An unexpected one crashes the screen that formats it.", file=sys.stderr)
+
+    return not failed
+
+
+def expected_placeholders(default_root) -> dict[str, collections.Counter]:
+    """The slots each translatable string is supposed to have.
+
+    **Every translatable string, including the ones with no placeholders at all.** Keeping only
+    those that have some would cover the half that can go missing and skip the half that can
+    appear: a translation introducing a `%1$s` the default never had throws
+    `MissingFormatArgumentException` the moment that screen opens in that language.
+    """
+    wanted: dict[str, collections.Counter] = {}
+
+    for element in default_root.iter("string"):
+        name = element.get("name")
+        if name and element.get("translatable") != "false":
+            wanted[name] = placeholders_in(inner_markup(element))
+
+    return wanted
+
+
+def placeholder_mismatches(
+        path: Path, wanted: dict[str, collections.Counter],
+) -> list[tuple[str, collections.Counter, collections.Counter]]:
+    """Every string in one locale whose slots differ from the default's, as (name, missing, extra).
+
+    Counters rather than sets, so `^1 and ^1` losing one of its two is caught. Compared by
+    multiset and not in order: reordering is the whole point of the positional form, and
+    languages need it - `%2$s: %1$s` is a correct translation of `%1$s (%2$s)`.
+    """
+    mismatched = []
+
+    for element in ElementTree.parse(path).getroot().iter("string"):
+        name = element.get("name")
+        if name not in wanted:
+            continue
+
+        found = placeholders_in(inner_markup(element))
+        if found != wanted[name]:
+            mismatched.append((name, wanted[name] - found, found - wanted[name]))
+
+    return mismatched
 
 
 def load_spec(path: Path) -> dict | None:
@@ -539,15 +632,12 @@ def use_utf8_output() -> None:
             stream.reconfigure(encoding="utf-8")
 
 
-def main(argv: list[str]) -> int:
-    use_utf8_output()
+def run_without_input_file(argv: list[str], locales: list[str]) -> int | None:
+    """The modes that read the tree rather than a JSON file, or None if this is not one of them.
 
-    locales = discover_locales()
-
-    if not locales or DEFAULT_LOCALE not in locales:
-        print(f"Found no default strings.xml under {RES_DIR}", file=sys.stderr)
-        return 2
-
+    Split out of {@code main} only to keep its branch count under flake8's limit - the dispatch
+    was one arm too long once --check grew a second thing to check. No behaviour of its own.
+    """
     if argv == ["--locales"]:
         print(f"Discovered {len(locales)} locale(s) under {RES_DIR.relative_to(REPO_ROOT)}:")
         for locale in locales:
@@ -562,6 +652,22 @@ def main(argv: list[str]) -> int:
 
     if len(argv) >= 2 and argv[0] == "--remove":
         return remove_strings(argv[1:], locales)
+
+    return None
+
+
+def main(argv: list[str]) -> int:
+    use_utf8_output()
+
+    locales = discover_locales()
+
+    if not locales or DEFAULT_LOCALE not in locales:
+        print(f"Found no default strings.xml under {RES_DIR}", file=sys.stderr)
+        return 2
+
+    handled = run_without_input_file(argv, locales)
+    if handled is not None:
+        return handled
 
     mode = argv[0] if len(argv) == 2 and argv[0] in ("--fill", "--replace") else None
     if mode:

--- a/scripts/test/test_add_strings.py
+++ b/scripts/test/test_add_strings.py
@@ -132,6 +132,74 @@ def test_check_ignores_untranslatable_strings(res: Path):
 
 
 # ---------------------------------------------------------------------------------------
+# check: placeholder parity
+#
+# A translation that loses a placeholder is the quietest failure this tool can have. The
+# string is present, so the check above is satisfied; the XML is valid, so aapt is happy;
+# and the app does not throw - expandTemplate finds no ^1 and substitutes nothing. The
+# result is one language where the sentence naming the device's serial never names it.
+# ---------------------------------------------------------------------------------------
+
+def test_check_fails_when_a_translation_drops_a_template_slot(res: Path):
+    make_locale(res, "values", with_strings(
+        '<string name="serial">Serial Number: ^1</string>'))
+    make_locale(res, "values-de", with_strings(
+        '<string name="serial">Seriennummer</string>'))
+
+    assert add_strings.check(["default", "de"]) == 1
+
+
+def test_check_fails_when_a_translation_drops_a_format_argument(res: Path):
+    make_locale(res, "values", with_strings(
+        '<string name="found">Found %1$d tags</string>'))
+    make_locale(res, "values-de", with_strings(
+        '<string name="found">Tags gefunden</string>'))
+
+    assert add_strings.check(["default", "de"]) == 1
+
+
+def test_check_fails_on_an_unexpected_placeholder(res: Path):
+    # The louder half: getString throws MissingFormatArgumentException and takes the screen
+    # down, in that locale only.
+    make_locale(res, "values", with_strings(
+        '<string name="found">Found some tags</string>'))
+    make_locale(res, "values-de", with_strings(
+        '<string name="found">%1$d Tags gefunden</string>'))
+
+    assert add_strings.check(["default", "de"]) == 1
+
+
+def test_check_allows_placeholders_to_be_reordered(res: Path):
+    # Reordering is the entire point of the positional form, and languages need it.
+    make_locale(res, "values", with_strings(
+        '<string name="pair">%1$s (%2$s)</string>'))
+    make_locale(res, "values-de", with_strings(
+        '<string name="pair">%2$s: %1$s</string>'))
+
+    assert add_strings.check(["default", "de"]) == 0
+
+
+def test_check_counts_repeated_placeholders(res: Path):
+    make_locale(res, "values", with_strings(
+        '<string name="twice">^1 and ^1</string>'))
+    make_locale(res, "values-de", with_strings(
+        '<string name="twice">^1</string>'))
+
+    assert add_strings.check(["default", "de"]) == 1
+
+
+def test_check_passes_when_placeholders_match(res: Path):
+    make_locale(res, "values", with_strings(
+        '<string name="serial">Serial Number: ^1</string>',
+        '<string name="found">Found %1$d tags</string>'))
+    make_locale(res, "values-de", with_strings(
+        '<string name="serial">Seriennummer: ^1</string>',
+        '<string name="found">%1$d Tags gefunden</string>'))
+
+    assert add_strings.check(["default", "de"]) == 0
+
+
+# ---------------------------------------------------------------------------------------
 # add_strings
 # ---------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Connecting an Apple account registers this app **as a device**. The user finds that out later,
from their own account: a row in the device list, which Apple renders next to the words "If you do
not recognise this device", with a **Remove from Account** button beside it.

Nothing in the app has ever said that row would appear, or what it would look like. So the app
creates an entry the user is invited to remove, and removing it breaks a connection that was
working — hours later, on a different screen, with nothing linking the two. That is `AGENTS.md`
rule 11 arriving at the one place the user can actually see it.

This adds a step at the end of the connect flow that shows them the row before they find it.

## It is a replica, not a description

The tile is deliberately the same shape as the device picker two steps earlier, and carries what
Apple actually prints:

```
MacBookPro
MacBook Pro 13" (macOS 13.1)
Serial Number: 0PENTAGVIEWR
```

Then the warning, then a link to `account.apple.com` so they can go and look.

## Three things in the copy were wrong, and checking is what found them

None of these would have failed a test, because all three were confidently written.

**"Signing out removes it."** The draft copy in the spec says this. It does not — `removeDevice`
in this codebase is about beacons, and nothing anywhere asks Apple to deregister. It now says the
opposite: the app never removes it, and doing so is theirs to do in Apple's settings.

**"It appears in your device list as OpenTagViewer."** It does not. Apple synthesises the row's
title from the claimed model and **ignores the name the app sends** — the entry reads
`MacBookPro`. Shipping that line would have sent people hunting for a row that does not exist,
and mistrusting the one that does. There is now a test asserting the copy does *not* say it.

**"MacBook Pro (13-inch, 2016)."** Mine, inferred from `MacBookPro13,2`, and wrong: Apple prints
`MacBook Pro 13"`. Confirmed against a real account in macOS Settings → Apple Account → My
Devices, which is the only reason any of the above is right.

The serial is left carrying the whole identification, which is what rule 11 already says.

## One identity, read rather than re-composed

The tile is built from the `Hardware` profile the app registers under, so it cannot describe a
different machine than the one on the account.

- `marketingName()` and `deviceListName()` live on the profile. The second derives `MacBookPro`
  from `MacBookPro13,2`, so both profiles get it right rather than one being hardcoded.
- `Hardware.DEFAULT` replaces a bare `LEGACY_MAC` inside `generate()`. The screen and the
  generator now read one value; disagreeing would put one machine on screen and register another.
- `AdiDeviceIdentity.APP_SERIAL` is a **copy** of Python's `identity.APP_SERIAL`, so a UI thread
  does not have to start CPython to draw a label. Two copies of one value is exactly what rule 11
  warns about, so `IdentityBridgeTest` now fails if they differ.

**`LocalAnisette.profileToShow` is read-only, and that is the point.** The existing loader *writes*
an identity when none is stored. Calling it from a screen would mean that opening a page mints and
permanently fixes the identity of an install that has never signed in.

## Shown on every connect

Nothing about it stops being true, and the entries **accumulate** — each fresh install adds
another, all with the same title and the same model. Someone who saw this once a year ago is
exactly the person who has since forgotten which row it was.

For the same reason the copy does not tell anyone to delete stale entries: nothing on screen can
tell them apart.

## Two ten-locale traps, one of them shipped

**Paragraph breaks vanished.** A real newline in `strings.xml` is whitespace and Android collapses
it; only the literal escape `\n` survives. The two are indistinguishable in the XML, the diff and
the translation JSON, and both are valid — so the note shipped as one nine-line block and nothing
said so. Caught by looking at the render.

**A dropped placeholder is quieter still.** The serial reaches the sentence through a `^1` slot. A
translation that loses it is valid XML, passes `--check`, and does not throw: `expandTemplate`
finds nothing to replace, and that one language gets a sentence about the serial that never says
it. An *extra* slot is the loud half — `MissingFormatArgumentException`, that locale only.

So `add_strings.py --check` now compares placeholder multisets across locales. Reordering is
allowed, because that is the entire point of the positional form. Six cases in `scripts/test`, and
writing them found a hole in my first version: strings with no placeholders in the default were
skipped entirely, which is precisely the half that crashes.

## Tests

| | |
| --- | --- |
| Inflate | every id the activity looks up, bold-but-not-everything, the blank line under the warning, the `^1` slot, 4.5:1 in both themes |
| Drive | the tile matches the profile the app registers under, the serial reaches tile and prose, the page is the last step and closes |
| Bridge | Java's serial equals Python's |
| Tooling | placeholder parity, including reordering and repeats |

The Espresso test also writes the only picture of this page assembled — the inflate test cannot
see it, because the chip and the link styling are applied in code.

## An extra step breaks every journey that walked past it

Three whole-app journeys drove the flow to the end and expected the results button to close the
screen. It now leads to this page instead, so they pressed once and waited for a list that was one
press away.

Worth stating what that cost, because it is the argument for `Eventually` having a budget at all:
each one sat in its retry loop for the full **~260 seconds** before failing, turning a ~12 minute
suite into 25. Fixed, they take 12.2s, 7.0s and 2.3s. The suite was never slow - three tests were
waiting for a screen that had moved.

**Not verified:** the chip and link colours in dark mode. They resolve theme attributes at runtime
so they should follow, but the activity test runs in the device's light theme, and that is
reasoning rather than evidence.

## Also in here

`scripts/add_strings.py`'s `main` was already one branch over flake8's complexity limit before this
change, so the pre-commit hook rejected any commit touching the file. Its no-input-file modes are
extracted to a helper; no behaviour change.

---

🤖 Written by [Claude Code](https://claude.com/claude-code)
