### PR TITLE
Say why the MAX() in getLastForAllBeacons cannot be deleted

### DIFF
--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/db/room/LatestReportPerBeaconTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/db/room/LatestReportPerBeaconTest.java
@@ -1,0 +1,181 @@
+package dev.wander.android.opentagviewer.db.room;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import androidx.room.Room;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dev.wander.android.opentagviewer.db.room.entity.LocationReport;
+import dev.wander.android.opentagviewer.db.room.entity.OwnedBeacon;
+
+/**
+ * The map's "where is each tag now" query, which relies on a SQLite rule to be correct.
+ *
+ * <p>{@code getLastForAllBeacons} is
+ * {@code SELECT MAX(timestamp), * FROM LocationReport GROUP BY beacon_id}. In standard SQL that
+ * is meaningless - the bare columns may come from any row of the group. SQLite guarantees they
+ * come from the row that produced the max, but <b>only while the query contains exactly one
+ * {@code min()} or {@code max()}</b>.
+ *
+ * <p><b>So the query has a precondition that nothing in the type system carries.</b> Delete the
+ * aggregate as unused - it is, its value is never read - or add a second one, and the query
+ * still compiles, still returns one row per tag, and starts returning an arbitrary report for
+ * each. The map then shows positions from whenever, indefinitely, with nothing failing.
+ *
+ * <p>This is the thing that notices. It is on a device rather than the JVM because it is a claim
+ * about SQLite's behaviour, and only the real engine can answer it - rule 13's carve-out, not an
+ * exception to it: a fake would be asserting my belief about SQLite back at me.
+ */
+@RunWith(AndroidJUnit4.class)
+public class LatestReportPerBeaconTest {
+
+    private static final String A_TAG = "tag-a";
+    private static final String ANOTHER_TAG = "tag-b";
+
+    private OpenTagViewerDatabase db;
+
+    @Before
+    public void openAnInMemoryDatabase() {
+        this.db = Room.inMemoryDatabaseBuilder(
+                        getInstrumentation().getTargetContext(), OpenTagViewerDatabase.class)
+                .allowMainThreadQueries()
+                .build();
+
+        // A report has a foreign key onto the tag that produced it, so the tags have to exist
+        // before any of them do. Both tags for every test, including the ones that only use one -
+        // an empty group is not what any of these are about, and a tag with no reports simply
+        // does not appear in a GROUP BY over the reports table.
+        this.db.ownedBeaconDao().insertAll(own(A_TAG), own(ANOTHER_TAG));
+    }
+
+    @After
+    public void closeIt() {
+        this.db.close();
+    }
+
+    /**
+     * <b>The newest report per tag, when the newest is not the last row inserted.</b>
+     *
+     * <p>Insertion order is deliberately not timestamp order. A query that returned "whichever
+     * row SQLite reached last" would pass against rows inserted oldest-first, which is how they
+     * arrive in practice and therefore how a test written without thinking would arrange them.
+     */
+    @Test
+    public void eachTagComesBackAtItsNewestReport() {
+        this.db.locationReportDao().insertAll(
+                report(A_TAG, 3_000L, 3.0),
+                report(A_TAG, 9_000L, 9.0),
+                report(A_TAG, 6_000L, 6.0),
+                report(ANOTHER_TAG, 5_000L, 5.0),
+                report(ANOTHER_TAG, 1_000L, 1.0));
+
+        final Map<String, LocationReport> byBeacon = byBeacon(
+                this.db.locationReportDao().getLastForAllBeacons());
+
+        assertEquals("one row per tag, not one per report", 2, byBeacon.size());
+
+        assertEquals("tag-a came back at the wrong timestamp",
+                9_000L, byBeacon.get(A_TAG).timestamp);
+        assertEquals("tag-b came back at the wrong timestamp",
+                5_000L, byBeacon.get(ANOTHER_TAG).timestamp);
+    }
+
+    /**
+     * <b>And the whole row is that report, not a mixture.</b>
+     *
+     * <p>The timestamp is the column the aggregate is over, so a broken query can still return
+     * the right one while taking latitude and longitude from a different row - which is the
+     * failure that matters, because the coordinates are what gets drawn. Each report here is at
+     * a distinct position, so a mixed row is detectable.
+     */
+    @Test
+    public void thecoordinatesBelongToThatSameReport() {
+        this.db.locationReportDao().insertAll(
+                report(A_TAG, 3_000L, 3.0),
+                report(A_TAG, 9_000L, 9.0),
+                report(A_TAG, 6_000L, 6.0));
+
+        final LocationReport newest =
+                byBeacon(this.db.locationReportDao().getLastForAllBeacons()).get(A_TAG);
+
+        assertNotNull(newest);
+        assertEquals("the latitude came from a different row than the timestamp",
+                9.0, newest.latitude, 0.000_001);
+        assertEquals("the longitude came from a different row than the timestamp",
+                -9.0, newest.longitude, 0.000_001);
+        assertEquals("the hash id came from a different row than the timestamp",
+                A_TAG + "-9000", newest.hashId);
+    }
+
+    /** A tag with exactly one report is still returned - the group of one. */
+    @Test
+    public void atagWithASingleReportIsNotDropped() {
+        this.db.locationReportDao().insertAll(report(A_TAG, 4_000L, 4.0));
+
+        final Map<String, LocationReport> byBeacon = byBeacon(
+                this.db.locationReportDao().getLastForAllBeacons());
+
+        assertEquals(1, byBeacon.size());
+        assertEquals(4_000L, byBeacon.get(A_TAG).timestamp);
+    }
+
+    /** And an empty table is an empty list rather than a row of nulls. */
+    @Test
+    public void nothingStoredIsNothingReturned() {
+        assertEquals(List.of(), this.db.locationReportDao().getLastForAllBeacons());
+    }
+
+    private static Map<String, LocationReport> byBeacon(final List<LocationReport> reports) {
+        final Map<String, LocationReport> out = new HashMap<>();
+        for (final LocationReport report : reports) {
+            out.put(report.beaconId, report);
+        }
+        return out;
+    }
+
+    /** Just enough of a tag to satisfy the foreign key; nothing here reads any of it. */
+    private static OwnedBeacon own(final String id) {
+        return OwnedBeacon.builder()
+                .id(id)
+                .content("{}")
+                .accessoryJson("{\"type\":\"accessory\"}")
+                .version("0.0.2")
+                .fromAccount(false)
+                .isRemoved(false)
+                .build();
+    }
+
+    /**
+     * A report whose every field follows from its timestamp.
+     *
+     * <p>So "this column came from the wrong row" is visible in the assertion rather than needing
+     * to be worked out - a row at 9000 has latitude 9.0 and hash {@code tag-a-9000}.
+     */
+    private static LocationReport report(
+            final String beaconId, final long timestamp, final double position) {
+        return LocationReport.builder()
+                .hashId(beaconId + "-" + timestamp)
+                .beaconId(beaconId)
+                .publishedAt(timestamp)
+                .description("report at " + timestamp)
+                .timestamp(timestamp)
+                .confidence(1)
+                .latitude(position)
+                .longitude(-position)
+                .horizontalAccuracy(10L)
+                .status(0)
+                .lastUpdate(timestamp)
+                .build();
+    }
+}

