### PR TITLE
Stop a point with no address crashing the history list

### DIFF
--- a/app/src/main/java/dev/wander/android/opentagviewer/ui/history/HistoryItemsAdapter.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/ui/history/HistoryItemsAdapter.java
@@ -45,6 +45,19 @@ public class HistoryItemsAdapter extends RecyclerView.Adapter<HistoryItemsAdapte
 
     private static final Map<String, List<Address>> GEOCODING_CACHE = new ConcurrentHashMap<>();
 
+    /**
+     * Put a result in the cache directly.
+     *
+     * <p>So a test can arrange the state issue #41 needs - a point already looked up and
+     * found to have no address - without a geocoder, which on a test device answers nothing
+     * for every coordinate on earth and so cannot produce the interesting case on purpose.
+     */
+    @androidx.annotation.VisibleForTesting
+    static void cacheGeocodeForTest(final double latitude, final double longitude,
+                                    final List<Address> result) {
+        GEOCODING_CACHE.put(cacheKey(latitude, longitude), result);
+    }
+
     private final List<BeaconLocationReport> locations;
 
     private final Set<Integer> selectedItems;
@@ -149,8 +162,11 @@ public class HistoryItemsAdapter extends RecyclerView.Adapter<HistoryItemsAdapte
 
 
         var cachedLocation = this.getCachedGeocode(item.getLatitude(), item.getLongitude());
-        if (cachedLocation != null) {
-            viewHolder.getLocationName().setText(convertLocationToUIName(cachedLocation));
+        final String cachedName = cachedLocation == null
+                ? null : convertLocationToUIName(cachedLocation);
+
+        if (cachedName != null) {
+            viewHolder.getLocationName().setText(cachedName);
         } else {
             viewHolder.getLocationName().setText(
                     String.format(Locale.ROOT, "%.6f, %.6f", item.getLatitude(), item.getLongitude()));
@@ -173,28 +189,66 @@ public class HistoryItemsAdapter extends RecyclerView.Adapter<HistoryItemsAdapte
         }
     }
 
