### PR TITLE
Show whether Apple's ADI libraries still match, on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 [![Android build & tests](https://github.com/parawanderer/OpenTagViewer/actions/workflows/build-debug.yml/badge.svg?branch=main)](https://github.com/parawanderer/OpenTagViewer/actions/workflows/build-debug.yml)
 [![Exporter tests](https://github.com/parawanderer/OpenTagViewer/actions/workflows/macos-scripts-python.yml/badge.svg?branch=main)](https://github.com/parawanderer/OpenTagViewer/actions/workflows/macos-scripts-python.yml)
 [![Release](https://github.com/parawanderer/OpenTagViewer/actions/workflows/build-release.yml/badge.svg)](https://github.com/parawanderer/OpenTagViewer/actions/workflows/build-release.yml)
+[![Apple's ADI libraries](https://github.com/parawanderer/OpenTagViewer/actions/workflows/check-adi-libraries.yml/badge.svg)](https://github.com/parawanderer/OpenTagViewer/actions/workflows/check-adi-libraries.yml)
+
+<sub>That last one is checked weekly against Apple's own APK, and is the only badge here that
+can go red without anybody changing anything — see
+<a href="./CONTRIBUTING.md#continuous-integration">what it watches</a>.</sub>
 
 Apparently, this is the first **<img src="https://github.com/user-attachments/assets/aa0531f6-6a5e-4c9f-b3c4-dfc3899c8a49" width="20"/> Android App** to allow you to view/track your **<img src="https://github.com/user-attachments/assets/fa3b912f-d204-4252-9449-465eb62f128c" height="20"/> official Apple AirTags**.
 


### PR DESCRIPTION
The weekly `check-adi-libraries` workflow is the only thing watching whether Apple has moved the
ADI entry points out from under local Anisette. It has been running green - last scheduled run
2026-08-18, and no `adi-drift` issue has ever been opened - but nothing said so anywhere a person
would look.

Adds its badge next to the other three, with a line of context, because it is unlike them: the
other badges go red when somebody breaks something, and this one goes red when **Apple** changes
an APK. A red build badge is a to-do; a red ADI badge is news.

Checked the CI table in `CONTRIBUTING.md` already documents the workflow, since the caption links
there.

No `?branch=main` on this one, matching the Release badge - the workflow runs on a schedule rather
than on pushes, so pinning it to a branch would show "no status" instead of the last real run.

---

🤖 Written by [Claude Code](https://claude.com/claude-code)