--- a/app/src/main/java/dev/wander/android/opentagviewer/db/room/dao/LocationReportDao.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/db/room/dao/LocationReportDao.java
@@ -4,6 +4,7 @@ import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
+import androidx.room.RewriteQueriesToDropUnusedColumns;
 
 import java.util.List;
 
@@ -17,6 +18,28 @@ public interface LocationReportDao {
     @Query("SELECT * FROM LocationReport WHERE beacon_id = :beaconId AND timestamp >= :startUnixMS AND timestamp < :endUnixMS ORDER BY timestamp ASC")
     List<LocationReport> getInTimeRange(String beaconId, long startUnixMS, long endUnixMS);
 
+    /**
+     * The newest report held for each beacon - one row per tag, which is what the map draws.
+     *
+     * <p><b>The {@code MAX(timestamp)} is load-bearing, and its value is never read.</b> In
+     * standard SQL, selecting bare columns alongside an aggregate is meaningless: the group has
+     * many rows and the engine may take those columns from any of them. SQLite makes one
+     * documented exception - if a query contains <i>exactly one</i> {@code min()} or
+     * {@code max()} aggregate, every bare column comes from the row that produced it
+     * (<a href="https://www.sqlite.org/lang_select.html#bareagg">lang_select §bareagg</a>).
+     *
+     * <p>So the aggregate is not here for its result. It is here to choose which row of each
+     * group the rest of the columns come from, and deleting it as unused would leave a query
+     * that still compiles, still returns one row per tag, and returns an <i>arbitrary</i> report
+     * for each - a map showing positions from whenever, with nothing failing anywhere.
+     *
+     * <p>Adding a second aggregate breaks it the same silent way, because the guarantee holds
+     * only while there is exactly one. {@code LatestReportPerBeaconTest} is what notices.
+     *
+     * <p>{@code latest_report_timestamp} is that same row's {@code timestamp} under another
+     * name, so nothing maps it and Room is told to drop it rather than warning on every build.
+     */
+    @RewriteQueriesToDropUnusedColumns
     @Query("SELECT MAX(timestamp) AS latest_report_timestamp, * FROM LocationReport GROUP BY beacon_id")
     List<LocationReport> getLastForAllBeacons();
 


### PR DESCRIPTION
Every build prints this:

```
warning: The query returns some columns [latest_report_timestamp] which are not used by
LocationReport. ... getLastForAllBeacons()
```

The warning is harmless. What it is pointing at is not.

## The query has a precondition nothing carries

```sql
SELECT MAX(timestamp) AS latest_report_timestamp, * FROM LocationReport GROUP BY beacon_id
```

This is the map's "where is each tag now". In standard SQL it is meaningless: the group has many
rows, and the bare `*` columns may be taken from any of them. SQLite makes one documented
exception — if a query has **exactly one** `min()` or `max()` aggregate, every bare column comes
from the row that produced it ([lang_select §bareagg](https://www.sqlite.org/lang_select.html#bareagg)).

So `MAX(timestamp)` is not there for its value, which nothing reads. It is there to decide *which
row of each group the other eleven columns come from*. That is invisible from the Java side, and
the two obvious tidy-ups both break it silently:

- **Delete the aggregate**, since it is genuinely unused — the query still compiles and still
  returns one row per tag
- **Add a second aggregate** — the guarantee holds only while there is exactly one

Either way nothing throws, nothing warns, and the map starts showing the wrong position for every
tag, forever.

## What actually happens when you remove it

Not "an arbitrary row", in practice. I tried it:

```
tag-a came back at the wrong timestamp expected:<9000> but was:<3000>
the latitude came from a different row than the timestamp expected:<9.0> but was:<3.0>
```

The **oldest** report, for every tag. The map would show each tag at the first place it was ever
seen, which is the worst available answer and one that looks like a stale-cache bug rather than a
query bug.

## So: a comment, an annotation, and four tests

The annotation (`@RewriteQueriesToDropUnusedColumns`) silences the warning by having Room drop the
column, with no behaviour change. That part is cosmetic.

The comment says why the aggregate is load-bearing, and the tests make it enforceable:

| | |
| --- | --- |
| The newest report per tag | inserted out of order — oldest-first would pass against a query that just returns the last row scanned |
| The whole row is that report | a broken query can return the right timestamp with the wrong coordinates, and the coordinates are what gets drawn |
| One report is still a group | |
| Empty table, empty list | |

**Verified they fail**, by removing the `MAX()` as though it were dead weight: the first two turn
red with the output above, and the other two stay green — they cannot tell the difference, which
is right.

On a device rather than the JVM, and that is rule 13's carve-out rather than an exception to it:
this is a claim about what SQLite does, so only SQLite can answer it. A fake would assert my
belief about SQLite back at me.

---

🤖 Written by [Claude Code](https://claude.com/claude-code)