-    private List<Address> getCachedGeocode(double latitude, double longitude) {
-        final String key = String.format(Locale.ROOT, "%.4f,%.4f", latitude, longitude);
+    /**
+     * A cached address for this point, or null if there is not one worth using.
+     *
+     * <p><b>An empty list is not a cache hit.</b> It is what the geocoder returns when it could
+     * not answer - no backend on the device, no address at that point, a network lookup that
+     * failed - and it used to be stored and handed back like any other result. The caller then
+     * read element zero of it. That is issue #41: a crash that needs a coordinate which geocodes
+     * to nothing <i>and</i> a second bind of the same row, so the first view of a history list is
+     * always fine and scrolling back to it is not.
+     *
+     * <p>Treated as a miss rather than as an answer, so the point is looked up again later. A
+     * failed lookup is usually temporary; caching it made one bad moment permanent for the life
+     * of the process.
+     */
+    /** Rounded, so nearby points share an answer. One spelling, used by reader and writer. */
+    private static String cacheKey(final double latitude, final double longitude) {
+        return String.format(Locale.ROOT, "%.4f,%.4f", latitude, longitude);
+    }
+
+    @androidx.annotation.VisibleForTesting
+    static List<Address> getCachedGeocode(double latitude, double longitude) {
+        final String key = cacheKey(latitude, longitude);
         var cached = GEOCODING_CACHE.get(key);
-        if (cached != null) {
+        if (cached != null && !cached.isEmpty()) {
             Log.d(TAG, "Got geocoding data for " + key + " (rounded) from cache!");
             return cached;
         }
         return null;
     }
 
-    private static String convertLocationToUIName(@lombok.NonNull List<Address> geocodeData) {
+    /**
+     * The first address line, or null when there is nothing to show.
+     *
+     * <p>Guarded as well as the cache above, deliberately: "the cache holds a list" and "the list
+     * has something in it" are different claims, and only one caller was checking the second.
+     * Belt and braces here is cheap, and the failure it prevents is a crash on a screen the user
+     * is only scrolling.
+     */
+    @androidx.annotation.VisibleForTesting
+    static String convertLocationToUIName(@lombok.NonNull List<Address> geocodeData) {
+        if (geocodeData.isEmpty()) {
+            return null;
+        }
         var geocodingLocation = geocodeData.get(0);
         return geocodingLocation.getAddressLine(0);
     }
 
     private Observable<List<Address>> reverseGeocode(double latitude, double longitude) {
         return Observable.fromCallable(() -> {
-                    final String key = String.format(Locale.ROOT, "%.4f,%.4f", latitude, longitude);
+                    final String key = cacheKey(latitude, longitude);
                     Log.d(TAG, "Fetching geocoding data for " + key + " (rounded)...");
                     var result = this.geocoder.getFromLocation(latitude, longitude, 1);
-                    GEOCODING_CACHE.put(key, result);
-                    return result;
+
+                    // Only a real answer is remembered. Storing an empty one would turn a
+                    // momentary failure - no network, no backend - into a permanent "this place
+                    // has no name", and it is what the reader below would then index into.
+                    if (result != null && !result.isEmpty()) {
+                        GEOCODING_CACHE.put(key, result);
+                    }
+                    return result == null ? List.<Address>of() : result;
                 })
                 .subscribeOn(Schedulers.io());
     }

--- a/app/src/test/java/dev/wander/android/opentagviewer/ui/history/APointWithNoAddressTest.java
+++ b/app/src/test/java/dev/wander/android/opentagviewer/ui/history/APointWithNoAddressTest.java
@@ -1,0 +1,80 @@
+package dev.wander.android.opentagviewer.ui.history;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import android.location.Address;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * A history row for somewhere the geocoder cannot name.
+ *
+ * <p><b>Issue #41, which crashed on the second look and never the first.</b> An empty list is what
+ * the geocoder returns when it has no answer - mid-ocean, a device with no geocoding backend, a
+ * lookup that failed - and it was cached like any other result. The asynchronous path checked for
+ * it; the cache-hit path did not, and read element zero. So the row rendered fine when it was
+ * first bound, the empty answer went into the cache, and scrolling away and back threw
+ * {@code IndexOutOfBoundsException: Index: 0}.
+ *
+ * <p>That sequence is why one person hit it and nobody could reproduce it: it needs a point with
+ * no address <i>and</i> a re-bind of that row.
+ *
+ * <p>On the JVM, because none of this needs a device - it is a map, a list and a guard. Rule 13.
+ */
+public class APointWithNoAddressTest {
+
+    /** Somewhere unlikely to collide with another test's cache entry. */
+    private static final double LATITUDE = 41.1234;
+    private static final double LONGITUDE = -71.5678;
+
+    /**
+     * <b>The crash itself: an empty result must not be read for its first element.</b>
+     */
+    @Test
+    public void nothingIsReadOutOfAnEmptyResult() {
+        assertNull("an empty geocode has no name in it, and asking for one used to throw",
+                HistoryItemsAdapter.convertLocationToUIName(List.of()));
+    }
+
+    /**
+     * <b>And an empty result is never served from the cache as though it were an answer.</b>
+     *
+     * <p>This is the half that makes the crash reachable. Guarding the reader alone would stop the
+     * exception and leave the row permanently showing raw coordinates for a point the geocoder
+     * might well name a minute later, because the failure would stay cached for the life of the
+     * process.
+     */
+    @Test
+    public void anemptyResultIsAMissRatherThanAnAnswer() {
+        HistoryItemsAdapter.cacheGeocodeForTest(LATITUDE, LONGITUDE, List.of());
+
+        assertNull("an empty cached result must read as 'not looked up yet', so the point is"
+                        + " tried again rather than being named nothing forever",
+                HistoryItemsAdapter.getCachedGeocode(LATITUDE, LONGITUDE));
+    }
+
+    /**
+     * A real answer is still cached and still returned, which is the point of having a cache.
+     *
+     * <p>Paired with the case above deliberately: a fix that made {@code getCachedGeocode} always
+     * return null would pass that test and disable geocoding entirely.
+     */
+    @Test
+    public void arealResultIsStillServedFromTheCache() {
+        final List<Address> found = List.of(new Address(Locale.UK));
+        HistoryItemsAdapter.cacheGeocodeForTest(LATITUDE + 1, LONGITUDE + 1, found);
+
+        assertSame("a cached address must still come back, or nothing is being cached at all",
+                found, HistoryItemsAdapter.getCachedGeocode(LATITUDE + 1, LONGITUDE + 1));
+    }
+
+    /** A point nothing has looked up is a miss too, rather than an empty list. */
+    @Test
+    public void anunknownPointIsAMiss() {
+        assertNull(HistoryItemsAdapter.getCachedGeocode(12.3456, 65.4321));
+    }
+}


### PR DESCRIPTION
Fixes #41 — `IndexOutOfBoundsException: Index: 0` in `HistoryItemsAdapter.convertLocationToUIName`.

## Why one person hit it and nobody could reproduce it

The geocoder returns an **empty list** when it cannot answer: no geocoding backend on the device, no address at that point, a lookup that failed. `reverseGeocode` cached that like any other result:

```java
var result = this.geocoder.getFromLocation(latitude, longitude, 1);
GEOCODING_CACHE.put(key, result);      // an empty answer is still an answer, apparently
```

The asynchronous path guarded it — `if (geocodingResults.isEmpty()) return;` — and the cache-hit path did not. `getCachedGeocode` returned the empty list, it was not null, and `convertLocationToUIName` read element zero.

So the row renders **fine the first time**, the empty answer goes into the cache, and scrolling away and back throws. It needs a point with no address *and* a re-bind of that row, which is why it looked unreproducible and why the reporter is the only one affected.

## Both halves, because either alone is wrong

- **Guarding only the reader** stops the crash and leaves that row showing raw coordinates *forever* — the failed lookup stays cached for the life of the process, so a point the geocoder could have named a minute later never gets asked again.
- **Not caching empty results alone** leaves the reader still able to index into an empty list handed to it from anywhere else.

An empty result is now a cache **miss** rather than an answer, and the reader returns null instead of indexing.

Also unifies the cache key into one `cacheKey(...)` — the reader and the writer each had their own copy of the same `String.format`, which is two places to get rounding wrong.

## Tests

Four, on the JVM, because none of this needs a device — it is a map, a list and a guard (rule 13).

| | |
| --- | --- |
| an empty result is not read for element zero | the crash |
| an empty result is a miss, not an answer | the half that makes it reachable |
| a real result is still served from the cache | or a "fix" that always returns null would pass |
| an unlooked-up point is a miss | |

**Verified they fail**: putting issue #41 back turns exactly the first two red and leaves the other two green.

The test arranges the cache directly through a `@VisibleForTesting` seam, because a real geocoder on a test device answers nothing for every coordinate on earth and so cannot produce the interesting case on purpose.

---

🤖 Written by [Claude Code](https://claude.com/claude-code)