### PR TITLE
Say which half of an import failed, and give the rest a log worth sending

### DIFF
--- a/.claude/skills/watch-gradle-tests/SKILL.md
+++ b/.claude/skills/watch-gradle-tests/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: watch-gradle-tests
+description: Watch a Gradle instrumented-test run to a verdict without hand-writing greps. Use whenever running :app:testEmulatorDebugAndroidTest or :app:connectedDebugAndroidTest in the background.
+---
+
+# Watching a test run to a verdict
+
+The emulator suite takes upwards of ten minutes, so it gets backgrounded, so something has to
+report on it. **Do not write that something fresh each time.** Use the script.
+
+```bash
+# 1. Start the run, redirected to a file.
+./gradlew :app:testEmulatorDebugAndroidTest --console=plain > tmp/run.log 2>&1
+
+# 2. Prove the watcher sees the log before trusting it. One command, always.
+python .claude/skills/watch-gradle-tests/watch_tests.py tmp/run.log --once
+
+# 3. Arm a Monitor on the same script with no --once.
+python .claude/skills/watch-gradle-tests/watch_tests.py tmp/run.log
+```
+
+Each line it prints is one event: `FAILED <Class>.<method>` as each failure appears,
+`STALLED …` if the log stops growing, and `FINISHED` + `VERDICT` at the end.
+
+## Why this exists
+
+Three hand-written monitors in one afternoon each matched **nothing**, and each looked like a
+green run:
+
+| What was written | Why it matched nothing |
+| --- | --- |
+| `grep "(0 skipped)"` | the run had 5 skipped |
+| `grep "\S+ \[testEmulator\]"` | there is no space before `[testEmulator]` |
+| `... \| head -25` | truncated before the verdict, and `head`'s exit code hid it |
+
+All three exited 0. **Silence from a monitor is indistinguishable from silence from a healthy
+run**, so a red suite was reported as green until the log was read by hand. That is the whole
+argument for a script: the patterns get fixed once, and `--once` proves they still match before
+anything depends on them.
+
+## What it knows that a grep does not
+
+- **The XML has the last word.** The console can truncate, interleave, or count a retry
+  (`605/600` is a real line from this repo). `verdict_from_xml` reads
+  `app/build/outputs/androidTest-results/`, and **scopes to the newest run's own directory** —
+  AGP keeps `connected/` and `managedDevice/` side by side and clears neither, so summing
+  everything reported a 22-test run as 74. It always prints the results' age, because a verdict
+  that is quietly ten minutes old is the same bug wearing a coat.
+- **No results at all is not zero failures.** A run that dies before any test reports writes no
+  XML, and reading that as success is exactly how a red build gets called green.
+- **A stall is a result.** No output for eight minutes gets reported, with a diagnosis, rather
+  than looking like a slow test for another twenty.
+
+## The two silent hangs, which need opposite fixes
+
+The script separates them by whether *any* test has reported. Do not guess between them — the
+distinction is in the output.
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| No test ever reports, no managed AVD in `adb devices` | leaked managed-device slots — `MDLockCount` above zero with nothing running | `./gradlew --stop && rm ~/.android/avd/gradle-managed/active_gradle_devices` |
+| Tests ran, then stopped mid-suite | the device died under them | `adb logcat -b crash` — the emulator's Bluetooth stack aborting has done this here |
+| `connectedDebugAndroidTest` fails to install or hangs at once | stale ADB bridge inside the Gradle daemon | restart the emulator **and** `./gradlew --stop` — either alone leaves it broken |
+
+Killing a run is what leaks a slot, and every `Ctrl-C` adds one. Prefer letting a run finish; if
+you must kill one, clear the count in the same breath rather than meeting it next time.
+
+## Related
+
+- `AGENTS.md`, "Building and testing" — the managed device, and why it beats a hand-started
+  emulator.
+- `.claude/skills/watch-pr/` — the same discipline for CI: prove the poll body emits before
+  arming a Monitor on it.

--- a/.claude/skills/watch-gradle-tests/watch_tests.py
+++ b/.claude/skills/watch-gradle-tests/watch_tests.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python
+"""
+Watch a Gradle instrumented-test run and say what happened.
+
+Written because hand-rolled greps kept reporting nothing and being believed. Three separate
+monitors in one afternoon matched no lines each - one required ``(0 skipped)`` against a run with
+five skipped, one required a space before ``[testEmulator]`` that is not there, one truncated
+before the verdict with ``head``. Every one of them exited quietly, and quiet reads as green.
+
+So the patterns live here, once, with ``--once`` to prove they match before anything relies on
+them. Nothing about a run should be matched by a regex typed fresh at the call site.
+
+Usage::
+
+    python watch_tests.py <logfile> --once      # print what the log says now, and exit
+    python watch_tests.py <logfile>             # poll, one line per new event, exit when done
+
+Every line printed is an event worth a notification. Silence means nothing new, and only after
+``--once`` has shown the patterns matching something.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import sys
+import time
+import xml.etree.ElementTree as ET
+
+# **Anchored on the word FAILED, not on the decorations around it.** The name is followed
+# immediately by `[deviceName]` with no space, and the line carries ANSI colour codes; both have
+# already broken a hand-written pattern.
+FAILED_LINE = re.compile(r"^(dev\.wander\S*) > (\S+?)\[")
+
+# `(N skipped)` is not always `(0 skipped)`. Capture the numbers rather than matching a shape.
+PROGRESS = re.compile(r"Tests (\d+)/(\d+) completed\. \((\d+) skipped\) \((\d+) failed\)")
+
+# **MULTILINE, or `^` only matches the start of the whole file** and this reports "not yet"
+# forever on a finished run. The same omission has already shipped once in redact.py.
+TERMINAL = re.compile(r"^BUILD (SUCCESSFUL|FAILED)|^FAILURE: ", re.MULTILINE)
+
+# Where AGP leaves the authoritative answer. The console can be truncated, retried or interleaved;
+# these cannot.
+RESULT_XML = "app/build/outputs/androidTest-results/**/*.xml"
+
+LOCK_FILE = os.path.expanduser("~/.android/avd/gradle-managed/active_gradle_devices")
+
+
+def failures_in(log: str) -> list[str]:
+    """Every test the console has reported as failed, by name, without duplicates."""
+    seen = []
+    for line in log.splitlines():
+        if "FAILED" not in line:
+            continue
+        match = FAILED_LINE.match(line.strip())
+        if match:
+            name = f"{match.group(1).split('.')[-1]}.{match.group(2)}"
+            if name not in seen:
+                seen.append(name)
+    return seen
+
+
+def progress_of(log: str):
+    """The most recent (done, total, skipped, failed), or None before any test has run."""
+    found = PROGRESS.findall(log)
+    return tuple(int(n) for n in found[-1]) if found else None
+
+
+def leaked_device_locks() -> int:
+    """
+    How many managed-device slots AGP believes are in use.
+
+    Above zero with nothing running means the next run waits forever for a slot and boots no
+    emulator at all - see AGENTS.md. It is the single most misdiagnosable hang here, because it
+    produces no output whatsoever.
+    """
+    try:
+        with open(LOCK_FILE, encoding="utf-8") as handle:
+            match = re.search(r"MDLockCount\s+(\d+)", handle.read())
+            return int(match.group(1)) if match else 0
+    except OSError:
+        return 0
+
+
+def verdict_from_xml() -> str | None:
+    """
+    The result as the XML reports it, which is the one to trust.
+
+    **Scoped to the newest run's own directory.** AGP keeps ``connected/`` and
+    ``managedDevice/`` side by side and neither is cleared, so summing everything on disk mixes
+    this run with whatever ran before it - a 22-test run reported as 74 the first time this was
+    written, and a stale green would have masked a fresh red exactly as readily.
+
+    The age is always stated. A verdict that is quietly minutes old is the same failure in a
+    different coat.
+
+    Returns None when no results exist - itself an answer, and a different one from "zero
+    failures": a run that dies before any test reports writes nothing at all, and reading that as
+    success is how a red build gets called green.
+    """
+    files = glob.glob(RESULT_XML, recursive=True)
+    if not files:
+        return None
+
+    newest = max(files, key=os.path.getmtime)
+    run_dir = os.path.dirname(newest)
+    files = [f for f in files if os.path.dirname(f) == run_dir]
+
+    tests = failures = skipped = 0
+    named = []
+    for path in files:
+        root = ET.parse(path).getroot()
+        tests += int(root.get("tests", 0))
+        failures += int(root.get("failures", 0)) + int(root.get("errors", 0))
+        skipped += int(root.get("skipped", 0))
+        for case in root.iter("testcase"):
+            if list(case.iter("failure")) or list(case.iter("error")):
+                named.append(f"{case.get('classname', '').split('.')[-1]}.{case.get('name')}")
+
+    age = (time.time() - os.path.getmtime(newest)) / 60
+    where = os.path.basename(run_dir) or run_dir
+    summary = f"{tests} tests, {failures} failed, {skipped} skipped ({where}, {age:.0f} min old)"
+    return summary if not named else summary + " -> " + ", ".join(named)
+
+
+def describe_now(log: str) -> list[str]:
+    """Everything the log currently says, for --once."""
+    lines = []
+    done = progress_of(log)
+    lines.append(f"progress: {done[0]}/{done[1]}, {done[3]} failed, {done[2]} skipped"
+                 if done else "progress: no test has reported yet")
+
+    found = failures_in(log)
+    lines.extend(f"FAILED  {name}" for name in found)
+    if not found:
+        lines.append("failures: none reported on the console")
+
+    lines.append("terminal: " + ("yes" if TERMINAL.search(log) else "not yet"))
+    lines.append("xml verdict: " + (verdict_from_xml() or "no results written yet"))
+
+    locks = leaked_device_locks()
+    if locks:
+        lines.append(f"NOTE  MDLockCount is {locks} - if nothing is running, that is the hang")
+    return lines
+
+
+def diagnose_stall(log: str, age: float) -> list[str]:
+    """
+    Say which of the two silent hangs this is, because the fixes are unrelated.
+
+    Whether any test has reported is what separates them. Nothing at all means the run never got
+    a device - overwhelmingly a leaked managed-device slot. Tests that ran and then stopped means
+    the device died under them, which no amount of lock-clearing helps.
+    """
+    done = progress_of(log)
+    where = f"at {done[0]}/{done[1]}" if done else "before any test ran"
+    lines = [f"STALLED  no output for {age / 60:.0f} min, {where}"]
+
+    locks = leaked_device_locks()
+    if not done and locks:
+        lines.append(f"STALLED  MDLockCount is {locks} with no test output - almost certainly "
+                     f"leaked managed-device slots. ./gradlew --stop && rm {LOCK_FILE}")
+    elif done:
+        lines.append("STALLED  tests had been running, so suspect the device rather than the "
+                     "lock: adb logcat -b crash")
+    return lines
+
+
+def read(path: str) -> str:
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            return handle.read()
+    except OSError:
+        return ""
+
+
+def final_report(log: str) -> list[str]:
+    """What to say once the run is over. The XML has the last word, not the console."""
+    lines = []
+    done = progress_of(log)
+    if done:
+        lines.append(f"FINISHED  {done[0]}/{done[1]}, {done[3]} failed, {done[2]} skipped")
+    lines.append("VERDICT  " + (verdict_from_xml()
+                                or "NO RESULTS WRITTEN - the run died before any test reported"))
+    return lines
+
+
+def watch(args) -> int:
+    """Poll until the run reaches a terminal state, printing each new event once."""
+    reported: set[str] = set()
+    stalled_at = None
+    started = time.time()
+
+    while True:
+        log = read(args.logfile)
+
+        for name in failures_in(log):
+            if name not in reported:
+                reported.add(name)
+                print(f"FAILED  {name}", flush=True)
+
+        if TERMINAL.search(log):
+            for line in final_report(log):
+                print(line, flush=True)
+            return 0
+
+        # **A run that stops producing output is a result too.** Left unsaid it is
+        # indistinguishable from a slow test, which is how ten minutes goes by twice.
+        age = time.time() - os.path.getmtime(args.logfile) if os.path.exists(args.logfile) else 0
+        if age > args.stall_minutes * 60 and stalled_at != int(age // 60):
+            stalled_at = int(age // 60)
+            for line in diagnose_stall(log, age):
+                print(line, flush=True)
+
+        if time.time() - started > 3 * 60 * 60:
+            print("GIVING UP  watched for three hours", flush=True)
+            return 1
+
+        time.sleep(args.interval)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logfile", help="the file the gradle run is redirected to")
+    parser.add_argument("--once", action="store_true",
+                        help="print the current state and exit, to prove the patterns match")
+    parser.add_argument("--interval", type=int, default=40, help="seconds between polls")
+    parser.add_argument("--stall-minutes", type=float, default=8.0,
+                        help="say so if the log stops growing for this long")
+    args = parser.parse_args()
+
+    if args.once:
+        for line in describe_now(read(args.logfile)):
+            print(line)
+        return 0
+
+    return watch(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/ISSUE_TEMPLATE/app-bug.yml
+++ b/.github/ISSUE_TEMPLATE/app-bug.yml
@@ -8,8 +8,9 @@ body:
       value: |
         For the **Android app**.
 
-        The most useful thing you can attach is the log. The app can write one for you — see the
-        box near the bottom, which explains where the button is and how to make it appear.
+        The most useful thing you can attach is the log. The app writes one for you and takes
+        the personal details out of it first — see the box near the bottom for where the button
+        is.
 
   - type: input
     id: version
@@ -66,9 +67,9 @@ body:
     attributes:
       label: Which exporter made the zip?
       description: >-
-        Only if this is about importing or about missing locations. If the ⋮ menu →
-        **Information** lists what your tags were imported from, copy it from there; otherwise
-        whichever version you remember downloading, or leave it blank.
+        Only if this is about importing or about missing locations. The ⋮ menu →
+        **Information** prints it under the version, and the app's error page prints it too —
+        copy it from either.
         **Do not open the zip to find out.** It holds the keys to your tags, newer ones are
         password-protected on purpose, and unpacking it to read a version line is not worth the
         risk of what you might then attach.
@@ -81,8 +82,9 @@ body:
       description: |
         There are two ways to get one, and the first is easier if it is offered:
 
-        **If the app showed you an error page with an Export logs button**, use that button. It is
-        the same log, without any of the setting-up below.
+        **If the app showed you a page saying "This one is a bug"**, use its **Get the log**
+        button. It offers to copy the log for pasting into the box below, or to save it as a file
+        to attach — and it needs none of the setting-up below.
 
         **Otherwise** the button is hidden, because most people never need it:
 
@@ -97,10 +99,11 @@ body:
         keys to your tags: anybody who has it can locate them, and it cannot be un-posted. Nothing
         that gets asked here needs it.
 
-        **This is a raw Android log and nothing is removed from it.** Read it before posting and
-        take out anything you would not put on a public page: your Apple ID, device names, serial
-        numbers, anything a notification happened to say. Unlike the desktop exporter's Save logs
-        button, this one does not redact.
+        **Both routes clean the log first**, and tell you what they took out — Apple IDs, device
+        names, serial numbers, coordinates, place names and bundle passwords, replaced by
+        placeholders that stay consistent so the log still reads. It is best effort, not a
+        guarantee: it removes what has a recognisable shape, and something unusual on your
+        account may not. Worth a glance before you post, not a line-by-line audit.
 
         Never paste your Apple ID password, a verification code, or a device passcode. No answer
         requires them.
@@ -111,7 +114,7 @@ body:
     attributes:
       label: Before you post
       options:
-        - label: If I attached a log, I have read it and taken out anything personal I did not want public.
+        - label: If I attached a log, I have had a look at it and taken out anything personal the app missed.
           required: true
 
   - type: markdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,7 @@ Skills carry the longer version of a workflow, so this file can stay short:
 | `.claude/skills/add-strings/` | any user-facing string — adding, rewording, removing, checking |
 | `.claude/skills/device-screenshots/` | rendering the UI on the managed device and reading it cheaply |
 | `.claude/skills/watch-pr/` | watching a pushed PR's checks through to a verdict, and acting on it |
+| `.claude/skills/watch-gradle-tests/` | watching a backgrounded emulator suite to a verdict, and telling the silent hangs apart |
 
 The test for whether it belongs here rather than in a comment: would somebody hit it *before*
 reading the code that explains it? Anisette's machine-identity binding is the example — it
@@ -313,6 +314,45 @@ has nothing to do with the code. Recovering from that needs *both* an emulator r
 `./gradlew --stop`, because restarting only the emulator leaves the daemon holding the dead
 bridge. A managed device is created fresh per run, so nothing survives to go stale. It is
 also the only form of this that CI can run unattended.
+
+#### The run sits in `testEmulatorDebugAndroidTest` and never starts a test
+
+**Check the lock count first.** It is a one-line fix and it looks like four other things:
+
+```bash
+cat ~/.android/avd/gradle-managed/active_gradle_devices    # e.g. "MDLockCount 4"
+adb devices                                                # no managed AVD listed
+```
+
+If the count is above zero with no run in flight, that is the fault. Stop the daemons, delete
+the file, run again — AGP recreates it and there is nothing in it worth keeping:
+
+```bash
+./gradlew --stop
+rm ~/.android/avd/gradle-managed/active_gradle_devices
+```
+
+**Why it happens:** AGP counts the managed devices it has in flight in that file, and a run that
+is interrupted rather than finished never gives its slot back. Each `Ctrl-C`, each killed
+background job, each IDE stop button adds one. Once the count reaches the concurrency limit the
+next run waits for a slot that nothing will ever release.
+
+**Why it is worth a heading:** it boots *no emulator at all* and prints nothing while waiting, so
+for the first ten minutes it is indistinguishable from a device starting slowly, and after that
+from every other reason a run can hang. Three runs were abandoned here diagnosing it as port
+contention with a hand-started emulator — which it was not, and `adb devices` said so the whole
+time by listing no managed AVD.
+
+**So prefer letting a run finish over killing it**, and when you do kill one, clear the count in
+the same breath rather than meeting it on the next run.
+
+Two other hangs with the same symptom, so rule them in or out by what they leave behind:
+
+| What you see | What it is |
+| --- | --- |
+| No managed AVD in `adb devices`, no test output | the leaked lock above |
+| A managed AVD is up, tests ran and then stopped mid-suite | the device died — check `adb logcat -b crash`; the emulator's Bluetooth stack aborting has done this here |
+| `connectedDebugAndroidTest` fails to install, or hangs immediately | stale ADB bridge in the daemon — needs *both* an emulator restart and `./gradlew --stop` |
 
 Three consequences worth knowing:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,6 +279,23 @@ The device is defined in `testOptions { managedDevices { ... } }` in `app/build.
 and uses an `aosp-atd` image, which has **no Play Services** — a test that needs Maps would
 need a `google` image.
 
+**If a run sits in `:app:testEmulatorDebugAndroidTest` and never starts a test**, check the lock
+count before anything else:
+
+```bash
+cat ~/.android/avd/gradle-managed/active_gradle_devices    # "MDLockCount 4" with nothing running
+```
+
+AGP counts its in-flight managed devices there, and a run that is killed rather than finished
+never gives its slot back — so the count creeps up and eventually every run waits for a slot
+nothing will release. It boots no emulator and says nothing, which is why it reads as a slow
+start. Stop the daemons, delete the file, run again:
+
+```bash
+./gradlew --stop
+rm ~/.android/avd/gradle-managed/active_gradle_devices
+```
+
 > [!WARNING]
 > `connectedDebugAndroidTest` **uninstalls the app afterwards**, taking its session, settings
 > and every imported beacon with it. `allowBackup` is false, so on a real device that is gone

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,26 @@ if (requestedAbis != null) {
     }
 }
 
+/**
+ * The short commit this is being built from, or null when that cannot be known.
+ *
+ * **For log headers only.** It must never reach `versionName`: the app stamps
+ * `via: OpenTagViewer.android:<versionName>` into every bundle it exports, and rule 9 is that
+ * nothing patches a version at build time, because two artifacts built from one commit would
+ * then disagree about what produced them. A build description is a different question from a
+ * product version, and only the first one wants a commit in it.
+ *
+ * Null rather than a guess when git is absent or this is not a checkout - a source zip off a
+ * release tag has no commit to name, and inventing one is worse than saying nothing.
+ */
+val gitCommit: String? by lazy {
+    runCatching {
+        providers.exec {
+            commandLine("git", "rev-parse", "--short", "HEAD")
+        }.standardOutput.asText.get().trim().ifEmpty { null }
+    }.getOrNull()
+}
+
 android {
     namespace = "dev.wander.android.opentagviewer"
     compileSdk = 35
@@ -78,6 +98,11 @@ android {
         targetSdk = 35
         versionCode = 3
         versionName = "1.0.5"
+
+        // Null unless a build type sets it - see the debug block. A release is built from a tag
+        // and its versionName is exactly right, so there is nothing a commit would add; the
+        // field exists in both variants so code reading it compiles in both.
+        buildConfigField("String", "BUILD_COMMIT", "null")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -187,6 +212,17 @@ android {
             // SHA-1) to the key's restrictions if you need maps to render in debug builds.
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
+
+            // **`-debug` says this is not a release; it does not say which build.**
+            // `versionName` is a committed literal, so every commit after 1.0.5 reports 1.0.5
+            // perfectly confidently - and `build-debug.yml` publishes a debug APK artifact, so
+            // somebody can be running a build whose version string is months stale. The commit
+            // is the only thing that identifies such a build, which is exactly the distinction
+            // the exporter's `describe_build()` draws between a frozen download and a checkout.
+            buildConfigField(
+                "String",
+                "BUILD_COMMIT",
+                gitCommit?.let { "\"$it\"" } ?: "null")
 
             // Distinct launcher name, otherwise a debug install sits next to a real one
             // with an identical icon and label and there is no way to tell them apart.
@@ -422,6 +458,15 @@ chaquopy {
                 // desktop rather than reimplemented because what is displayed is what gets
                 // agreed to, and two renderers would eventually show two different documents.
                 "exporter/terms.py",
+                // Strips personal identifiers out of a log before anybody sends it. Pure stdlib -
+                // re, Counter, dataclass - and nothing else in exporter/.
+                //
+                // Shared for the same reason as terms.py, and more sharply: the wizard's Save
+                // logs button already runs these rules, and a second set in Java would mean two
+                // answers to "is my Apple ID in this file". The rules are patterns, so they need
+                // adding to as new identifiers turn up, and the one that gets forgotten is the
+                // copy nobody is looking at.
+                "exporter/redact.py",
             )
             // The package's own test suite is not part of the app. It imports pytest, which is
             // not in the APK, so it is dead weight that would fail if anything ever touched it.

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/Shot.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/Shot.java
@@ -1,0 +1,58 @@
+package dev.wander.android.opentagviewer;
+
+import android.graphics.Bitmap;
+import android.util.Log;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+/**
+ * A picture of whatever is on the screen, dialogs included.
+ *
+ * <p><b>Whole-screen, unlike the {@code view.draw(canvas)} pattern used elsewhere.</b> That one
+ * needs the view to be in the activity's own hierarchy, and a dialog is not - it lives in its
+ * own window, so drawing the activity produces the page behind it with a hole where the dialog
+ * should be. {@code UiAutomation} photographs the compositor's output instead, which is what a
+ * person actually sees.
+ *
+ * <p>Writes into the directory AGP passes as {@code additionalTestOutputDir} and does nothing
+ * when there isn't one, so it is free in an ordinary run. Names are
+ * {@code <subject>-<variant>.png} so {@code .claude/skills/device-screenshots/sheet.py} groups
+ * them.
+ *
+ * <p>As ever: a screenshot is not an assertion. It explains why a failure looks wrong; it cannot
+ * fail. Assert the thing that matters as well.
+ */
+public final class Shot {
+
+    private Shot() {}
+
+    private static final String TAG = "Shot";
+
+    public static void ofTheScreen(final String name) {
+        final String dir = InstrumentationRegistry.getArguments()
+                .getString("additionalTestOutputDir");
+        if (dir == null) {
+            return;
+        }
+
+        try {
+            final Bitmap bitmap =
+                    InstrumentationRegistry.getInstrumentation().getUiAutomation().takeScreenshot();
+            if (bitmap == null) {
+                Log.w(TAG, "the screen could not be photographed for " + name);
+                return;
+            }
+            try (FileOutputStream out =
+                         new FileOutputStream(new File(new File(dir), name + ".png"))) {
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
+            }
+            bitmap.recycle();
+        } catch (final Exception e) {
+            // A screenshot explains a failure; it is never the reason for one.
+            Log.w(TAG, "could not write " + name, e);
+        }
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/db/room/dao/WhichExportersMadeTheseTagsTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/db/room/dao/WhichExportersMadeTheseTagsTest.java
@@ -1,0 +1,130 @@
+package dev.wander.android.opentagviewer.db.room.dao;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import androidx.room.Room;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import dev.wander.android.opentagviewer.db.room.OpenTagViewerDatabase;
+import dev.wander.android.opentagviewer.db.room.entity.Import;
+
+/**
+ * Which exporters produced the bundles on this install.
+ *
+ * <p><b>The question the Information screen used to answer with {@code getMostRecent}.</b> That
+ * names one producer and reads as though it accounts for every tag on the phone - and importing
+ * twice is ordinary: a second Mac, a re-export after buying a tag, an old bundle alongside a
+ * current one. A report saying "exported with 1.3.0" when half the tags came out of 1.1.0 sends
+ * whoever reads it looking in the wrong place, which is the whole failure this screen exists to
+ * prevent.
+ *
+ * <p>An in-memory database rather than the device's own, so this says nothing about whatever the
+ * emulator happens to have imported and cannot disturb it.
+ */
+@SmallTest
+@RunWith(AndroidJUnit4.class)
+public class WhichExportersMadeTheseTagsTest {
+
+    private OpenTagViewerDatabase db;
+
+    @Before
+    public void openAnEmptyOne() {
+        this.db = Room.inMemoryDatabaseBuilder(
+                        getInstrumentation().getTargetContext(), OpenTagViewerDatabase.class)
+                .allowMainThreadQueries()
+                .build();
+    }
+
+    @After
+    public void closeIt() {
+        if (this.db != null) {
+            this.db.close();
+        }
+    }
+
+    /** <b>Every producer, not the last one.</b> */
+    @Test
+    public void twoBundlesFromTwoExportersAreBothNamed() {
+        this.imported("OpenTagViewer.wizard:1.1.0", 1_000L);
+        this.imported("OpenTagViewer.cli:1.3.0", 2_000L);
+
+        assertEquals(
+                List.of("OpenTagViewer.cli:1.3.0", "OpenTagViewer.wizard:1.1.0"),
+                this.dao().getDistinctProducers());
+    }
+
+    /**
+     * <b>Most recently used first, which is not the same as most recently inserted.</b>
+     *
+     * <p>Somebody who imports from 1.3.0, then re-imports an older bundle, then imports from
+     * 1.3.0 again has three rows and two producers. The ordering is by each producer's newest
+     * import - so 1.3.0 leads, despite its <i>first</i> row being the oldest of the three.
+     */
+    @Test
+    public void theOrderIsByEachProducersNewestImport() {
+        this.imported("OpenTagViewer.wizard:1.3.0", 1_000L);
+        this.imported("OpenTagViewer.wizard:1.1.0", 2_000L);
+        this.imported("OpenTagViewer.wizard:1.3.0", 3_000L);
+
+        assertEquals(
+                List.of("OpenTagViewer.wizard:1.3.0", "OpenTagViewer.wizard:1.1.0"),
+                this.dao().getDistinctProducers());
+    }
+
+    /** The same producer twice is one answer, not two. */
+    @Test
+    public void thesameExporterTwiceIsNamedOnce() {
+        this.imported("OpenTagViewer.wizard:1.3.0", 1_000L);
+        this.imported("OpenTagViewer.wizard:1.3.0", 2_000L);
+
+        assertEquals(1, this.dao().getDistinctProducers().size());
+    }
+
+    /**
+     * <b>An export from before {@code via:} existed contributes nothing rather than a blank.</b>
+     *
+     * <p>Null and empty are both real in this column - format 0.0.1 predates the field entirely.
+     * Letting either through puts "Tags imported from , OpenTagViewer.wizard:1.3.0" on the
+     * screen, which reads as a rendering bug rather than as an old bundle.
+     */
+    @Test
+    public void anexportThatNeverRecordedItselfIsNotAnEmptyEntry() {
+        this.imported(null, 1_000L);
+        this.imported("", 2_000L);
+        this.imported("OpenTagViewer.wizard:1.3.0", 3_000L);
+
+        assertEquals(List.of("OpenTagViewer.wizard:1.3.0"), this.dao().getDistinctProducers());
+    }
+
+    /** Nothing imported is an empty list, which the screen turns into words of its own. */
+    @Test
+    public void nothingImportedIsEmptyRatherThanNull() {
+        final List<String> producers = this.dao().getDistinctProducers();
+
+        assertTrue("expected no producers, got " + producers, producers.isEmpty());
+    }
+
+    private ImportDao dao() {
+        return this.db.importDao();
+    }
+
+    private void imported(final String via, final long at) {
+        this.dao().insert(Import.builder()
+                .version("0.0.2")
+                .importedAt(at)
+                .exportedAt(at)
+                .sourceUser("someone@example.com")
+                .exportedVia(via)
+                .build());
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/python/PythonPackagingTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/python/PythonPackagingTest.java
@@ -2,6 +2,7 @@ package dev.wander.android.opentagviewer.python;
 
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -163,6 +164,34 @@ public class PythonPackagingTest {
             assertNotNull(module + " must be importable in the APK",
                     Python.getInstance().getModule(module));
         }
+    }
+
+    /**
+     * The log redactor imports, and still strips something.
+     *
+     * <p><b>The one whitelisted module whose absence would be silent and harmful.</b> Everything
+     * else here fails loudly when it is missing - no sign-in, no import. This one is reached at
+     * the moment somebody is about to send their log to a public issue, and a caller that
+     * shrugged off the import error would hand over an unredacted one. So the app refuses to
+     * produce a log it could not clean, and this is what says the refusal will not be the normal
+     * case.
+     *
+     * <p>Asserted by running it rather than by importing it: {@code redact} is patterns and a
+     * {@code Counter}, so an import that resolved against something empty would still be an
+     * import. The rules themselves are the exporter's to test - {@code python/test/test_redact.py},
+     * a different CI job - and duplicating them here would be the second copy this arrangement
+     * exists to avoid.
+     */
+    @Test
+    public void theredactorIsPackagedAndRedacts() {
+        final PyObject redact = Python.getInstance().getModule("exporter.redact");
+        assertNotNull("exporter.redact must be importable in the APK", redact);
+
+        final PyObject result = redact.callAttr("redact", "signed in as someone@example.com");
+        final String cleaned = result.asList().get(0).toString();
+
+        assertFalse("the address survived redaction: " + cleaned,
+                cleaned.contains("someone@example.com"));
     }
 
     /**

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WhatTheInformationScreenAnswersTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WhatTheInformationScreenAnswersTest.java
@@ -1,0 +1,128 @@
+package dev.wander.android.opentagviewer.ui;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+
+import android.content.Context;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.InformationActivity;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.Shot;
+import dev.wander.android.opentagviewer.db.room.OpenTagViewerDatabase;
+import dev.wander.android.opentagviewer.db.room.dao.ImportDao;
+import dev.wander.android.opentagviewer.db.room.entity.Import;
+
+/**
+ * The screen a bug report sends people to, and whether it answers what the report asks.
+ *
+ * <p><b>Two questions, and until now it answered one.</b> The app version was here; which
+ * exporter produced the bundle was not - and the only place that lives is {@code
+ * OPENTAGVIEWER.yml} inside the export zip, a file holding the private keys to somebody's tags
+ * and one the issue template tells them in bold not to open. Asking a question whose answer is
+ * inside a file you have told people not to open is asking them to ignore you.
+ *
+ * <p>Both states matter. An install connected straight to an Apple account has no bundle behind
+ * it at all, and "nothing" is a real answer rather than a gap - it tells a maintainer the
+ * exporter is not involved, which rules out a whole class of cause.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class WhatTheInformationScreenAnswersTest {
+
+    private static final String AN_EXPORTER = "OpenTagViewer.wizard:1.3.0";
+
+    private ActivityScenario<InformationActivity> scenario;
+
+    /** Put back whatever the device had, so this cannot bleed into another test. */
+    private List<Import> before;
+
+    @Before
+    public void rememberWhatWasThere() {
+        this.before = imports().getAll();
+        for (final Import existing : this.before) {
+            imports().delete(existing);
+        }
+    }
+
+    @After
+    public void putItBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        for (final Import existing : imports().getAll()) {
+            imports().delete(existing);
+        }
+        for (final Import original : this.before) {
+            imports().insert(original);
+        }
+    }
+
+    /**
+     * <b>The exporter that made the bundle, on screen, so nobody opens the zip to find it.</b>
+     */
+    @Test
+    public void awhichExporterMadeTheBundle() {
+        imports().insert(Import.builder()
+                .version("0.0.2")
+                .importedAt(System.currentTimeMillis())
+                .exportedAt(System.currentTimeMillis())
+                .sourceUser("someone@example.com")
+                .exportedVia(AN_EXPORTER)
+                .build());
+
+        this.scenario = ActivityScenario.launch(InformationActivity.class);
+
+        // The read is a database call on a background thread, so the line arrives after the
+        // screen does.
+        Eventually.check(() -> onView(withId(R.id.appImportedFrom))
+                .check(matches(withText(containsString(AN_EXPORTER)))));
+
+        // And the version is still the thing above it, which is the other half the report wants.
+        onView(withId(R.id.appVersion)).check(matches(withText(startsWith("Version"))));
+
+        Shot.ofTheScreen("the_information_screen-imported_from_an_exporter");
+    }
+
+    /**
+     * <b>And "nothing" said out loud, rather than an empty line.</b>
+     *
+     * <p>A blank where an answer should be reads as a bug in this screen. It is not - it is the
+     * answer for anybody who connected an Apple account instead of importing a zip, and saying
+     * so rules the exporter out of whatever they are reporting.
+     */
+    @Test
+    public void bnothingImportedIsAlsoAnAnswer() {
+        this.scenario = ActivityScenario.launch(InformationActivity.class);
+
+        final Context context = getInstrumentation().getTargetContext();
+        Eventually.check(() -> onView(withId(R.id.appImportedFrom))
+                .check(matches(withText(context.getString(R.string.imported_from_nothing)))));
+        onView(withId(R.id.appImportedFrom)).check(matches(isDisplayed()));
+
+        Shot.ofTheScreen("the_information_screen-nothing_imported");
+    }
+
+    private static ImportDao imports() {
+        return OpenTagViewerDatabase
+                .getInstance(getInstrumentation().getTargetContext().getApplicationContext())
+                .importDao();
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/error/TheErrorPageIsReportableTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/error/TheErrorPageIsReportableTest.java
@@ -1,0 +1,317 @@
+package dev.wander.android.opentagviewer.ui.error;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasData;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasType;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import android.app.Activity;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.app.Instrumentation.ActivityResult;
+import android.content.Intent;
+
+import androidx.lifecycle.Lifecycle.State;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.python.LogRedactor;
+
+/**
+ * The page somebody lands on when the app cannot say what went wrong.
+ *
+ * <p><b>Its whole job is to make a report possible, so what it hands over is the thing to test.</b>
+ * Two questions decide whether it works: does the link carry the template that puts the questions
+ * in front of the reporter, and can an <i>unredacted</i> log ever leave the app. The second is the
+ * one with a permanent cost - an Apple ID posted to a public issue cannot be un-posted - and it
+ * only happens on the path where redaction fails, which is exactly the path a real device will not
+ * take on demand.
+ *
+ * <p>Hence a fake redactor. {@code AppDependencies.replaceLogRedactor} produces both the working
+ * case and the broken one; the broken one is not reachable otherwise, because it means Chaquopy
+ * failing to start.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class TheErrorPageIsReportableTest {
+
+    private static final String A_CAUSE = "KeychainSessionError: No keychain keys are held";
+
+    /** Something a real logcat would carry and a report must not. */
+    private static final String SOMETHING_PERSONAL = "someone@example.com";
+
+    /** Only the redactor's output carries this, so finding it proves which text went.
+     * Asserting the absence of the personal string alone would pass on an empty payload. */
+    private static final String REDACTED_MARKER = " [cleaned by the redactor]";
+
+    private ActivityScenario<ErrorReportActivity> scenario;
+
+    @Before
+    public void catchTheIntents() {
+        Intents.init();
+
+        // **Only what leaves the app, named explicitly.**
+        //
+        // "anything that is not ACTION_MAIN" reads as the same thing and is not: the intent that
+        // launches the activity under test matches it too, so ActivityScenario.launch was
+        // answered by the stub, the activity never started, and the scenario waited for a RESUMED
+        // state that could not arrive. A hang rather than a failure, at 0 of 8 tests, with
+        // nothing in the output naming the cause.
+        // **Every intent the page can fire, or the real thing launches.** `intending` stubs
+        // only what it is named, and this class went on stubbing ACTION_CHOOSER after the share
+        // sheet became a document picker - so a real picker opened over the app and stayed there
+        // for whatever ran next.
+        intending(anyOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasAction(Intent.ACTION_CREATE_DOCUMENT)))
+                .respondWith(new ActivityResult(Activity.RESULT_CANCELED, null));
+    }
+
+    @After
+    public void putTheRealOnesBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        Intents.release();
+        AppDependencies.reset();
+    }
+
+    private void open() {
+        this.scenario = ActivityScenario.launch(ErrorReportActivity.intentFor(
+                getInstrumentation().getTargetContext(), A_CAUSE));
+    }
+
+    /**
+     * <b>The report button opens the form, with the template that asks the questions.</b>
+     *
+     * <p>Not {@code /issues/new}. GitHub applies a template's labels and questions from its front
+     * matter; a bare form gives the reporter a blank box and the maintainer an unlabelled issue.
+     * And GitHub does not error on a wrong template name - it silently serves the blank one - so
+     * nothing but an assertion notices.
+     */
+    @Test
+    public void thereportButtonOpensTheTemplatedForm() {
+        AppDependencies.replaceLogRedactor(log -> new LogRedactor.Redacted(log, "nothing"));
+        this.open();
+
+        Eventually.check(() -> onView(withId(R.id.error_report_button))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.error_report_button)).perform(click());
+
+        intended(allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasData(hasToString(IssueReport.NEW_APP_BUG))));
+    }
+
+    /**
+     * <b>And the cause is on screen verbatim, in the words the failure arrived in.</b>
+     *
+     * <p>It is evidence, not prose: a maintainer searches for it, and a reporter pastes it. A
+     * translated or prettified cause is one nobody can match against a stack trace.
+     */
+    @Test
+    public void thefailureIsShownAsItArrived() {
+        AppDependencies.replaceLogRedactor(log -> new LogRedactor.Redacted(log, "nothing"));
+        this.open();
+
+        Eventually.check(() -> onView(withId(R.id.error_report_cause))
+                .check(matches(withText(A_CAUSE))));
+    }
+
+    /**
+     * <b>Copying puts the redacted text on the clipboard, and not the raw log.</b>
+     *
+     * <p>The fake stands in for {@code exporter.redact}, whose own rules are the exporter's to
+     * test. What is asserted here is the wiring - and it is asserted on the <i>payload</i>,
+     * which is the whole point. This test previously checked that a share sheet had opened and
+     * called itself "the shared log is the redacted one"; it would have stayed green while
+     * handing over an unredacted log, which is the one outcome that cannot be taken back.
+     */
+    @Test
+    public void thecopiedLogIsTheRedactedOne() {
+        AppDependencies.replaceLogRedactor(log ->
+                new LogRedactor.Redacted(
+                        log.replace(SOMETHING_PERSONAL, "<email>") + REDACTED_MARKER,
+                        "1 email address"));
+        this.open();
+
+        this.chooseFromTheLogMenu(R.string.error_report_log_copy);
+
+        final CharSequence copied = theClipboard();
+        assertNotNull("nothing was copied", copied);
+        assertThat(copied.toString(), containsString(REDACTED_MARKER));
+        assertThat("the raw log reached the clipboard",
+                copied.toString(), not(containsString(SOMETHING_PERSONAL)));
+    }
+
+    /**
+     * <b>Saving asks the system for somewhere to put it, rather than choosing for the user.</b>
+     *
+     * <p>A file the user picked the location of is one the browser's file picker can find again
+     * when they go to attach it, which is the entire reason this option exists. A cache file
+     * handed to a share sheet is not, and Drive and Files do not even appear as targets for one.
+     */
+    @Test
+    public void thesaveOptionOpensTheDocumentPicker() {
+        AppDependencies.replaceLogRedactor(log -> new LogRedactor.Redacted(log, "nothing"));
+        this.open();
+
+        this.chooseFromTheLogMenu(R.string.error_report_log_save);
+
+        intended(allOf(
+                hasAction(Intent.ACTION_CREATE_DOCUMENT),
+                hasType("text/plain"),
+                hasExtra(Intent.EXTRA_TITLE, "opentagviewer-log.txt")));
+    }
+
+    /**
+     * <b>And there is a way off this page that is on the page.</b>
+     *
+     * <p>The action bar is hidden here, so before Close existed the system back gesture was the
+     * only exit - no arrow, no X. Fine for anybody who knows that and a dead end for anybody who
+     * does not, on a screen somebody reaches at the moment they are already stuck.
+     */
+    @Test
+    public void thereisAWayOutThatIsNotTheBackGesture() {
+        AppDependencies.replaceLogRedactor(log -> new LogRedactor.Redacted(log, "nothing"));
+        this.open();
+
+        Eventually.check(() -> onView(withId(R.id.error_report_close))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.error_report_close)).perform(scrollTo(), click());
+
+        Eventually.check(() -> assertEquals(
+                State.DESTROYED, this.scenario.getState()));
+    }
+
+    /**
+     * Opens the two-way choice and picks one of them.
+     *
+     * <p><b>The wait between the two is not padding.</b> A dialog animates in, and
+     * `animationsDisabled` does not stop it - AGP zeroes the window and transition scales and
+     * leaves `animator_duration_scale` alone, so clicking the instant the builder returns hits a
+     * row that is still scaling up and less than 90% visible. Espresso calls that a
+     * PerformException, which reads like the view being wrong rather than early. It passed on a
+     * fast device and failed on the managed one, which is the usual way round.
+     */
+    private void chooseFromTheLogMenu(final int option) {
+        Eventually.check(() -> onView(withId(R.id.error_report_share_log))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.error_report_share_log)).perform(scrollTo(), click());
+
+        final String label = getInstrumentation().getTargetContext().getString(option);
+        Eventually.check(() -> onView(withText(label)).inRoot(isDialog())
+                .check(matches(isDisplayed())));
+        onView(withText(label)).inRoot(isDialog()).perform(click());
+    }
+
+    /** What is on the clipboard, read on the main thread as the framework requires. */
+    private static CharSequence theClipboard() {
+        final CharSequence[] held = new CharSequence[1];
+        getInstrumentation().runOnMainSync(() -> {
+            final ClipboardManager clipboard = getInstrumentation().getTargetContext()
+                    .getSystemService(ClipboardManager.class);
+            final ClipData clip = clipboard == null ? null : clipboard.getPrimaryClip();
+            held[0] = clip == null || clip.getItemCount() == 0
+                    ? null
+                    : clip.getItemAt(0).getText();
+        });
+        return held[0];
+    }
+
+    /**
+     * And it says what came out, rather than asking to be trusted.
+     */
+    @Test
+    public void itsaysWhatTheRedactorRemoved() {
+        AppDependencies.replaceLogRedactor(log ->
+                new LogRedactor.Redacted(log, "1 email address, 2 serial numbers"));
+        this.open();
+
+        Eventually.check(() -> onView(withId(R.id.error_report_log_note))
+                .check(matches(withText(containsString("1 email address, 2 serial numbers")))));
+    }
+
+    /**
+     * <b>A redactor that cannot run means no log at all - never the raw one.</b>
+     *
+     * <p>The case this class exists for. This page is reached <i>because</i> something broke, and
+     * "Chaquopy did not start" is a candidate - so the redactor failing is not hypothetical, it is
+     * correlated with being here. Falling back to the unredacted log would put somebody's Apple ID
+     * on a public issue at the exact moment they are least inclined to read it first, and it
+     * cannot be taken back.
+     *
+     * <p>So the button is absent, and the page says why rather than leaving a dead control.
+     */
+    @Test
+    public void arefusedRedactionOffersNoLogAtAll() {
+        AppDependencies.replaceLogRedactor(log -> null);
+        this.open();
+
+        Eventually.check(() -> onView(withId(R.id.error_report_log_note))
+                .check(matches(isDisplayed())));
+
+        onView(withId(R.id.error_report_share_log)).check(matches(not(isDisplayed())));
+        onView(withId(R.id.error_report_log_note)).check(matches(
+                withText(getInstrumentation().getTargetContext()
+                        .getString(R.string.error_report_log_unavailable))));
+    }
+
+    /**
+     * And reporting still works without one, because a report with no log still helps.
+     */
+    @Test
+    public void reportingIsStillOfferedWithoutALog() {
+        AppDependencies.replaceLogRedactor(log -> null);
+        this.open();
+
+        Eventually.check(() -> onView(withId(R.id.error_report_button))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.error_report_button)).perform(click());
+
+        intended(hasAction(Intent.ACTION_VIEW));
+    }
+
+    private static org.hamcrest.Matcher<android.net.Uri> hasToString(final String expected) {
+        return new org.hamcrest.TypeSafeMatcher<>() {
+            @Override
+            protected boolean matchesSafely(final android.net.Uri uri) {
+                return expected.equals(uri.toString());
+            }
+
+            @Override
+            public void describeTo(final org.hamcrest.Description description) {
+                description.appendText("a Uri of " + expected);
+            }
+        };
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/error/WalkingThroughTheErrorPageTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/error/WalkingThroughTheErrorPageTest.java
@@ -1,0 +1,188 @@
+package dev.wander.android.opentagviewer.ui.error;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import android.app.Activity;
+import android.app.Instrumentation.ActivityResult;
+import android.content.Intent;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.Shot;
+import dev.wander.android.opentagviewer.TestPace;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.python.LogRedactor;
+
+/**
+ * The error page as a person meets it, at a pace a person can follow.
+ *
+ * <p><b>Its sibling {@code TheErrorPageIsReportableTest} asserts; this one is for watching.</b>
+ * Six separate assertions each open and close the screen, so run in slow motion they are six
+ * flickers rather than a journey. This walks the whole thing once, paced with {@link TestPace}, so
+ * {@code slowMotion=2000} shows what somebody actually sees.
+ *
+ * <p>It still asserts as it goes - a demo that could pass while showing the wrong screen is
+ * decoration - but the assertions are the ones a viewer is looking at anyway, and the two states
+ * it covers are the ones that matter: a log that can be shared, and a log that cannot.
+ *
+ * <p>See {@code AGENTS.md} under "Showing a UI test to a person" for how to run it on a device
+ * with a window.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class WalkingThroughTheErrorPageTest {
+
+    private static final String A_CAUSE =
+            "KeychainSessionError: No keychain keys are held, so nothing can be decrypted.";
+
+    /** What a real logcat would carry and a public issue must not. */
+    private static final String AN_EMAIL = "someone@example.com";
+
+    private ActivityScenario<ErrorReportActivity> scenario;
+
+    @Before
+    public void catchWhatLeavesTheApp() {
+        Intents.init();
+        // **Only what leaves the app, named explicitly.**
+        //
+        // "anything that is not ACTION_MAIN" reads as the same thing and is not: the intent that
+        // launches the activity under test matches it too, so ActivityScenario.launch was
+        // answered by the stub, the activity never started, and the scenario waited for a RESUMED
+        // state that could not arrive. A hang rather than a failure, at 0 of 8 tests, with
+        // nothing in the output naming the cause.
+        // CANCELED for the picker: RESULT_OK with no data would have the page treat a
+        // cancelled save as a successful one, which is the opposite of what a stub should model.
+        intending(hasAction(Intent.ACTION_VIEW))
+                .respondWith(new ActivityResult(Activity.RESULT_OK, null));
+        intending(hasAction(Intent.ACTION_CREATE_DOCUMENT))
+                .respondWith(new ActivityResult(Activity.RESULT_CANCELED, null));
+    }
+
+    @After
+    public void putTheRealOnesBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        Intents.release();
+        AppDependencies.reset();
+    }
+
+    /**
+     * <b>The whole page, in the order somebody reads it.</b>
+     *
+     * <p>Arrive on a failure nobody can act on, see what it was, see which build and which bundle
+     * it happened to, learn that the log is cleaned and what came out of it, share it, then open
+     * the report form.
+     */
+    @Test
+    public void awholeReportFromAFailureNobodyCanAct0n() {
+        // Stands in for exporter.redact: takes the address out, and says it did.
+        AppDependencies.replaceLogRedactor(log -> new LogRedactor.Redacted(
+                log.replace(AN_EMAIL, "<email>"), "1 email address, 2 device names"));
+
+        this.scenario = ActivityScenario.launch(ErrorReportActivity.intentFor(
+                getInstrumentation().getTargetContext(), A_CAUSE));
+
+        // 1. It says plainly that this is a bug rather than something to retry.
+        Eventually.check(() -> onView(withId(R.id.error_report_title))
+                .check(matches(isDisplayed())));
+        TestPace.afterAStep();
+
+        // 2. And what actually failed, verbatim - the thing a maintainer searches for.
+        onView(withId(R.id.error_report_cause)).check(matches(withText(A_CAUSE)));
+        TestPace.afterAStep();
+
+        // 3. The two questions the report form opens with, already answered on screen. This is
+        //    what stops somebody opening their export zip to read a version line out of it.
+        onView(withId(R.id.error_report_build))
+                .check(matches(withText(containsString("OpenTagViewer app"))));
+        onView(withId(R.id.error_report_imported_from)).check(matches(isDisplayed()));
+        TestPace.afterAStep();
+
+        // 4. The log is offered only once it has been through the redactor, and the page says
+        //    what came out rather than asking to be trusted.
+        Eventually.check(() -> onView(withId(R.id.error_report_share_log))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.error_report_log_note))
+                .check(matches(withText(containsString("1 email address, 2 device names"))));
+        Shot.ofTheScreen("the_error_page-log_can_be_shared");
+        TestPace.afterAStep();
+
+        // 5. And it asks which of the two things is wanted, because they are not the same
+        //    thing: pasting into the form's log box, or producing a file to attach. This was a
+        //    share sheet, which served neither - with text and no stream, Drive and Files do not
+        //    appear as targets at all.
+        onView(withId(R.id.error_report_share_log)).perform(scrollTo(), click());
+        onView(withText(getInstrumentation().getTargetContext()
+                .getString(R.string.error_report_log_save)))
+                .inRoot(isDialog()).check(matches(isDisplayed()));
+        Shot.ofTheScreen("the_error_page-how_do_you_want_the_log");
+        TestPace.afterAStep();
+
+        // 6. Saving goes to the document picker, so the file lands where the user chose - which
+        //    is the only place a browser's file picker can find it again.
+        onView(withText(getInstrumentation().getTargetContext()
+                .getString(R.string.error_report_log_save))).inRoot(isDialog()).perform(click());
+        intended(hasAction(Intent.ACTION_CREATE_DOCUMENT));
+        TestPace.afterAStep();
+
+        // 7. And the report button lands on the form with the questions already in it.
+        onView(withId(R.id.error_report_button)).perform(scrollTo(), click());
+        intended(hasAction(Intent.ACTION_VIEW));
+        TestPace.afterAStep();
+    }
+
+    /**
+     * <b>And the same page when the log cannot be cleaned.</b>
+     *
+     * <p>Worth watching rather than only asserting, because the correct behaviour is an
+     * <i>absence</i> - no share button - and an absence is the kind of thing that looks like a
+     * layout bug until you know it is deliberate. The page says why, and reporting still works.
+     */
+    @Test
+    public void andwhatItLooksLikeWhenTheLogCannotBeCleaned() {
+        AppDependencies.replaceLogRedactor(log -> null);
+
+        this.scenario = ActivityScenario.launch(ErrorReportActivity.intentFor(
+                getInstrumentation().getTargetContext(), A_CAUSE));
+
+        Eventually.check(() -> onView(withId(R.id.error_report_log_note))
+                .check(matches(withText(getInstrumentation().getTargetContext()
+                        .getString(R.string.error_report_log_unavailable)))));
+        TestPace.afterAStep();
+
+        // No button, rather than a button that hands over an unredacted log.
+        onView(withId(R.id.error_report_share_log)).check(matches(not(isDisplayed())));
+        Shot.ofTheScreen("the_error_page-log_cannot_be_cleaned");
+        TestPace.afterAStep();
+
+        // Reporting without a log still helps, so it is still offered.
+        onView(withId(R.id.error_report_button)).perform(scrollTo(), click());
+        intended(hasAction(Intent.ACTION_VIEW));
+        TestPace.afterAStep();
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/importing/WalkingThroughAnImportThatFailedTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/importing/WalkingThroughAnImportThatFailedTest.java
@@ -1,0 +1,264 @@
+package dev.wander.android.opentagviewer.ui.importing;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import android.app.Instrumentation.ActivityResult;
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.appcompat.app.AlertDialog;
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.Shot;
+import dev.wander.android.opentagviewer.TestPace;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.python.LogRedactor;
+import dev.wander.android.opentagviewer.ui.TestHostActivity;
+import dev.wander.android.opentagviewer.ui.error.ErrorReportActivity;
+
+/**
+ * The two halves of a failed import, side by side, at a pace a person can follow.
+ *
+ * <p><b>They used to be one screen saying one thing, and that was the bug.</b> Picking a zip
+ * starts two operations - reading the file and storing the tags, then asking Apple where those
+ * tags are - and a single error handler covered both. So an Anisette server being down produced
+ * "Error occurred while importing new devices. Try to restart the app and retry", for an import
+ * that had succeeded and whose tags were visible in the device list. Issues
+ * <a href="https://github.com/parawanderer/OpenTagViewer/issues/19">#19</a> and
+ * <a href="https://github.com/parawanderer/OpenTagViewer/issues/26">#26</a> are 34 comments of
+ * people discovering that for themselves.
+ *
+ * <p>Watching the two in sequence is the point: one says <i>this is a bug, report it</i>, the
+ * other says <i>your tags are fine, this is probably your Anisette server</i>. If they ever read
+ * alike again, the fix has been undone.
+ *
+ * <p>Run it slowly on a device with a window - see {@code AGENTS.md}, "Showing a UI test to a
+ * person". It asserts as it goes, because a demo that can pass while showing the wrong screen is
+ * decoration.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class WalkingThroughAnImportThatFailedTest {
+
+    /** What a zip failing below the importer actually looks like. */
+    private static final String A_ZIP_CAUSE =
+            "EOFException: Unexpected end of ZLIB input stream";
+
+    /** And what a first fetch failing looks like - nothing to do with a file. */
+    private static final String A_FETCH_CAUSE =
+            "PythonAppleFindMyException: Anisette server at https://ani.example.com returned 502";
+
+    private ActivityScenario<?> scenario;
+
+    @Before
+    public void catchWhatLeavesTheApp() {
+        Intents.init();
+        // Only what leaves the app, named explicitly - a matcher broad enough to catch the
+        // launch intent stubs ActivityScenario itself and hangs the run. See the note in
+        // TheErrorPageIsReportableTest.
+        intending(anyOf(hasAction(Intent.ACTION_VIEW), hasAction(Intent.ACTION_CHOOSER)))
+                .respondWith(new ActivityResult(Activity.RESULT_OK, null));
+    }
+
+    @After
+    public void putTheRealOnesBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        Intents.release();
+        AppDependencies.reset();
+    }
+
+    /**
+     * <b>First half: the zip really could not be read, and nothing here can say why.</b>
+     *
+     * <p>This is the only failure that now claims to be about the file, and the only one that
+     * offers to open a bug report. Everything the reporter would otherwise be asked for is
+     * already on the screen.
+     */
+    @Test
+    public void azipNobodyCanReadIsTheOneThingWorthReporting() {
+        AppDependencies.replaceLogRedactor(log -> new LogRedactor.Redacted(
+                log.replace("someone@example.com", "<email>"), "1 email address"));
+
+        final Context context = getInstrumentation().getTargetContext();
+        this.scenario = ActivityScenario.launch(ErrorReportActivity.intentFor(
+                context, A_ZIP_CAUSE, R.string.error_report_body_import));
+
+        // 1. It says this is a bug rather than something to retry.
+        Eventually.check(() -> onView(withId(R.id.error_report_title))
+                .check(matches(isDisplayed())));
+        TestPace.afterAStep();
+
+        // 2. And it describes the right phase. The protocol wording - "something came back that
+        //    this app does not know how to read" - is false here: nothing came back from
+        //    anywhere, somebody chose a file.
+        onView(withId(R.id.error_report_body)).check(matches(withText(
+                context.getString(R.string.error_report_body_import))));
+        onView(withId(R.id.error_report_body)).check(matches(not(withText(
+                context.getString(R.string.error_report_body)))));
+        TestPace.afterAStep();
+
+        // 3. The failure verbatim, which is what a maintainer searches for.
+        onView(withId(R.id.error_report_cause)).check(matches(withText(A_ZIP_CAUSE)));
+        TestPace.afterAStep();
+
+        // 4. The log, cleaned, and said to have been cleaned.
+        Eventually.check(() -> onView(withId(R.id.error_report_share_log))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.error_report_log_note))
+                .check(matches(withText(containsString("1 email address"))));
+        Shot.ofTheScreen("an_import_that_failed-the_zip_could_not_be_read");
+        TestPace.afterAStep();
+
+        // 5. And the form, with the questions already in it.
+        onView(withId(R.id.error_report_button)).perform(scrollTo(), click());
+        intended(hasAction(Intent.ACTION_VIEW));
+        TestPace.afterAStep();
+    }
+
+    /**
+     * <b>Second half: the tags arrived and their locations did not.</b>
+     *
+     * <p>Everything about this is the opposite. The import is not retracted, there is nothing to
+     * retry, and the likely fix is a setting rather than a bug report - so it names the setting.
+     * Three reporters across #19 and #26 reached that conclusion unaided, one of them 25
+     * comments in.
+     */
+    @Test
+    public void btagsThatArrivedWithoutTheirLocationsSayExactlyThat() {
+        final AtomicInteger settingsOpened = new AtomicInteger();
+
+        final ActivityScenario<TestHostActivity> host =
+                ActivityScenario.launch(TestHostActivity.class);
+        this.scenario = host;
+
+        host.onActivity(activity -> ImportedButNotLocatedDialog.show(
+                activity, A_FETCH_CAUSE, settingsOpened::incrementAndGet));
+
+        final Context context = getInstrumentation().getTargetContext();
+
+        // 1. The headline is the reassurance, because the first thing somebody does here is
+        //    look to see whether their tags survived.
+        onView(withText(context.getString(R.string.imported_but_not_located_title)))
+                .inRoot(isDialog()).check(matches(isDisplayed()));
+        TestPace.afterAStep();
+
+        // 2. It names Anisette, and it names the failure. The app always knew which exception
+        //    it was; it used to throw that away and say "error occurred while importing".
+        onView(withText(containsString("Anisette"))).inRoot(isDialog())
+                .check(matches(isDisplayed()));
+        onView(withText(containsString(A_FETCH_CAUSE))).inRoot(isDialog())
+                .check(matches(isDisplayed()));
+        Shot.ofTheScreen("an_import_that_failed-the_tags_arrived_the_locations_did_not");
+        TestPace.afterAStep();
+
+        // 3. **No offer to report it.** This fails when somebody else's server is down or a
+        //    phone is on a train, and it retries by itself every minute. Inviting a bug report
+        //    for that fills the tracker with weather.
+        assertTrue("the fetch failure must not offer a bug report",
+                nothingOnScreenSays(context.getString(R.string.error_report_button)));
+        TestPace.afterAStep();
+
+        // 4. What it offers instead is the setting that actually fixes it.
+        onView(withText(context.getString(R.string.imported_but_not_located_open_settings)))
+                .inRoot(isDialog()).perform(click());
+        assertEquals(1, settingsOpened.get());
+        TestPace.afterAStep();
+    }
+
+    /**
+     * <b>And both of the ways out of it work, without doing anything.</b>
+     *
+     * <p>OK and the back gesture are defaults - {@code MaterialAlertDialogBuilder} makes a
+     * cancelable dialog and a null listener dismisses - which is exactly why they are pinned. A
+     * later {@code setCancelable(false)}, added for some other reason, would take the back
+     * gesture away silently, and nothing else here would notice.
+     *
+     * <p>Neither must open settings. Dismissing is not consent to be sent somewhere.
+     */
+    @Test
+    public void cthedialogCanBeDismissedBothWays() {
+        final Context context = getInstrumentation().getTargetContext();
+        final AtomicInteger settingsOpened = new AtomicInteger();
+        final AlertDialog[] dialog = new AlertDialog[1];
+
+        final ActivityScenario<TestHostActivity> host =
+                ActivityScenario.launch(TestHostActivity.class);
+        this.scenario = host;
+
+        // **Asked of the dialog, not of the view tree.** Written the obvious way - press back,
+        // then assert the title is not on screen - this class took 15 minutes and still failed:
+        // proving a view absent means inRoot(isDialog()) against a screen with no dialog, and
+        // Espresso's root picker retries for seconds before conceding. A boolean is instant, and
+        // it is also the thing actually being claimed.
+        host.onActivity(activity -> dialog[0] = ImportedButNotLocatedDialog.show(
+                activity, A_FETCH_CAUSE, settingsOpened::incrementAndGet));
+        Eventually.check(() -> assertTrue("the dialog never appeared", dialog[0].isShowing()));
+
+        // perform, not a bare pressBack: if the dialog has not taken focus yet the key reaches
+        // the activity instead and finishes it, and Espresso reports NoActivityResumedException
+        // from the same call that would have worked a moment later.
+        Eventually.perform("back", () -> !dialog[0].isShowing(), Espresso::pressBack);
+
+        host.onActivity(activity -> dialog[0] = ImportedButNotLocatedDialog.show(
+                activity, A_FETCH_CAUSE, settingsOpened::incrementAndGet));
+        Eventually.check(() -> assertTrue("the dialog never reappeared", dialog[0].isShowing()));
+
+        onView(withText(context.getString(R.string.ok))).inRoot(isDialog()).perform(click());
+        Eventually.check(() -> assertFalse("OK did not dismiss the dialog",
+                dialog[0].isShowing()));
+
+        assertEquals("dismissing must not open settings", 0, settingsOpened.get());
+    }
+
+    /**
+     * Whether a piece of text is absent from the dialog.
+     *
+     * <p>Phrased as a caught {@link NoMatchingViewException} rather than
+     * {@code matches(not(isDisplayed()))} because the assertion here is that the view does not
+     * <i>exist</i> - a button never added, not one hidden. The usual warning about expecting
+     * that exception applies to views that are present and GONE, which is the opposite case.
+     */
+    private static boolean nothingOnScreenSays(final String text) {
+        try {
+            onView(withText(text)).inRoot(isDialog()).check(matches(isDisplayed()));
+            return false;
+        } catch (final NoMatchingViewException expected) {
+            return true;
+        }
+    }
+
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/mydevices/WhichExporterMadeThisTagTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/mydevices/WhichExporterMadeThisTagTest.java
@@ -1,0 +1,163 @@
+package dev.wander.android.opentagviewer.ui.mydevices;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.allOf;
+
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import dev.wander.android.opentagviewer.DeviceInfoActivity;
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.Shot;
+import dev.wander.android.opentagviewer.db.room.OpenTagViewerDatabase;
+import dev.wander.android.opentagviewer.db.room.entity.BeaconNamingRecord;
+import dev.wander.android.opentagviewer.db.room.entity.Import;
+import dev.wander.android.opentagviewer.db.room.entity.OwnedBeacon;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+
+/**
+ * Which exporter produced <i>this</i> tag, on the tag's own page.
+ *
+ * <p><b>The Information screen cannot answer this, and that is why both exist.</b> It lists every
+ * producer on the install - correct, and no use when a report is about one tag out of twelve
+ * behaving oddly. Which program wrote a bundle decides what to expect of the tags in it: whether
+ * a key alignment record came with them, which format the plists are, whether a known exporter
+ * bug applies. Per tag, that is a fact; aggregated, it is a shortlist.
+ *
+ * <p>The row costs nothing to fill. This page already reads the {@code Import} for its "Exported
+ * by" and "Exported at" rows, so {@code exportedVia} was in the object it already had.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class WhichExporterMadeThisTagTest {
+
+    private static final String A_TAG = "test-provenance-tag";
+    private static final String A_TEST_USER = "whichexportermadethistag@example.invalid";
+    private static final String AN_EXPORTER = "OpenTagViewer.cli:1.3.0";
+
+    private static final String A_PLIST = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<plist version=\"1.0\"><dict>"
+            + "<key>batteryLevel</key><integer>1</integer>"
+            + "<key>model</key><string></string>"
+            + "<key>pairingDate</key><date>2025-02-27T20:03:32Z</date>"
+            + "<key>privateKey</key><dict><key>key</key><dict>"
+            + "<key>data</key><data>bm90LWEtcmVhbC1rZXk=</data></dict></dict>"
+            + "<key>productId</key><integer>4660</integer>"
+            + "<key>stableIdentifier</key><array><string>2001~#0~#A0</string></array>"
+            + "<key>systemVersion</key><string>1.0</string>"
+            + "<key>vendorId</key><integer>76</integer>"
+            + "</dict></plist>";
+
+    private OpenTagViewerDatabase db;
+    private ActivityScenario<DeviceInfoActivity> scenario;
+
+    @Before
+    public void clearTheDecks() {
+        this.db = OpenTagViewerDatabase.getInstance(getInstrumentation().getTargetContext());
+        this.forgetIt();
+    }
+
+    @After
+    public void putEverythingBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        AppDependencies.reset();
+        this.forgetIt();
+    }
+
+    /** <b>The one this exists for.</b> */
+    @Test
+    public void athetagSaysWhichExporterWroteIt() {
+        this.seed(AN_EXPORTER);
+        this.open();
+
+        Eventually.check(() -> onView(allOf(
+                withId(R.id.device_settings_exported_with),
+                hasDescendant(withText(AN_EXPORTER))))
+                .check(matches(isDisplayed())));
+
+        Shot.ofTheScreen("the_device_page-exported_with");
+    }
+
+    /**
+     * <b>And an export from before {@code via:} existed says so, rather than vanishing.</b>
+     *
+     * <p>Format 0.0.1 predates the field, so null is a real value here. Hiding the row would read
+     * as a gap in the page; saying it was not recorded dates the bundle, which is itself the
+     * answer to "how old is this export".
+     */
+    @Test
+    public void banexportTooOldToRecordItselfSaysThatInstead() {
+        this.seed(null);
+        this.open();
+
+        final Context context = getInstrumentation().getTargetContext();
+        Eventually.check(() -> onView(allOf(
+                withId(R.id.device_settings_exported_with),
+                hasDescendant(withText(
+                        context.getString(R.string.exported_with_something_unrecorded)))))
+                .check(matches(isDisplayed())));
+    }
+
+    private void seed(final String via) {
+        final long importId = this.db.importDao().insert(Import.builder()
+                .version("0.0.2")
+                .importedAt(1_700_000_000_000L)
+                .exportedAt(1_699_000_000_000L)
+                .sourceUser(A_TEST_USER)
+                .exportedVia(via)
+                .build());
+
+        this.db.ownedBeaconDao().insertAll(OwnedBeacon.builder()
+                .id(A_TAG)
+                .importId(importId)
+                .content(A_PLIST)
+                .version("0.0.2")
+                .fromAccount(false)
+                .isRemoved(false)
+                .build());
+
+        this.db.beaconNamingRecordDao().insertAll(BeaconNamingRecord.builder()
+                .id(A_TAG)
+                .importId(importId)
+                .version("0.0.2")
+                .isRemoved(false)
+                .content("<?xml version=\"1.0\" encoding=\"UTF-8\"?><plist version=\"1.0\"><dict>"
+                        + "<key>identifier</key><string>" + A_TAG + "</string>"
+                        + "<key>name</key><string>A Tag With A History</string>"
+                        + "</dict></plist>")
+                .build());
+    }
+
+    private void open() {
+        final Intent intent = new Intent(
+                getInstrumentation().getTargetContext(), DeviceInfoActivity.class);
+        intent.putExtra("beaconId", A_TAG);
+        this.scenario = ActivityScenario.launch(intent);
+    }
+
+    private void forgetIt() {
+        this.db.ownedBeaconDao().delete(OwnedBeacon.builder().id(A_TAG).build());
+        this.db.beaconNamingRecordDao().delete(BeaconNamingRecord.builder().id(A_TAG).build());
+        for (final Import stale : this.db.importDao().getImportsFromUser(A_TEST_USER)) {
+            this.db.importDao().delete(stale);
+        }
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,6 +67,12 @@
             android:foregroundServiceType="location">
         </service>
 
+        <!-- Reached only when the app cannot name what went wrong - see the class doc. -->
+        <activity
+            android:name=".ui.error.ErrorReportActivity"
+            android:exported="false"
+            android:label="@string/error_report_title" />
+
         <activity
             android:name=".DeviceInfoActivity"
             android:exported="false"

--- a/app/src/main/java/dev/wander/android/opentagviewer/DeviceInfoActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/DeviceInfoActivity.java
@@ -177,12 +177,27 @@ public class DeviceInfoActivity extends AppCompatActivity {
         // about where somebody's data came from, made on the strength of a missing join.
         if (this.importData == null) {
             findViewById(R.id.device_settings_exported_by).setVisibility(View.GONE);
+            findViewById(R.id.device_settings_exported_with).setVisibility(View.GONE);
             findViewById(R.id.device_settings_exported_at).setVisibility(View.GONE);
             findViewById(R.id.device_settings_imported_at).setVisibility(View.GONE);
         } else {
             binding.setExportedAt(timestampFormat.format(new Date(this.importData.exportedAt)));
             binding.setImportedAt(timestampFormat.format(new Date(this.importData.importedAt)));
             binding.setExportedBy(this.importData.sourceUser);
+
+            // **Per tag, which the Information screen cannot be.** That one lists every producer
+            // on the install; this one says which produced *this* tag, and when a report is about
+            // one tag misbehaving that is the fact that decides what to expect of it. The row
+            // this sits next to already read from the same `Import`, so the value was here and
+            // simply unused.
+            //
+            // Said rather than hidden when there is no value: an export predating `via:` is
+            // itself information - it dates the bundle - and a missing row would read as this
+            // screen having a gap.
+            binding.setExportedWith(
+                    this.importData.exportedVia == null || this.importData.exportedVia.isBlank()
+                            ? this.getString(R.string.exported_with_something_unrecorded)
+                            : this.importData.exportedVia);
         }
 
         if (this.beaconInformation.isFromAccount()) {

--- a/app/src/main/java/dev/wander/android/opentagviewer/InformationActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/InformationActivity.java
@@ -27,10 +27,14 @@ import java.io.InputStream;
 import java.util.List;
 
 import dev.wander.android.opentagviewer.databinding.ActivityInformationBinding;
+import dev.wander.android.opentagviewer.db.room.OpenTagViewerDatabase;
 import dev.wander.android.opentagviewer.ui.compat.WindowPaddingUtil;
 import dev.wander.android.opentagviewer.ui.widget.FlowLayout;
 import dev.wander.android.opentagviewer.util.android.PropertiesUtil;
 import dev.wander.android.opentagviewer.util.android.WebLink;
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public class InformationActivity extends AppCompatActivity {
     private static final String TAG = InformationActivity.class.getSimpleName();
@@ -64,6 +68,7 @@ public class InformationActivity extends AppCompatActivity {
             throw new RuntimeException(e);
         }
 
+        this.showWhereTheTagsCameFrom();
         this.showContributors();
 
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main), (v, insets) -> {
@@ -71,6 +76,48 @@ public class InformationActivity extends AppCompatActivity {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
             return insets;
         });
+    }
+
+    /**
+     * Says which exporter produced the bundle these tags were imported from.
+     *
+     * <p><b>Because the issue template asks, and the honest alternative was worse.</b> The
+     * {@code via:} line is inside {@code OPENTAGVIEWER.yml} in the export zip - a file holding
+     * the private keys to somebody's tags, which the template tells them in bold not to open.
+     * Asking a question whose answer is in a file you have told people not to open is asking
+     * them to ignore you.
+     *
+     * <p><b>All of them, not the most recent one.</b> Importing twice is ordinary, and naming
+     * only the newest bundle would state one producer as though it accounted for every tag on
+     * the phone. Where a report says 1.3.0 and half the tags came out of 1.1.0, whoever reads it
+     * goes looking in the wrong place - which is the same failure as the import error that named
+     * the wrong phase, one level up.
+     *
+     * <p>Off the main thread: Room refuses a query on it, so doing this inline would not be slow,
+     * it would throw.
+     */
+    private void showWhereTheTagsCameFrom() {
+        final TextView importedFrom = this.findViewById(R.id.appImportedFrom);
+        if (importedFrom == null) {
+            return;
+        }
+
+        var async = Observable.fromCallable(() -> OpenTagViewerDatabase
+                        .getInstance(this.getApplicationContext())
+                        .importDao().getDistinctProducers())
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        producers -> importedFrom.setText(producers.isEmpty()
+                                ? this.getString(R.string.imported_from_nothing)
+                                : this.getString(R.string.imported_from_x,
+                                        String.join(", ", producers))),
+                        error -> {
+                            // A line that cannot be read is not worth a broken screen; the
+                            // version above it is still the more important half.
+                            Log.w(TAG, "Could not read where the tags were imported from", error);
+                            importedFrom.setVisibility(View.GONE);
+                        });
     }
 
     /**

--- a/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
@@ -49,6 +49,8 @@ import com.google.android.gms.maps.model.LatLng;
 
 import dev.wander.android.opentagviewer.ui.compat.WindowPaddingUtil;
 import dev.wander.android.opentagviewer.ui.importing.BundlePasscodeDialog;
+import dev.wander.android.opentagviewer.ui.importing.ImportOutcome;
+import dev.wander.android.opentagviewer.ui.importing.ImportedButNotLocatedDialog;
 import dev.wander.android.opentagviewer.ui.login.TwoFactorAgainOverlay;
 import dev.wander.android.opentagviewer.ui.settings.AnisetteUpgradeDialog;
 import dev.wander.android.opentagviewer.ui.settings.ICloudSetupOfferDialog;
@@ -69,6 +71,8 @@ import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import dev.wander.android.opentagviewer.db.room.entity.Import;
+import dev.wander.android.opentagviewer.ui.error.ErrorReportActivity;
 import dev.wander.android.opentagviewer.db.room.entity.OwnedBeacon;
 import java.util.Locale;
 import java.util.HashMap;
@@ -97,6 +101,7 @@ import dev.wander.android.opentagviewer.db.repo.model.ImportData;
 import dev.wander.android.opentagviewer.db.util.BeaconCombinerUtil;
 import dev.wander.android.opentagviewer.python.AccessoryRequest;
 import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.python.LogRedactor;
 import dev.wander.android.opentagviewer.ui.BeaconIcon;
 import dev.wander.android.opentagviewer.python.PythonAppleService;
 import dev.wander.android.opentagviewer.python.PythonAccountLoginException;
@@ -827,25 +832,62 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
     private void onImportFilePicked(Intent data, final String passcode) {
         Log.d(TAG, "File has been picked");
 
-        // combine them into the current list of beaconLocations & show this list
+        // **Two chains, not one, and the split is the whole point.**
+        //
+        // Reading the zip and committing the tags is the import. Going to Apple for their
+        // locations is a separate operation that happens to run next, and it fails for
+        // completely unrelated reasons - a network, a session, an Anisette server. Joined into
+        // one chain they shared an error handler, so every one of those reported "Error
+        // occurred while importing new devices. Try to restart the app and retry" for an import
+        // that had already succeeded and could be seen in the device list.
+        //
+        // Issues #19 and #26 are 34 comments of people working that out for themselves; three
+        // of them fixed their "import error" by changing their Anisette server, which is not
+        // consulted while reading a zip. A marker saying how far the chain got would fix the
+        // message, but decoupling makes the wrong message impossible to write.
         var async = this.extractImportedData(data, passcode)
             .flatMap(this.beaconRepo::addNewImport)
-            .doOnNext((importData) -> {
-                this.runOnUiThread(() -> {
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                importData -> {
                     Toast.makeText(
                             this,
                             this.getString(R.string.loading_location_data_for_x_new_imported_devices, importData.getOwnedBeacons().size()),
                             LENGTH_LONG).show();
+                    this.locateFreshlyImportedTags(importData);
+                },
+                error -> {
+                    // Nothing was stored, so this really is an import failure and can say so.
+                    // The fetch never runs, and the periodic refresh is still waiting on this.
+                    this.initialFetchComplete = true;
+                    this.onImportFailed(data, error);
                 });
-            })
-            /*
-             * Fetching and parsing still run concurrently, but they are merged rather than
-             * zipped: zip completed as soon as the single-emission parse branch did, which
-             * cancelled every accessory after the first. See RxFlows#allThen for the full
-             * account. The two doOnNext handlers write to different maps, so their order
-             * relative to each other does not matter.
-             */
-            .flatMapCompletable(storedBeacons -> RxFlows.allThen(
+    }
+
+    /**
+     * The first fetch for tags that are already on the phone.
+     *
+     * <p><b>Started by a successful import, and answerable for nothing about it.</b> Whatever
+     * happens here, the tags are stored and stay stored - so a failure is about locations, and
+     * the message says that rather than retracting an import that worked.
+     */
+    private void locateFreshlyImportedTags(final ImportData storedBeacons) {
+        /*
+         * Fetching and parsing still run concurrently, but they are merged rather than
+         * zipped: zip completed as soon as the single-emission parse branch did, which
+         * cancelled every accessory after the first. See RxFlows#allThen for the full
+         * account. The two doOnNext handlers write to different maps, so their order
+         * relative to each other does not matter.
+         */
+        // **Deferred, because this is now called from the main thread.**
+        //
+        // `subscribeOn` moves the *subscription*, not the construction - and building this
+        // expression is not free: `combine` streams every beacon into two maps and
+        // `plistFallbacks` walks them again, both evaluated as arguments before `allThen` is
+        // even entered. While this hung off the import chain it inherited that chain's IO
+        // thread; splitting the two handed it to whatever called it, which is the UI thread.
+        // Nothing here belongs there.
+        var async = Completable.defer(() -> RxFlows.allThen(
                     // A last pass once everything has landed, for anything the per-accessory
                     // passes below could not resolve.
                     this.updateBeaconGeocodings(),
@@ -871,6 +913,9 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
                     BeaconDataParser.parseAsync(BeaconCombinerUtil.combine(storedBeacons))
                             .doOnNext(this::addBeaconToCurrent)
             ))
+            // **Explicit now that this is its own chain.** It used to inherit whatever thread
+            // `addNewImport` emitted on; nothing here is safe to start on the main one.
+            .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             // An import is a first fetch too. Without this the periodic refresh stays disabled
             // for the rest of the session whenever the app started with nothing stored, which
@@ -879,23 +924,92 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
             .subscribe(() -> {
                 this.showLastDeviceLocations();
                 Log.i(TAG, "Finished visualising new location reports!");
-            }, error -> {
-                Log.e(TAG, "Error occurred while importing new devices!", error);
+            }, error -> this.onFirstFetchAfterImportFailed(error));
+    }
 
-                final ZipImporterException.Reason reason = ZipImporterException.reasonOf(error);
-                if (reason == ZipImporterException.Reason.LOCKED
-                        || reason == ZipImporterException.Reason.WRONG_PASSCODE) {
-                    // A question, not a failure. The exporter locks bundles by default, so this
-                    // is the ordinary path rather than something having gone wrong.
-                    BundlePasscodeDialog.show(
-                            this,
-                            reason == ZipImporterException.Reason.WRONG_PASSCODE,
-                            code -> this.onImportFilePicked(data, code));
-                    return;
-                }
+    /**
+     * What to say when the zip could not be read, or the tags could not be stored.
+     *
+     * @param data the picked file, kept so a locked bundle can be retried with a code rather
+     *             than sending the user back to the picker
+     */
+    private void onImportFailed(final Intent data, final Throwable error) {
+        Log.e(TAG, "Error occurred while importing new devices!", error);
 
+        switch (ImportOutcome.of(error)) {
+            case ASK_FOR_THE_PASSCODE:
+                // A question, not a failure. The exporter locks bundles by default, so this is
+                // the ordinary path rather than something having gone wrong.
+                BundlePasscodeDialog.show(
+                        this,
+                        ZipImporterException.reasonOf(error)
+                                == ZipImporterException.Reason.WRONG_PASSCODE,
+                        code -> this.onImportFilePicked(data, code));
+                return;
+
+            case REPORT_THE_IMPORT:
+                // **An import nobody can explain goes to the report page, not to a toast.**
+                //
+                // Every named reason has advice worth giving - the wrong file, a damaged zip, a
+                // passcode. This one has none, and what it used to say was "try to restart the
+                // app and retry", which cannot help and asks somebody to repeat the thing that
+                // just failed.
+                Log.w(TAG, "Import failed for a reason nothing here can name", error);
+                this.startActivity(ErrorReportActivity.intentFor(
+                        this, describe(error), R.string.error_report_body_import));
+                return;
+
+            default:
                 Toast.makeText(this, importFailureMessage(error), LENGTH_LONG).show();
-            });
+        }
+    }
+
+    /**
+     * What to say when the tags are stored and Apple could not be asked where they are.
+     *
+     * <p><b>Never that the import failed.</b> It did not - the tags are in the database and in
+     * the device list, and telling somebody otherwise sends them to re-import a bundle that
+     * imported fine. That was the state of issues #19 and #26.
+     *
+     * <p>The two causes with real handling keep it: a session Apple has stopped accepting goes
+     * back to sign-in, and one wanting a code gets asked for one. What is left is overwhelmingly
+     * the Anisette server, which is why the dialog names it - it is the answer three reporters
+     * arrived at themselves, one of them 25 comments in.
+     *
+     * <p><b>And no report button, deliberately.</b> The bug page belongs to the zip half. This
+     * half fails for reasons that are somebody's server being down or their phone being on a
+     * train, it retries by itself every minute, and inviting a report each time it happens would
+     * fill the tracker with weather.
+     */
+    private void onFirstFetchAfterImportFailed(final Throwable error) {
+        Log.e(TAG, "Tags were imported, but their first location fetch failed", error);
+
+        if (isAccountRestoreFailure(error)) {
+            handleAccountRestoreFailureOnUiThread();
+            return;
+        }
+
+        // Self-handling and asynchronous: it asks Apple whether this session actually wants a
+        // code, and does nothing if it does not. Harmless to call alongside the dialog.
+        this.askForACodeIfTheSessionNeedsOne();
+
+        ImportedButNotLocatedDialog.show(
+                this, describe(error), this::showSettingsPage);
+    }
+
+    /**
+     * The failure in the words it arrived in, for pasting into a report.
+     *
+     * <p>Class name and message rather than a stack trace: the trace is in the log the page
+     * offers, and a screenful of frames is not something anybody reads off a phone.
+     */
+    private static String describe(final Throwable error) {
+        if (error == null) {
+            return "unknown";
+        }
+        return error.getMessage() == null
+                ? error.getClass().getSimpleName()
+                : error.getClass().getSimpleName() + ": " + error.getMessage();
     }
 
     /**
@@ -938,29 +1052,84 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
             return;
         }
 
-        String logLines = LogCollectorUtil.getLastLogs();
+        // **Off the main thread, which it was not.** Four blocking things happen here - reading
+        // the database for the import provenance, spawning `logcat` and reading it out, running
+        // it through the redactor, and writing the file. All of them were on the UI thread. The
+        // database one would throw outright (Room refuses main-thread queries), and the rest
+        // were an ANR waiting for a slow enough device.
+        var async = Observable.fromCallable(() -> {
+                    final Import lastImport =
+                            OpenTagViewerDatabase.getInstance(this.getApplicationContext())
+                                    .importDao().getMostRecent();
 
-        try (OutputStream os = this.getContentResolver().openOutputStream(writeTarget)) {
-            BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os));
-            bw.write(logLines);
-            bw.flush();
-            bw.close();
+                    final String logLines = LogCollectorUtil.getLastLogsWithHeader(
+                            BuildConfig.VERSION_NAME,
+                            BuildConfig.BUILD_COMMIT,
+                            lastImport == null ? null : lastImport.exportedVia);
 
-            Log.d(TAG, "Logs export to " + writeTarget + " complete!");
+                    // **Redacted here too, and not because this button is more dangerous than
+                    // the other one - because it is the same log.** This wrote a raw logcat
+                    // while the error page's copy went through the redactor, which is two
+                    // answers to "is my Apple ID in this file" from one app. The file from this
+                    // button is the one that historically got attached to issues.
+                    final LogRedactor.Redacted cleaned =
+                            AppDependencies.logRedactor().redact(logLines);
+                    if (cleaned == null) {
+                        // Nothing written, deliberately. A raw log cannot be un-posted, and
+                        // somebody exporting one is on their way to attaching it somewhere.
+                        return new ExportedLog(null, null);
+                    }
 
-            Toast.makeText(
-                    this,
-                    R.string.log_file_has_been_exported_successfully,
-                    LENGTH_LONG
-            ).show();
+                    try (OutputStream os =
+                                 this.getContentResolver().openOutputStream(writeTarget)) {
+                        final BufferedWriter bw =
+                                new BufferedWriter(new OutputStreamWriter(os));
+                        bw.write(cleaned.getText());
+                        bw.flush();
+                        bw.close();
+                    }
+                    return new ExportedLog(writeTarget, cleaned.getSummary());
+                })
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        written -> {
+                            if (written.target == null) {
+                                Log.w(TAG, "The log could not be cleaned, so none was written");
+                                Toast.makeText(
+                                        this,
+                                        R.string.export_logs_cannot_be_cleaned,
+                                        LENGTH_LONG
+                                ).show();
+                                return;
+                            }
 
-        } catch (IOException e) {
-            Log.e(TAG, "Failed to save file", e);
-            Toast.makeText(
-                    this,
-                    R.string.failed_to_export_log_file,
-                    LENGTH_LONG
-            ).show();
+                            Log.d(TAG, "Logs export to " + written.target + " complete!");
+                            Toast.makeText(
+                                    this,
+                                    this.getString(
+                                            R.string.export_logs_cleaned, written.summary),
+                                    LENGTH_LONG
+                            ).show();
+                        },
+                        error -> {
+                            Log.e(TAG, "Failed to save file", error);
+                            Toast.makeText(
+                                    this,
+                                    R.string.failed_to_export_log_file,
+                                    LENGTH_LONG
+                            ).show();
+                        });
+    }
+
+    /** Where the log went and what came out of it, or a null target meaning nothing was written. */
+    private static final class ExportedLog {
+        private final Uri target;
+        private final String summary;
+
+        private ExportedLog(final Uri target, final String summary) {
+            this.target = target;
+            this.summary = summary;
         }
     }
 

--- a/app/src/main/java/dev/wander/android/opentagviewer/db/room/dao/ImportDao.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/db/room/dao/ImportDao.java
@@ -20,6 +20,39 @@ public interface ImportDao {
     @Query("SELECT * FROM Import WHERE id = :importId")
     Import getById(long importId);
 
+    /**
+     * The most recent import, or null if nothing has ever been imported.
+     *
+     * <p>Read for one thing: naming the bundle a log came from. Which program wrote an export
+     * decides what to expect of it, and until this the only way to find out was to open the zip -
+     * a bad instruction generally and a dangerous one now that bundles are password-protected by
+     * default.
+     *
+     * <p>Null is a real answer, not a gap: an install connected straight to an Apple account has
+     * no bundle behind it at all.
+     */
+    @Query("SELECT * FROM Import ORDER BY imported_at DESC LIMIT 1")
+    Import getMostRecent();
+
+    /**
+     * Every distinct exporter that produced a bundle on this install, newest first.
+     *
+     * <p><b>Distinct, because {@link #getMostRecent()} answers a different question than it
+     * looks like it does.</b> Importing twice is ordinary - a second Mac, a re-export after a
+     * new tag, a bundle from an older wizard alongside a current one - and asking only for the
+     * latest names one producer while implying it accounts for everything on the phone. A report
+     * saying "exported with 1.3.0" when half the tags came out of 1.1.0 sends whoever reads it
+     * looking in the wrong place.
+     *
+     * <p>{@code GROUP BY} rather than {@code SELECT DISTINCT}, because the ordering is by
+     * something not in the result: SQLite rejects an {@code ORDER BY} on a column a
+     * {@code DISTINCT} query does not select, and {@code MAX(imported_at)} per producer is the
+     * sort that actually means "most recently used".
+     */
+    @Query("SELECT via FROM Import WHERE via IS NOT NULL AND via != ''"
+            + " GROUP BY via ORDER BY MAX(imported_at) DESC")
+    List<String> getDistinctProducers();
+
     @Insert
     long insert(Import importData);
 

--- a/app/src/main/java/dev/wander/android/opentagviewer/python/AppDependencies.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/python/AppDependencies.java
@@ -75,6 +75,16 @@ public final class AppDependencies {
     private static HardwareDescriber hardwareDescriber = new ChaquopyHardwareDescriber();
 
     /**
+     * Strips personal identifiers out of a log before it is offered to anybody.
+     *
+     * <p>Here for the usual reason and one sharper one: the screen that offers a log is the error
+     * page, which exists <i>because</i> something already broke. A test of it has to be able to
+     * produce a working redactor and one that cannot run, and the second is the case that decides
+     * whether an unredacted log can escape.
+     */
+    private static LogRedactor logRedactor = new ChaquopyLogRedactor();
+
+    /**
      * Turns coordinates into something a person recognises.
      *
      * <p><b>Here because a screen with no geocoder does not look broken.</b> The card falls back
@@ -149,6 +159,10 @@ public final class AppDependencies {
         return hardwareDescriber;
     }
 
+    public static LogRedactor logRedactor() {
+        return logRedactor;
+    }
+
     public static AnisetteServerTesterService serverTester(final CronetEngine engine) {
         return serverTesterFactory.apply(engine);
     }
@@ -174,6 +188,11 @@ public final class AppDependencies {
     }
 
     @VisibleForTesting
+    public static void replaceLogRedactor(final LogRedactor replacement) {
+        logRedactor = replacement;
+    }
+
+    @VisibleForTesting
     public static void replaceAnisette(final Function<UserSettings, AnisetteSource> replacement) {
         anisetteFactory = (context, settings, hasSession) -> replacement.apply(settings);
     }
@@ -185,6 +204,7 @@ public final class AppDependencies {
         anisetteFactory = LocalAnisette::new;
         serverTesterFactory = AnisetteServerTesterService::new;
         hardwareDescriber = new ChaquopyHardwareDescriber();
+        logRedactor = new ChaquopyLogRedactor();
         icloudFactory = AppDependencies::openRealICloud;
         geocoderFactory = (context, locale) ->
                 AddressLookup.through(new Geocoder(context, locale));

--- a/app/src/main/java/dev/wander/android/opentagviewer/python/ChaquopyLogRedactor.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/python/ChaquopyLogRedactor.java
@@ -1,0 +1,44 @@
+package dev.wander.android.opentagviewer.python;
+
+import android.util.Log;
+
+import com.chaquo.python.PyObject;
+import com.chaquo.python.Python;
+
+/**
+ * {@link LogRedactor} over {@code exporter.redact}, the same module the desktop wizard's
+ * Save logs button runs.
+ *
+ * <p><b>Blocking, and needs a started interpreter.</b> Never call it on the main thread.
+ */
+public class ChaquopyLogRedactor implements LogRedactor {
+    private static final String TAG = ChaquopyLogRedactor.class.getSimpleName();
+
+    private static final String MODULE = "exporter.redact";
+
+    @Override
+    public Redacted redact(final String log) {
+        if (log == null) {
+            return null;
+        }
+
+        try {
+            final PyObject module = Python.getInstance().getModule(MODULE);
+
+            // redact() hands back (text, Counter); summarise() turns the second into a sentence.
+            final PyObject result = module.callAttr("redact", log);
+            final PyObject cleaned = result.asList().get(0);
+            final PyObject counts = result.asList().get(1);
+
+            return new Redacted(
+                    cleaned.toString(),
+                    module.callAttr("summarise", counts).toString());
+        } catch (final Exception e) {
+            // **Null, not the log.** The caller is about to hand this to somebody who will attach
+            // it to a public issue. A redactor that could not run is a reason to withhold the
+            // file, never a reason to send the unredacted one - see LogRedactor#redact.
+            Log.w(TAG, "Could not redact the log, so it will not be offered", e);
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/dev/wander/android/opentagviewer/python/LogRedactor.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/python/LogRedactor.java
@@ -1,0 +1,48 @@
+package dev.wander.android.opentagviewer.python;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Takes the personal identifiers out of a log before anybody sends it somewhere public.
+ *
+ * <p><b>The rules live in Python and are shared with the desktop exporter</b> -
+ * {@code exporter/redact.py}, whitelisted into the APK. Not ported to Java on purpose: the wizard's
+ * Save logs button already runs them, they are patterns that need adding to as new identifiers turn
+ * up, and two sets would mean two answers to "is my Apple ID in this file" with only one of them
+ * being maintained.
+ *
+ * <p>Behind an interface for the usual reason - the real one needs a running interpreter, so a
+ * screen that called it directly could not be tested without one.
+ */
+public interface LogRedactor {
+
+    /** A cleaned log, and one line saying what came out of it. */
+    @AllArgsConstructor
+    @Getter
+    class Redacted {
+        private final String text;
+
+        /**
+         * What was removed, in words - "3 email addresses, 1 serial number".
+         *
+         * <p>Shown to the person about to send the file. It is the difference between trusting a
+         * claim that something was cleaned and being told what was found, and it costs nothing:
+         * the redactor counts as it goes.
+         */
+        private final String summary;
+    }
+
+    /**
+     * @return the redacted log, or <b>null</b> if it could not be redacted.
+     *
+     * <p><b>Null means do not send this.</b> The caller's job is to withhold the log, not to fall
+     * back to the raw one - this runs at the moment somebody is about to attach a file to a public
+     * issue, and the failure mode of guessing wrong is their Apple ID on the internet
+     * permanently. Refusing is recoverable; the alternative is not.
+     *
+     * <p>It can genuinely fail: the error page that offers this exists <i>because</i> something
+     * broke, and "Python did not start" is one of the things that might have.
+     */
+    Redacted redact(String log);
+}

--- a/app/src/main/java/dev/wander/android/opentagviewer/ui/error/ErrorReportActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/ui/error/ErrorReportActivity.java
@@ -1,0 +1,279 @@
+package dev.wander.android.opentagviewer.ui.error;
+
+import static android.view.View.GONE;
+import static android.widget.Toast.LENGTH_LONG;
+
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.Button;
+import android.widget.Toast;
+import android.widget.TextView;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+
+import dev.wander.android.opentagviewer.BuildConfig;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.db.room.OpenTagViewerDatabase;
+import dev.wander.android.opentagviewer.db.room.entity.Import;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.python.LogRedactor;
+import dev.wander.android.opentagviewer.util.LogCollectorUtil;
+import dev.wander.android.opentagviewer.util.android.WebLink;
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+/**
+ * "This one is a bug" - the screen for a failure nobody here can fix.
+ *
+ * <p><b>Shown only when the app cannot name the cause.</b> An {@code UnhandledProtocolError} from
+ * Python, or anything that reaches {@code REASON_UNKNOWN}. Never for a rejected passcode, an
+ * account with no tags, a network that is down, or a session wanting a verification code - each of
+ * those has a screen that says what to do, and this one would be worse than the advice they
+ * already give. A page that turns up for ordinary mistakes is one people learn to dismiss, and
+ * then it is worth nothing on the day it is right.
+ *
+ * <p>It carries the three things a report needs and a person otherwise has to hunt for: which
+ * build this is, which exporter made their bundle, and the failure verbatim. The last was the
+ * reason somebody would open an export zip - a file holding their tags' private keys - to read a
+ * version line out of it.
+ */
+public class ErrorReportActivity extends AppCompatActivity {
+    private static final String TAG = ErrorReportActivity.class.getSimpleName();
+
+    /** What went wrong, in the words the failure arrived in. Never translated - it is evidence. */
+    public static final String EXTRA_CAUSE = "cause";
+
+    /**
+     * Which explanation to show above the cause.
+     *
+     * <p><b>Because "something came back that this app cannot read" is false for half the callers.</b>
+     * It is exactly right for a protocol failure and wrong for a bundle that would not parse -
+     * nothing came back from anywhere, somebody chose a file. A page that misdescribes what
+     * happened is worse than a generic one, because the reader corrects for it and stops trusting
+     * the rest.
+     */
+    public static final String EXTRA_BODY = "body";
+
+    /** The protocol case: Apple sent something the library does not understand. */
+    public static Intent intentFor(final Context context, final String cause) {
+        return intentFor(context, cause, R.string.error_report_body);
+    }
+
+    public static Intent intentFor(
+            final Context context, final String cause, final int bodyRes) {
+        return new Intent(context, ErrorReportActivity.class)
+                .putExtra(EXTRA_CAUSE, cause)
+                .putExtra(EXTRA_BODY, bodyRes);
+    }
+
+    /** The redacted log, held once prepared so the share button is instant and cannot re-fail. */
+    private LogRedactor.Redacted log;
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        this.setContentView(R.layout.activity_error_report);
+
+        if (this.getSupportActionBar() != null) {
+            this.getSupportActionBar().hide();
+        }
+
+        this.<TextView>findViewById(R.id.error_report_build).setText(
+                "OpenTagViewer app " + LogCollectorUtil.describeBuild(
+                        BuildConfig.VERSION_NAME, BuildConfig.BUILD_COMMIT));
+
+        this.<TextView>findViewById(R.id.error_report_cause)
+                .setText(this.getIntent().getStringExtra(EXTRA_CAUSE));
+
+        this.<TextView>findViewById(R.id.error_report_body).setText(this.getIntent()
+                .getIntExtra(EXTRA_BODY, R.string.error_report_body));
+
+        this.findViewById(R.id.error_report_button).setOnClickListener(
+                v -> WebLink.open(this, IssueReport.NEW_APP_BUG));
+
+        // finish() rather than a navigate-up: this page is always arrived at from somewhere, and
+        // that somewhere is where closing it should land - the map, mid-import, wherever it was.
+        this.findViewById(R.id.error_report_close).setOnClickListener(v -> this.finish());
+
+        // Nothing to share until the log has been through the redactor, and that is a Python call
+        // on a screen that exists because something already broke.
+        this.findViewById(R.id.error_report_share_log).setVisibility(GONE);
+
+        this.prepareTheEvidence();
+    }
+
+    /**
+     * Reads the provenance and the log, off the main thread, and only then offers the log.
+     *
+     * <p><b>The share button is hidden until there is something safe to share.</b> Redaction runs
+     * through Chaquopy, and this screen is reached <i>because</i> something failed - "Python did
+     * not start" being one of the candidates. A button that appeared regardless and then handed
+     * over a raw logcat would put somebody's Apple ID on a public issue at the moment they are
+     * least inclined to read it first.
+     */
+    private void prepareTheEvidence() {
+        final TextView importedFrom = this.findViewById(R.id.error_report_imported_from);
+        final TextView note = this.findViewById(R.id.error_report_log_note);
+        final Button share = this.findViewById(R.id.error_report_share_log);
+
+        var async = Observable.fromCallable(() -> {
+                    final Import last = OpenTagViewerDatabase
+                            .getInstance(this.getApplicationContext()).importDao().getMostRecent();
+
+                    final String via = last == null ? null : last.exportedVia;
+                    final String raw = LogCollectorUtil.getLastLogsWithHeader(
+                            BuildConfig.VERSION_NAME, BuildConfig.BUILD_COMMIT, via);
+
+                    return new Evidence(via, AppDependencies.logRedactor().redact(raw));
+                })
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        evidence -> {
+                            importedFrom.setText(evidence.via == null
+                                    ? this.getString(R.string.imported_from_nothing)
+                                    : this.getString(R.string.imported_from_x, evidence.via));
+
+                            if (evidence.log == null) {
+                                note.setText(R.string.error_report_log_unavailable);
+                                return;
+                            }
+
+                            this.log = evidence.log;
+                            note.setText(this.getString(
+                                    R.string.error_report_log_cleaned, evidence.log.getSummary()));
+                            share.setVisibility(android.view.View.VISIBLE);
+                            share.setOnClickListener(v -> this.offerTheLog());
+                        },
+                        error -> {
+                            Log.w(TAG, "Could not prepare the log for reporting", error);
+                            note.setText(R.string.error_report_log_unavailable);
+                        });
+    }
+
+    /**
+     * Asks which of the two things somebody actually wants, because they are not the same thing.
+     *
+     * <p><b>It shipped as a share sheet, and a share sheet serves neither well.</b> With text and
+     * no stream, Drive and Files do not appear as targets at all - so the file half of the sheet
+     * was simply absent, on a button whose main purpose is producing a file to attach. And the
+     * copy half depended on whichever clipboard target the phone happened to have.
+     *
+     * <p>Two named choices instead. Attaching a file to a GitHub issue on a phone goes through
+     * the browser's file picker, which reads storage - so a file has to exist somewhere the user
+     * chose, which is what the document picker is for. Pasting into the form's
+     * {@code render: shell} box just wants the clipboard.
+     */
+    private void offerTheLog() {
+        new MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.error_report_log_how)
+                .setItems(
+                        new CharSequence[] {
+                                this.getString(R.string.error_report_log_copy),
+                                this.getString(R.string.error_report_log_save)},
+                        (dialog, which) -> {
+                            if (which == 0) {
+                                this.copyTheLog();
+                            } else {
+                                this.saveTheLog();
+                            }
+                        })
+                .setNegativeButton(R.string.cancel, null)
+                .show();
+    }
+
+    /** Straight to the clipboard, for pasting into the form's log box. */
+    private void copyTheLog() {
+        final ClipboardManager clipboard = this.getSystemService(ClipboardManager.class);
+        if (clipboard == null) {
+            Toast.makeText(this, R.string.failed_to_export_log_file, LENGTH_LONG).show();
+            return;
+        }
+
+        clipboard.setPrimaryClip(ClipData.newPlainText("OpenTagViewer log", this.log.getText()));
+
+        // **Android 13 shows its own confirmation, and a toast on top of it reads as a bug.**
+        // Below that there is nothing at all, and silence after a tap is indistinguishable from
+        // a dead button.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            Toast.makeText(this, R.string.error_report_log_copied, LENGTH_LONG).show();
+        }
+    }
+
+    /**
+     * Somewhere the user picks, through the document picker.
+     *
+     * <p>The same route as Settings' own Export Logs button, deliberately: a file the user chose
+     * the location of is one the browser's file picker can find again, which a cache file handed
+     * over by a share sheet is not.
+     */
+    private void saveTheLog() {
+        this.saveLogLauncher.launch(new Intent(Intent.ACTION_CREATE_DOCUMENT)
+                .addCategory(Intent.CATEGORY_OPENABLE)
+                .setType("text/plain")
+                .putExtra(Intent.EXTRA_TITLE, "opentagviewer-log.txt"));
+    }
+
+    /**
+     * Writes the redacted log where the picker said, off the main thread.
+     *
+     * <p>Registered as a field rather than made at click time: registering has to happen before
+     * the activity is started, so a launcher created inside a click listener throws.
+     */
+    private final ActivityResultLauncher<Intent> saveLogLauncher = this.registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            result -> {
+                final Uri target = result.getData() == null ? null : result.getData().getData();
+                if (result.getResultCode() != RESULT_OK || target == null || this.log == null) {
+                    return; // cancelled, which is not a failure and needs no message
+                }
+
+                var async = Observable.fromCallable(() -> {
+                            try (OutputStream out = this.getContentResolver()
+                                    .openOutputStream(target);
+                                 Writer writer = new OutputStreamWriter(
+                                         out, StandardCharsets.UTF_8)) {
+                                writer.write(this.log.getText());
+                            }
+                            return target;
+                        })
+                        .subscribeOn(Schedulers.io())
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(
+                                written -> Toast.makeText(this,
+                                        R.string.log_file_has_been_exported_successfully,
+                                        LENGTH_LONG).show(),
+                                error -> {
+                                    Log.w(TAG, "Could not write the log out", error);
+                                    Toast.makeText(this, R.string.failed_to_export_log_file,
+                                            LENGTH_LONG).show();
+                                });
+            });
+
+    /** What the background read produced, so the UI thread does one hand-off rather than two. */
+    private static final class Evidence {
+        private final String via;
+        private final LogRedactor.Redacted log;
+
+        private Evidence(final String via, final LogRedactor.Redacted log) {
+            this.via = via;
+            this.log = log;
+        }
+    }
+}

--- a/app/src/main/java/dev/wander/android/opentagviewer/ui/error/IssueReport.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/ui/error/IssueReport.java
@@ -1,0 +1,42 @@
+package dev.wander.android.opentagviewer.ui.error;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Where the app sends somebody who has hit a bug.
+ *
+ * <p><b>One constant, because nothing tests a link.</b> The desktop exporter keeps its own as
+ * {@code GITHUB_ISSUES_LINK} in {@code exporter/version.py} for the same reason: a URL inlined at
+ * two call sites goes stale at one of them, and the symptom is a worse bug report months later
+ * with nothing to connect it to the change.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class IssueReport {
+
+    /**
+     * The template file {@link #NEW_APP_BUG} names, relative to {@code .github/ISSUE_TEMPLATE/}.
+     *
+     * <p><b>Named separately so a test can check it exists.</b> GitHub does not error on an
+     * unknown {@code ?template=} - it quietly drops the reporter on a blank issue with none of the
+     * questions and none of the labels. So renaming the file breaks this with no error anywhere,
+     * and the only symptom is worse reports, indefinitely.
+     */
+    public static final String TEMPLATE = "app-bug.yml";
+    /**
+     * The issue form for app problems.
+     *
+     * <p><b>{@code ?template=} and not {@code ?labels=}.</b> Labels in a URL are applied only for
+     * somebody with permission to label the repository, which a person reporting a bug is not -
+     * the template's own front matter applies them whoever files. The template is also what puts
+     * the questions in front of the reporter at all.
+     *
+     * <p>An unauthenticated visitor is redirected to a sign-in page and returned here afterwards,
+     * so the query survives the round trip. There is no way to file anonymously and GitHub has no
+     * social sign-in, which is why the screen says an account is needed rather than letting
+     * somebody discover it after writing everything out.
+     */
+    public static final String NEW_APP_BUG =
+            "https://github.com/parawanderer/OpenTagViewer/issues/new?template=" + TEMPLATE;
+
+}

--- a/app/src/main/java/dev/wander/android/opentagviewer/ui/importing/ImportOutcome.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/ui/importing/ImportOutcome.java
@@ -1,0 +1,50 @@
+package dev.wander.android.opentagviewer.ui.importing;
+
+import dev.wander.android.opentagviewer.util.parse.ZipImporterException;
+
+/**
+ * What was wrong with an import that did not complete, and so what to say about it.
+ *
+ * <p><b>Only reachable now for failures that really are the import's.</b> Reading the zip and
+ * committing the tags is one chain; going to Apple for their locations is another, started only
+ * once the first has succeeded. They used to be joined, sharing an error handler, so a network
+ * timeout or a bad Anisette server - neither consulted while reading a zip - reported "Error
+ * occurred while importing new devices" for an import that had already succeeded and could be
+ * seen in the device list. Issues
+ * <a href="https://github.com/parawanderer/OpenTagViewer/issues/19">#19</a> and
+ * <a href="https://github.com/parawanderer/OpenTagViewer/issues/26">#26</a> are 34 comments of
+ * people working that out for themselves.
+ *
+ * <p>So the trap this replaces is {@code reasonOf} returning {@code UNKNOWN}. It is a reasonable
+ * answer from a function about zip problems - "not one of mine" - and the caller read it as "an
+ * unknown import problem", which is a different claim entirely.
+ */
+public enum ImportOutcome {
+
+    /** Locked, or the code was wrong. A question rather than a failure - ask again. */
+    ASK_FOR_THE_PASSCODE,
+
+    /** A named problem with the file, which has advice worth giving. */
+    EXPLAIN_THE_FILE,
+
+    /**
+     * Nothing was stored and nothing here can name why.
+     *
+     * <p>The only case where "the app could not read that file" is true, and now the only case
+     * that says it. Rare, by construction: the file has already been through the importer's own
+     * checks, so what is left is something below it going wrong.
+     */
+    REPORT_THE_IMPORT;
+
+    public static ImportOutcome of(final Throwable error) {
+        switch (ZipImporterException.reasonOf(error)) {
+            case LOCKED:
+            case WRONG_PASSCODE:
+                return ASK_FOR_THE_PASSCODE;
+            case UNKNOWN:
+                return REPORT_THE_IMPORT;
+            default:
+                return EXPLAIN_THE_FILE;
+        }
+    }
+}

--- a/app/src/main/java/dev/wander/android/opentagviewer/ui/importing/ImportedButNotLocatedDialog.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/ui/importing/ImportedButNotLocatedDialog.java
@@ -1,0 +1,60 @@
+package dev.wander.android.opentagviewer.ui.importing;
+
+import android.app.Activity;
+
+import androidx.appcompat.app.AlertDialog;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import dev.wander.android.opentagviewer.R;
+
+/**
+ * "Your tags are here. Where they are is not, yet."
+ *
+ * <p><b>The message that replaces a two-year-old lie.</b> What used to appear at this moment was
+ * a toast saying the import had failed and to restart the app - for an import that had committed
+ * its tags to the database and could be seen in the device list. Three reporters across issues
+ * <a href="https://github.com/parawanderer/OpenTagViewer/issues/19">#19</a> and
+ * <a href="https://github.com/parawanderer/OpenTagViewer/issues/26">#26</a> resolved that
+ * "import error" by changing their Anisette server, which tells you both that the message named
+ * the wrong phase and what the real cause usually is.
+ *
+ * <p>A dialog rather than a toast because the first thing a person does here is look at the
+ * screen to see whether their tags arrived, and a toast is gone by then. It is also the only
+ * place the exception is ever put in front of them: the app knew which failure it was and
+ * replaced it with a sentence about importing, which is why none of those reports can be
+ * attributed to a cause.
+ *
+ * <p><b>No report button.</b> This fails when a public Anisette server is down or a phone is on a
+ * train, and the fetch retries by itself every minute - so it is weather, and asking for a bug
+ * report about weather fills a tracker with reports nobody can act on. The bug page belongs to
+ * the half of the import that reads the zip.
+ */
+public final class ImportedButNotLocatedDialog {
+
+    private ImportedButNotLocatedDialog() {}
+
+    /**
+     * @param cause        the failure in the words it arrived in. Shown, not hidden in the log:
+     *                     it is the difference between a report that names a cause and 25
+     *                     comments of guessing.
+     * @param onSettings   opens settings, where the Anisette choice lives
+     * @return the dialog, so a test can ask whether it is still showing. Asking Espresso to
+     *         prove a view is absent means {@code inRoot(isDialog())} against a screen with no
+     *         dialog, and its root picker retries for seconds before admitting there isn't one.
+     */
+    public static AlertDialog show(
+            final Activity activity,
+            final String cause,
+            final Runnable onSettings) {
+
+        return new MaterialAlertDialogBuilder(activity)
+                .setTitle(R.string.imported_but_not_located_title)
+                .setMessage(activity.getString(
+                        R.string.imported_but_not_located_body, cause))
+                .setNegativeButton(R.string.ok, null)
+                .setPositiveButton(R.string.imported_but_not_located_open_settings,
+                        (dialog, which) -> onSettings.run())
+                .show();
+    }
+}

--- a/app/src/main/java/dev/wander/android/opentagviewer/util/LogCollectorUtil.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/util/LogCollectorUtil.java
@@ -29,4 +29,57 @@ public class LogCollectorUtil {
             throw new RuntimeException(e);
         }
     }
+
+    /**
+     * The log, with a few lines at each end saying what produced it.
+     *
+     * <p><b>Because the questions a bug report opens with are all answerable here.</b> The issue
+     * template asks for the app version and for which exporter wrote the bundle, and both were
+     * things the log already knew and never said - so every report either guessed, or went and
+     * opened an export zip full of private keys to read one line out of it.
+     *
+     * <p><b>At both ends, which is not belt and braces.</b> Five hundred lines is more than most
+     * people paste: somebody who has found the interesting part copies the tail around it, and a
+     * header is exactly the part that gets left behind. Repeating it costs three lines and means
+     * either end of an excerpt still says what it came from.
+     *
+     * <p>Kept to what identifies the build and the data, and nothing about the person: no account,
+     * no tag names, no identifiers. A header that leaked would be worse than none, because it
+     * arrives above content people have been told to read before posting, in the position they
+     * skim past as boilerplate.
+     *
+     * @param appVersion  what the app calls itself - {@code BuildConfig.VERSION_NAME}.
+     * @param importedVia the {@code via:} of the most recent import, or null if nothing has been
+     *                    imported: an account-connected install genuinely has no bundle behind it,
+     *                    and saying so is an answer rather than a gap.
+     */
+    /**
+     * What to call this build in a log, so a report says which one produced it.
+     *
+     * <p><b>{@code versionName} alone is not the answer on a checkout.</b> It is a committed
+     * literal, so every commit after a release reports the old version perfectly confidently -
+     * and {@code build-debug.yml} publishes a debug APK artifact, so somebody can be running a
+     * build whose version string is months stale. {@code BUILD_COMMIT} is set for debug builds
+     * only and is what identifies those.
+     *
+     * <p>The same three cases the exporter's {@code describe_build()} distinguishes, for the same
+     * reason: a release is exactly what its version says, a checkout is its commit, and anything
+     * without one falls back to the version rather than inventing something.
+     */
+    public static String describeBuild(final String appVersion, final String buildCommit) {
+        return buildCommit == null ? appVersion : appVersion + " (" + buildCommit + ")";
+    }
+
+    public static String getLastLogsWithHeader(
+            final String appVersion, final String buildCommit, final String importedVia) {
+        final String what = "OpenTagViewer app " + describeBuild(appVersion, buildCommit)
+                + " | tags imported from: "
+                + (importedVia == null ? "nothing - no bundle imported" : importedVia);
+
+        return what + "\n"
+                + "The last " + NUM_LINES_UP + " lines of this device's log follow, "
+                + "unfiltered by the app.\n\n"
+                + getLastLogs()
+                + "\n" + what + "\n";
+    }
 }

--- a/app/src/main/java/dev/wander/android/opentagviewer/util/parse/AppleZipImporterUtil.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/util/parse/AppleZipImporterUtil.java
@@ -614,6 +614,18 @@ public class AppleZipImporterUtil {
     private static Import parseImportInfo(final String importInfo) throws JsonProcessingException {
         OpenTagViewerYamlContent content = YamlParser.MAPPER.readValue(importInfo, OpenTagViewerYamlContent.class);
 
+        // **Said once, here, so every log from now on answers it.**
+        //
+        // Which program wrote a bundle decides what to expect of it - the wizard, its CLI and
+        // the app all stamp their own `via:` - and it was stored and never mentioned again. The
+        // only way a user could answer "which exporter made this zip" was to open the bundle,
+        // which is a bad instruction generally and a dangerous one now that exports are
+        // password-protected by default: it walks somebody through decrypting a file holding
+        // their tags' private keys, on the way to reading one version line.
+        Log.i(TAG, String.format(
+                "Importing a bundle of format %s, written by %s",
+                content.getVersion(), content.getVia()));
+
         return Import.builder()
                 .importedAt(System.currentTimeMillis())
                 .exportedAt(content.getExportTimestamp())

--- a/app/src/main/res/layout/activity_device_info.xml
+++ b/app/src/main/res/layout/activity_device_info.xml
@@ -38,6 +38,10 @@
             type="String" />
 
         <variable
+            name="exportedWith"
+            type="String" />
+
+        <variable
             name="exportedAt"
             type="String" />
 
@@ -313,6 +317,14 @@
                         app:onClick="@{clickItemHandler}"
                         app:sectionSubtitle="@{exportedBy}"
                         app:title="@{@string/exported_by}" />
+
+                    <include
+                        android:id="@+id/device_settings_exported_with"
+                        layout="@layout/settings_item_noicon_clickable"
+                        app:clickable="@{true}"
+                        app:onClick="@{clickItemHandler}"
+                        app:sectionSubtitle="@{exportedWith}"
+                        app:title="@{@string/exported_with}" />
 
                     <include
                         android:id="@+id/device_settings_exported_at"

--- a/app/src/main/res/layout/activity_error_report.xml
+++ b/app/src/main/res/layout/activity_error_report.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  The screen for a failure nobody here can fix.
+
+  **Shown only when the app cannot name the cause** - an UnhandledProtocolError, or anything that
+  reaches REASON_UNKNOWN. Never for a rejected passcode, an account with no tags, a network that
+  is down or a session wanting a verification code: those all have screens that tell somebody what
+  to do, and this one would be strictly worse than the advice they already give. A page that
+  appears for ordinary mistakes teaches people to dismiss it, and then it is worth nothing on the
+  day it is right.
+
+  The two buttons are the whole point: a link that lands on the form with the questions already in
+  it, and a log that has been through the redactor first.
+-->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/error_report_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <!--
+          **colorPrimary, not colorError.** The red one read as an alert - something the user had
+          done, or something now at risk - and neither is what this page is for. Their tags are
+          fine and there is nothing to undo; the page exists to ask for a report. Tinted to match
+          the app mark on the Information page, which is the same colour and the same gesture:
+          this is the app talking about itself.
+        -->
+        <ImageView
+            android:layout_width="56dp"
+            android:layout_height="56dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="48dp"
+            android:contentDescription="@null"
+            android:src="@drawable/warning_24px_fill"
+            app:tint="?attr/colorPrimary" />
+
+        <TextView
+            android:id="@+id/error_report_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:fontFamily="@font/nunito_bold"
+            android:gravity="center_horizontal"
+            android:text="@string/error_report_title"
+            android:textColor="?attr/colorOnSurface"
+            android:textSize="24sp" />
+
+        <TextView
+            android:id="@+id/error_report_body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:lineSpacingExtra="3dp"
+            android:text="@string/error_report_body"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:textSize="14sp" />
+
+        <!--
+          What the report form asks for first, on screen so nobody has to go and find it - and in
+          particular so nobody opens their export zip to read a version line out of it.
+        -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:background="@drawable/layout_rounded"
+            android:backgroundTint="?attr/colorSurfaceContainerLow"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/error_report_build"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="monospace"
+                android:textColor="?attr/colorOnSurface"
+                android:textSize="13sp"
+                tools:text="OpenTagViewer app 1.1.0 (25e1679)" />
+
+            <TextView
+                android:id="@+id/error_report_imported_from"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:textSize="13sp"
+                tools:text="Tags imported from OpenTagViewer.wizard:1.3.0" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="@string/error_report_what_failed"
+                android:textColor="?attr/colorOutline"
+                android:textSize="11sp" />
+
+            <!--
+              What the failure actually was, verbatim. Not translated and not tidied: it is for
+              pasting into a report, and a translated cause is one a maintainer cannot search for.
+              Labelled above, because an unexplained monospace line in a box is not self-evident.
+            -->
+            <TextView
+                android:id="@+id/error_report_cause"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:fontFamily="monospace"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:textSize="12sp"
+                tools:text="KeychainSessionError: No keychain keys are held" />
+
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/error_report_button"
+            style="@style/Widget.Material3.Button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp"
+            android:text="@string/error_report_button" />
+
+        <TextView
+            android:id="@+id/error_report_needs_github"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="@string/error_report_needs_github"
+            android:textColor="?attr/colorOutline"
+            android:textSize="12sp" />
+
+        <Button
+            android:id="@+id/error_report_share_log"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp"
+            android:text="@string/error_report_share_log" />
+
+        <!--
+          Says what the redactor took out, or why there is no log to take. Both are answers; the
+          second is why the button above may be gone.
+        -->
+        <TextView
+            android:id="@+id/error_report_log_note"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:textColor="?attr/colorOutline"
+            android:textSize="12sp"
+            tools:text="The log is cleaned before it leaves the app: 3 email addresses, 1 serial" />
+
+        <!--
+          **A way out that is on the screen.**
+
+          The action bar is hidden here, so before this existed the only way off the page was the
+          system back gesture - no arrow, no X, nothing to press. That is fine for anybody who
+          knows it and a dead end for anybody who does not, on a page somebody reaches at the
+          moment they are already stuck.
+
+          Last and quiet, because the two buttons above are what the page is for; this one is
+          only the exit.
+        -->
+        <Button
+            android:id="@+id/error_report_close"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="24dp"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp"
+            android:text="@string/error_report_close" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/activity_information.xml
+++ b/app/src/main/res/layout/activity_information.xml
@@ -76,6 +76,23 @@
                     android:textAlignment="center"
                     android:textSize="16sp" />
 
+                <!--
+                  **The two questions a bug report opens with, answered where somebody can read
+                  them off.** The version was already here; what it was missing is which exporter
+                  made the bundle - and the alternative was people opening an export zip to read
+                  a version line out of it, which is a file holding the private keys to their
+                  tags. The issue template says not to, and now it does not have to.
+                -->
+                <TextView
+                    android:id="@+id/appImportedFrom"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:textAlignment="center"
+                    android:textColor="?attr/colorOnSurfaceVariant"
+                    android:textSize="13sp"
+                    tools:text="Tags imported from OpenTagViewer.wizard:1.3.0" />
+
                 <TextView
                     android:id="@+id/appAbout"
                     android:layout_width="match_parent"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -275,4 +275,27 @@ Du kannst das jetzt einrichten oder jederzeit später in den Einstellungen.</str
     <string name="icloud_results_next">Weiter</string>
     <string name="icloud_registered_serial_label">Seriennummer: ^1</string>
     <string name="icloud_registered_model_and_os">%1$s (%2$s)</string>
+    <string name="imported_from_x">Tags importiert aus %1$s</string>
+    <string name="imported_from_nothing">Keine Tags aus einer Datei importiert</string>
+    <string name="error_report_title">Das ist ein Fehler in der App</string>
+    <string name="error_report_body">Es kam etwas zurück, das diese App nicht lesen kann. Ein erneuter Versuch hilft daher nicht, und an deinen Einstellungen ist nichts zu ändern.\n\nMeist bedeutet das, dass Apple etwas geändert hat. Ein Bericht mit angehängtem Protokoll macht es behebbar – das Protokoll verrät fast immer, welcher Teil betroffen ist.</string>
+    <string name="error_report_button">Fehler melden</string>
+    <string name="error_report_needs_github">Öffnet GitHub. Dort musst du dich zuerst anmelden oder ein Konto erstellen.</string>
+    <string name="error_report_share_log">Protokoll holen</string>
+    <string name="error_report_log_cleaned">Das Protokoll wird bereinigt, bevor es die App verlässt: %1$s</string>
+    <string name="error_report_log_unavailable">Das Protokoll kann gerade nicht geteilt werden, weil der Teil der App, der persönliche Daten daraus entfernt, nicht läuft. Eine Meldung ohne Protokoll hilft trotzdem.</string>
+    <string name="error_report_what_failed">Was fehlgeschlagen ist</string>
+    <string name="error_report_body_import">Die App konnte diese Datei nicht lesen und kann nicht sagen, was daran nicht stimmt – ein erneuter Versuch mit derselben Datei hilft also nicht.\n\nWenn sie aus dem Exporter stammt, hätte es funktionieren müssen, und genau deshalb lohnt sich eine Meldung. Das Protokoll verrät meist, an welcher Stelle es abgebrochen ist.</string>
+    <string name="imported_but_not_located_title">Deine Tags sind importiert</string>
+    <string name="imported_but_not_located_body">Sie sind auf diesem Telefon gespeichert und bleiben dort. Nicht funktioniert hat die Abfrage bei Apple, wo sie sich befinden:\n\n%1$s\n\nMeist liegt das am Anisette-Server, über den deine Anmeldung läuft: Ist ein öffentlicher Server ausgefallen, kommen keine Standorte mehr an, während sonst alles normal aussieht. Werden die Anmeldedaten stattdessen auf diesem Gerät erzeugt, bist du von fremden Servern unabhängig.\n\nDie App versucht es jede Minute erneut, eine kurze Störung erledigt sich also von selbst.</string>
+    <string name="imported_but_not_located_open_settings">Anmeldedaten</string>
+    <string name="error_report_close">Schließen</string>
+    <string name="error_report_log_how">Wie möchtest du das Protokoll?</string>
+    <string name="error_report_log_copy">Kopieren, zum Einfügen in die Meldung</string>
+    <string name="error_report_log_save">Als Datei speichern, zum Anhängen</string>
+    <string name="error_report_log_copied">Das Protokoll wurde kopiert</string>
+    <string name="export_logs_cannot_be_cleaned">Das Protokoll konnte nicht gespeichert werden, weil der Teil der App, der persönliche Angaben daraus entfernt, nicht läuft. Es wurde nichts geschrieben – ein ungefiltertes Protokoll ist es nicht wert, weitergegeben zu werden.</string>
+    <string name="export_logs_cleaned">Protokoll gespeichert. Es wurde zuvor bereinigt: %1$s</string>
+    <string name="exported_with">Exportiert mit</string>
+    <string name="exported_with_something_unrecorded">Nicht vermerkt – ein älterer Exporter</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -275,4 +275,27 @@ You can set this up now, or any time later from Settings.</string>
     <string name="icloud_results_next">Next</string>
     <string name="icloud_registered_serial_label">Serial Number: ^1</string>
     <string name="icloud_registered_model_and_os">%1$s (%2$s)</string>
+    <string name="imported_from_x">Tags imported from %1$s</string>
+    <string name="imported_from_nothing">No tags imported from a file</string>
+    <string name="error_report_title">This one is a bug</string>
+    <string name="error_report_body">Something came back that this app does not know how to read, so retrying will not help and there is nothing to change in your settings.\n\nThat usually means Apple altered something. A report with the log attached is what makes it fixable — the log almost always says which part.</string>
+    <string name="error_report_button">Report this</string>
+    <string name="error_report_needs_github">Opens GitHub, which will ask you to sign in or create an account first.</string>
+    <string name="error_report_share_log">Get the log</string>
+    <string name="error_report_log_cleaned">The log is cleaned before it leaves the app: %1$s</string>
+    <string name="error_report_log_unavailable">The log cannot be shared right now, because the part of the app that removes personal details from it is not running. Reporting without it still helps.</string>
+    <string name="error_report_what_failed">What failed</string>
+    <string name="error_report_body_import">The app could not read that file, and cannot say what is wrong with it — so trying again with the same file will not help.\n\nIf it came from the exporter it should have worked, which makes this worth reporting. The log usually says which part it stopped on.</string>
+    <string name="imported_but_not_located_title">Your tags are imported</string>
+    <string name="imported_but_not_located_body">They are saved on this phone and will stay there. What did not work was asking Apple where they are:\n\n%1$s\n\nThat is usually the Anisette server your sign-in goes through — when a public one is down, locations stop arriving while everything else looks fine. Producing sign-in data on this device instead avoids depending on anyone else’s server.\n\nThe app keeps trying every minute, so a brief outage sorts itself out.</string>
+    <string name="imported_but_not_located_open_settings">Sign-in data</string>
+    <string name="error_report_close">Close</string>
+    <string name="error_report_log_how">How do you want the log?</string>
+    <string name="error_report_log_copy">Copy it, to paste into the report</string>
+    <string name="error_report_log_save">Save it as a file, to attach</string>
+    <string name="error_report_log_copied">The log has been copied</string>
+    <string name="export_logs_cannot_be_cleaned">The log could not be saved, because the part of the app that removes personal details from it is not running. Nothing was written — an uncleaned log is not worth handing out.</string>
+    <string name="export_logs_cleaned">Log saved. It was cleaned first: %1$s</string>
+    <string name="exported_with">Exported with</string>
+    <string name="exported_with_something_unrecorded">Not recorded — an older exporter</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -275,4 +275,27 @@ Vous pouvez configurer cela maintenant, ou à tout moment depuis les réglages.<
     <string name="icloud_results_next">Suivant</string>
     <string name="icloud_registered_serial_label">Numéro de série : ^1</string>
     <string name="icloud_registered_model_and_os">%1$s (%2$s)</string>
+    <string name="imported_from_x">Balises importées depuis %1$s</string>
+    <string name="imported_from_nothing">Aucune balise importée depuis un fichier</string>
+    <string name="error_report_title">Ceci est un bug</string>
+    <string name="error_report_body">L’app a reçu quelque chose qu’elle ne sait pas lire : réessayer n’y changera rien, et il n’y a rien à modifier dans vos réglages.\n\nCela signifie généralement qu’Apple a changé quelque chose. Un rapport accompagné du journal est ce qui rend la correction possible : le journal indique presque toujours quelle partie est en cause.</string>
+    <string name="error_report_button">Signaler</string>
+    <string name="error_report_needs_github">Ouvre GitHub, qui vous demandera d’abord de vous connecter ou de créer un compte.</string>
+    <string name="error_report_share_log">Obtenir le journal</string>
+    <string name="error_report_log_cleaned">Le journal est nettoyé avant de quitter l’app : %1$s</string>
+    <string name="error_report_log_unavailable">Le journal ne peut pas être partagé pour l’instant : la partie de l’app qui en retire les données personnelles ne fonctionne pas. Signaler sans le journal aide quand même.</string>
+    <string name="error_report_what_failed">Ce qui a échoué</string>
+    <string name="error_report_body_import">L’app n’a pas pu lire ce fichier et ne sait pas dire ce qui ne va pas : réessayer avec le même fichier n’y changera rien.\n\nS’il vient de l’exportateur, il aurait dû fonctionner, et c’est bien pour cela que cela vaut la peine d’être signalé. Le journal indique généralement à quel endroit cela s’est arrêté.</string>
+    <string name="imported_but_not_located_title">Vos tags sont importés</string>
+    <string name="imported_but_not_located_body">Ils sont enregistrés sur ce téléphone et y resteront. Ce qui n’a pas fonctionné, c’est la demande à Apple de leur position :\n\n%1$s\n\nEn général, cela vient du serveur Anisette par lequel passe votre connexion : quand un serveur public est hors service, les positions cessent d’arriver alors que tout le reste semble normal. Produire les données de connexion sur cet appareil évite de dépendre du serveur de quelqu’un d’autre.\n\nL’app réessaie chaque minute : une panne brève se résout donc d’elle-même.</string>
+    <string name="imported_but_not_located_open_settings">Données de connexion</string>
+    <string name="error_report_close">Fermer</string>
+    <string name="error_report_log_how">Comment voulez-vous le journal ?</string>
+    <string name="error_report_log_copy">Le copier, pour le coller dans le signalement</string>
+    <string name="error_report_log_save">L’enregistrer comme fichier, pour le joindre</string>
+    <string name="error_report_log_copied">Le journal a été copié</string>
+    <string name="export_logs_cannot_be_cleaned">Le journal n’a pas pu être enregistré, car la partie de l’app qui en retire les données personnelles ne fonctionne pas. Rien n’a été écrit : un journal non nettoyé ne vaut pas la peine d’être diffusé.</string>
+    <string name="export_logs_cleaned">Journal enregistré. Il a d’abord été nettoyé : %1$s</string>
+    <string name="exported_with">Exporté avec</string>
+    <string name="exported_with_something_unrecorded">Non enregistré — un exportateur plus ancien</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -275,4 +275,27 @@
     <string name="icloud_results_next">次へ</string>
     <string name="icloud_registered_serial_label">シリアル番号：^1</string>
     <string name="icloud_registered_model_and_os">%1$s（%2$s）</string>
+    <string name="imported_from_x">%1$s からインポートしたタグ</string>
+    <string name="imported_from_nothing">ファイルからインポートしたタグはありません</string>
+    <string name="error_report_title">これは不具合です</string>
+    <string name="error_report_body">このアプリが解釈できないものが返ってきました。再試行しても解決せず、設定を変える必要もありません。\n\nたいていは Apple 側の変更が原因です。ログを添えて報告していただければ修正できます。どの部分かは、ほぼ必ずログに書かれています。</string>
+    <string name="error_report_button">報告する</string>
+    <string name="error_report_needs_github">GitHub を開きます。先にサインイン、またはアカウント作成を求められます。</string>
+    <string name="error_report_share_log">ログを取得</string>
+    <string name="error_report_log_cleaned">ログはアプリから出る前に整理されます：%1$s</string>
+    <string name="error_report_log_unavailable">個人情報を取り除く処理が動いていないため、いまはログを共有できません。ログなしの報告でも役に立ちます。</string>
+    <string name="error_report_what_failed">失敗した内容</string>
+    <string name="error_report_body_import">このファイルを読み取れず、どこがおかしいのかも判別できませんでした。同じファイルで再試行しても解決しません。\n\nエクスポーターで作成したものなら本来は読めるはずなので、報告する価値があります。どこで止まったかは、たいていログに書かれています。</string>
+    <string name="imported_but_not_located_title">タグの読み込みは完了しました</string>
+    <string name="imported_but_not_located_body">タグはこの端末に保存され、消えることはありません。できなかったのは、Apple に現在地を問い合わせることです：\n\n%1$s\n\n原因はたいてい、サインインが経由する Anisette サーバーです。公開サーバーが停止していると、ほかは正常に見えるのに位置情報だけ届かなくなります。サインイン用データをこの端末で生成すれば、他人のサーバーに頼らずに済みます。\n\nアプリは 1 分ごとに再試行するので、一時的な停止であれば自然に解消します。</string>
+    <string name="imported_but_not_located_open_settings">サインインデータ</string>
+    <string name="error_report_close">閉じる</string>
+    <string name="error_report_log_how">ログをどの形で受け取りますか？</string>
+    <string name="error_report_log_copy">コピーする（報告に貼り付ける用）</string>
+    <string name="error_report_log_save">ファイルとして保存する（添付する用）</string>
+    <string name="error_report_log_copied">ログをコピーしました</string>
+    <string name="export_logs_cannot_be_cleaned">ログを保存できませんでした。個人情報を取り除く部分が動作していないためです。ファイルは書き出していません。未処理のログを渡す価値はありません。</string>
+    <string name="export_logs_cleaned">ログを保存しました。事前に次のものを取り除いています：%1$s</string>
+    <string name="exported_with">エクスポート元</string>
+    <string name="exported_with_something_unrecorded">記録なし（古いエクスポーター）</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -275,4 +275,27 @@
     <string name="icloud_results_next">다음</string>
     <string name="icloud_registered_serial_label">일련번호: ^1</string>
     <string name="icloud_registered_model_and_os">%1$s (%2$s)</string>
+    <string name="imported_from_x">%1$s에서 가져온 태그</string>
+    <string name="imported_from_nothing">파일에서 가져온 태그가 없습니다</string>
+    <string name="error_report_title">이건 버그입니다</string>
+    <string name="error_report_body">이 앱이 읽을 수 없는 응답이 돌아왔습니다. 다시 시도해도 해결되지 않으며, 설정에서 바꿀 것도 없습니다.\n\n대개 Apple 쪽에서 무언가 바뀐 경우입니다. 로그를 첨부해 신고해 주시면 고칠 수 있습니다. 어느 부분인지는 대부분 로그에 나옵니다.</string>
+    <string name="error_report_button">신고하기</string>
+    <string name="error_report_needs_github">GitHub이 열리며, 먼저 로그인하거나 계정을 만들어야 합니다.</string>
+    <string name="error_report_share_log">로그 가져오기</string>
+    <string name="error_report_log_cleaned">로그는 앱을 떠나기 전에 정리됩니다: %1$s</string>
+    <string name="error_report_log_unavailable">개인 정보를 제거하는 기능이 동작하지 않아 지금은 로그를 공유할 수 없습니다. 로그 없이 신고해도 도움이 됩니다.</string>
+    <string name="error_report_what_failed">실패한 내용</string>
+    <string name="error_report_body_import">이 파일을 읽을 수 없었고, 무엇이 잘못됐는지도 알 수 없습니다. 같은 파일로 다시 시도해도 해결되지 않습니다.\n\n내보내기 도구로 만든 파일이라면 원래 열려야 하므로, 신고할 가치가 있습니다. 어디에서 멈췄는지는 대개 로그에 나옵니다.</string>
+    <string name="imported_but_not_located_title">태그를 가져왔습니다</string>
+    <string name="imported_but_not_located_body">태그는 이 휴대폰에 저장되어 있으며 그대로 유지됩니다. 실패한 것은 Apple에 위치를 요청하는 일이었습니다:\n\n%1$s\n\n대개는 로그인이 거쳐 가는 Anisette 서버 때문입니다. 공개 서버가 멈추면 다른 것은 멀쩡해 보여도 위치만 도착하지 않습니다. 로그인 데이터를 이 기기에서 직접 만들면 남의 서버에 의존하지 않아도 됩니다.\n\n앱이 1분마다 다시 시도하므로 짧은 장애는 저절로 해결됩니다.</string>
+    <string name="imported_but_not_located_open_settings">로그인 데이터</string>
+    <string name="error_report_close">닫기</string>
+    <string name="error_report_log_how">로그를 어떤 방식으로 받으시겠어요?</string>
+    <string name="error_report_log_copy">복사하기 — 신고서에 붙여 넣기용</string>
+    <string name="error_report_log_save">파일로 저장하기 — 첨부용</string>
+    <string name="error_report_log_copied">로그를 복사했습니다</string>
+    <string name="export_logs_cannot_be_cleaned">로그를 저장하지 못했습니다. 개인 정보를 제거하는 부분이 실행되지 않고 있기 때문입니다. 아무것도 기록하지 않았습니다 — 정리되지 않은 로그는 넘길 만한 것이 못 됩니다.</string>
+    <string name="export_logs_cleaned">로그를 저장했습니다. 먼저 다음을 제거했습니다: %1$s</string>
+    <string name="exported_with">내보낸 도구</string>
+    <string name="exported_with_something_unrecorded">기록 없음 — 오래된 내보내기 도구</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -275,4 +275,27 @@ Je kunt dit nu instellen, of later altijd nog via Instellingen.</string>
     <string name="icloud_results_next">Volgende</string>
     <string name="icloud_registered_serial_label">Serienummer: ^1</string>
     <string name="icloud_registered_model_and_os">%1$s (%2$s)</string>
+    <string name="imported_from_x">Tags geïmporteerd uit %1$s</string>
+    <string name="imported_from_nothing">Geen tags uit een bestand geïmporteerd</string>
+    <string name="error_report_title">Dit is een bug</string>
+    <string name="error_report_body">Er kwam iets terug dat deze app niet kan lezen, dus opnieuw proberen helpt niet en er valt niets aan je instellingen te wijzigen.\n\nMeestal betekent dat dat Apple iets heeft veranderd. Een melding met het logbestand erbij maakt het oplosbaar — het log zegt bijna altijd welk deel.</string>
+    <string name="error_report_button">Dit melden</string>
+    <string name="error_report_needs_github">Opent GitHub, waar je eerst moet inloggen of een account moet aanmaken.</string>
+    <string name="error_report_share_log">Log ophalen</string>
+    <string name="error_report_log_cleaned">Het log wordt opgeschoond voordat het de app verlaat: %1$s</string>
+    <string name="error_report_log_unavailable">Het log kan nu niet gedeeld worden, omdat het onderdeel dat persoonlijke gegevens eruit haalt niet draait. Melden zonder log helpt nog steeds.</string>
+    <string name="error_report_what_failed">Wat er misging</string>
+    <string name="error_report_body_import">De app kon dat bestand niet lezen en kan niet zeggen wat eraan mankeert — het opnieuw proberen met hetzelfde bestand helpt dus niet.\n\nAls het uit de exporter komt, had het moeten werken, en juist daarom is het het melden waard. Het log zegt meestal waar het is blijven steken.</string>
+    <string name="imported_but_not_located_title">Je tags zijn geïmporteerd</string>
+    <string name="imported_but_not_located_body">Ze staan op deze telefoon en blijven daar. Wat niet lukte, was Apple vragen waar ze zijn:\n\n%1$s\n\nDat ligt meestal aan de Anisette-server waar je aanmelding langs gaat: als een publieke server uit de lucht is, komen er geen locaties meer binnen terwijl de rest er normaal uitziet. Aanmeldgegevens op dit toestel maken scheelt de afhankelijkheid van andermans server.\n\nDe app blijft het elke minuut proberen, dus een korte storing lost zichzelf op.</string>
+    <string name="imported_but_not_located_open_settings">Aanmeldgegevens</string>
+    <string name="error_report_close">Sluiten</string>
+    <string name="error_report_log_how">Hoe wil je het log hebben?</string>
+    <string name="error_report_log_copy">Kopiëren, om in het rapport te plakken</string>
+    <string name="error_report_log_save">Opslaan als bestand, om bij te voegen</string>
+    <string name="error_report_log_copied">Het log is gekopieerd</string>
+    <string name="export_logs_cannot_be_cleaned">Het log kon niet worden opgeslagen, omdat het onderdeel van de app dat persoonlijke gegevens eruit haalt niet draait. Er is niets weggeschreven — een ongeschoond log is het niet waard om te delen.</string>
+    <string name="export_logs_cleaned">Log opgeslagen. Het is eerst geschoond: %1$s</string>
+    <string name="exported_with">Geëxporteerd met</string>
+    <string name="exported_with_something_unrecorded">Niet vastgelegd — een oudere exporter</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -275,4 +275,27 @@
     <string name="icloud_results_next">Далее</string>
     <string name="icloud_registered_serial_label">Серийный номер: ^1</string>
     <string name="icloud_registered_model_and_os">%1$s (%2$s)</string>
+    <string name="imported_from_x">Метки импортированы из %1$s</string>
+    <string name="imported_from_nothing">Метки из файла не импортировались</string>
+    <string name="error_report_title">Это ошибка приложения</string>
+    <string name="error_report_body">Пришло что-то, что приложение не умеет читать, поэтому повторная попытка не поможет и менять настройки не нужно.\n\nОбычно это значит, что Apple что-то изменила. Отчёт с приложенным журналом делает ошибку исправимой — журнал почти всегда указывает, где именно.</string>
+    <string name="error_report_button">Сообщить об ошибке</string>
+    <string name="error_report_needs_github">Откроется GitHub — там сначала попросят войти или создать учётную запись.</string>
+    <string name="error_report_share_log">Получить журнал</string>
+    <string name="error_report_log_cleaned">Журнал очищается перед отправкой из приложения: %1$s</string>
+    <string name="error_report_log_unavailable">Сейчас журналом поделиться нельзя: часть приложения, которая удаляет из него личные данные, не работает. Сообщение без журнала всё равно поможет.</string>
+    <string name="error_report_what_failed">Что не удалось</string>
+    <string name="error_report_body_import">Приложение не смогло прочитать этот файл и не может сказать, что с ним не так, — повторная попытка с тем же файлом не поможет.\n\nЕсли он получен из экспортера, он должен был подойти, и именно поэтому об этом стоит сообщить. Журнал обычно указывает, на чём всё остановилось.</string>
+    <string name="imported_but_not_located_title">Метки импортированы</string>
+    <string name="imported_but_not_located_body">Они сохранены на этом телефоне и там останутся. Не удалось другое — запросить у Apple, где они находятся:\n\n%1$s\n\nОбычно дело в сервере Anisette, через который проходит вход: когда публичный сервер недоступен, местоположения перестают приходить, хотя всё остальное выглядит нормально. Если данные для входа создаются на самом устройстве, чужой сервер больше не нужен.\n\nПриложение повторяет попытку каждую минуту, так что кратковременный сбой пройдёт сам.</string>
+    <string name="imported_but_not_located_open_settings">Данные для входа</string>
+    <string name="error_report_close">Закрыть</string>
+    <string name="error_report_log_how">В каком виде нужен журнал?</string>
+    <string name="error_report_log_copy">Скопировать, чтобы вставить в отчёт</string>
+    <string name="error_report_log_save">Сохранить файлом, чтобы прикрепить</string>
+    <string name="error_report_log_copied">Журнал скопирован</string>
+    <string name="export_logs_cannot_be_cleaned">Журнал не удалось сохранить: часть приложения, которая удаляет из него личные данные, не работает. Ничего не записано — неочищенный журнал отдавать не стоит.</string>
+    <string name="export_logs_cleaned">Журнал сохранён. Перед этим он был очищен: %1$s</string>
+    <string name="exported_with">Экспортировано через</string>
+    <string name="exported_with_something_unrecorded">Не записано — более старый экспортер</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -275,4 +275,27 @@
     <string name="icloud_results_next">下一步</string>
     <string name="icloud_registered_serial_label">序列号：^1</string>
     <string name="icloud_registered_model_and_os">%1$s（%2$s）</string>
+    <string name="imported_from_x">标签导入自 %1$s</string>
+    <string name="imported_from_nothing">没有从文件导入的标签</string>
+    <string name="error_report_title">这是一个程序缺陷</string>
+    <string name="error_report_body">返回了本应用无法解读的内容，因此重试没有用，你的设置也不需要改动。\n\n这通常意味着 Apple 改动了什么。附上日志的报告才能让它被修复——日志几乎总能指出是哪一部分。</string>
+    <string name="error_report_button">报告问题</string>
+    <string name="error_report_needs_github">将打开 GitHub，需要先登录或注册账号。</string>
+    <string name="error_report_share_log">获取日志</string>
+    <string name="error_report_log_cleaned">日志在离开应用前会先清理：%1$s</string>
+    <string name="error_report_log_unavailable">目前无法分享日志，因为负责移除个人信息的部分没有在运行。不带日志的报告同样有帮助。</string>
+    <string name="error_report_what_failed">失败的内容</string>
+    <string name="error_report_body_import">应用无法读取该文件，也说不出它哪里有问题——用同一个文件重试没有用。\n\n如果它来自导出工具，本应可以读取，正因如此才值得报告。日志通常会指出停在了哪一步。</string>
+    <string name="imported_but_not_located_title">标签已导入</string>
+    <string name="imported_but_not_located_body">标签已保存在这台手机上，不会丢失。没能成功的是向 Apple 询问它们在哪里：\n\n%1$s\n\n这通常是登录所经过的 Anisette 服务器造成的：公共服务器一旦停摆，位置就不再送达，而其他一切看起来都正常。改为在本机生成登录数据，就不必依赖别人的服务器。\n\n应用每分钟都会重试，短暂的故障会自行恢复。</string>
+    <string name="imported_but_not_located_open_settings">登录数据</string>
+    <string name="error_report_close">关闭</string>
+    <string name="error_report_log_how">你想要哪种形式的日志？</string>
+    <string name="error_report_log_copy">复制，用于粘贴到报告里</string>
+    <string name="error_report_log_save">保存为文件，用于上传附件</string>
+    <string name="error_report_log_copied">日志已复制</string>
+    <string name="export_logs_cannot_be_cleaned">日志无法保存，因为负责去除个人信息的部分没有运行。什么都没有写入——未经清理的日志不值得交出去。</string>
+    <string name="export_logs_cleaned">日志已保存。已先行清理：%1$s</string>
+    <string name="exported_with">导出工具</string>
+    <string name="exported_with_something_unrecorded">未记录——较旧的导出工具</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -275,4 +275,27 @@
     <string name="icloud_results_next">下一步</string>
     <string name="icloud_registered_serial_label">序號：^1</string>
     <string name="icloud_registered_model_and_os">%1$s（%2$s）</string>
+    <string name="imported_from_x">標籤匯入自 %1$s</string>
+    <string name="imported_from_nothing">沒有從檔案匯入的標籤</string>
+    <string name="error_report_title">這是一個程式缺陷</string>
+    <string name="error_report_body">回傳了本 App 無法解讀的內容，因此重試沒有用，你的設定也不需要更動。\n\n這通常表示 Apple 改動了什麼。附上日誌的回報才能讓它被修復——日誌幾乎總能指出是哪一部分。</string>
+    <string name="error_report_button">回報問題</string>
+    <string name="error_report_needs_github">將開啟 GitHub，需要先登入或註冊帳號。</string>
+    <string name="error_report_share_log">取得日誌</string>
+    <string name="error_report_log_cleaned">日誌在離開 App 前會先清理：%1$s</string>
+    <string name="error_report_log_unavailable">目前無法分享日誌，因為負責移除個人資訊的部分沒有在執行。不帶日誌的回報同樣有幫助。</string>
+    <string name="error_report_what_failed">失敗的內容</string>
+    <string name="error_report_body_import">App 無法讀取該檔案，也說不出它哪裡有問題——用同一個檔案重試沒有用。\n\n如果它來自匯出工具，本應可以讀取，正因如此才值得回報。日誌通常會指出停在了哪一步。</string>
+    <string name="imported_but_not_located_title">標籤已匯入</string>
+    <string name="imported_but_not_located_body">標籤已儲存在這支手機上，不會遺失。沒能成功的是向 Apple 詢問它們在哪裡：\n\n%1$s\n\n這通常是登入所經過的 Anisette 伺服器造成的：公用伺服器一旦停擺，位置就不再送達，而其他一切看起來都正常。改為在本機產生登入資料，就不必依賴別人的伺服器。\n\nApp 每分鐘都會重試，短暫的故障會自行恢復。</string>
+    <string name="imported_but_not_located_open_settings">登入資料</string>
+    <string name="error_report_close">關閉</string>
+    <string name="error_report_log_how">你想要哪種形式的日誌？</string>
+    <string name="error_report_log_copy">複製，用於貼到回報中</string>
+    <string name="error_report_log_save">儲存為檔案，用於上傳附件</string>
+    <string name="error_report_log_copied">日誌已複製</string>
+    <string name="export_logs_cannot_be_cleaned">日誌無法儲存，因為負責移除個人資訊的部分沒有運行。什麼都沒有寫入——未經清理的日誌不值得交出去。</string>
+    <string name="export_logs_cleaned">日誌已儲存。已先行清理：%1$s</string>
+    <string name="exported_with">匯出工具</string>
+    <string name="exported_with_something_unrecorded">未記錄——較舊的匯出工具</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -307,4 +307,27 @@ You can set this up now, or any time later from Settings.</string>
     <string name="icloud_results_next">Next</string>
     <string name="icloud_registered_serial_label">Serial Number: ^1</string>
     <string name="icloud_registered_model_and_os">%1$s (%2$s)</string>
+    <string name="imported_from_x">Tags imported from %1$s</string>
+    <string name="imported_from_nothing">No tags imported from a file</string>
+    <string name="error_report_title">This one is a bug</string>
+    <string name="error_report_body">Something came back that this app does not know how to read, so retrying will not help and there is nothing to change in your settings.\n\nThat usually means Apple altered something. A report with the log attached is what makes it fixable — the log almost always says which part.</string>
+    <string name="error_report_button">Report this</string>
+    <string name="error_report_needs_github">Opens GitHub, which will ask you to sign in or create an account first.</string>
+    <string name="error_report_share_log">Get the log</string>
+    <string name="error_report_log_cleaned">The log is cleaned before it leaves the app: %1$s</string>
+    <string name="error_report_log_unavailable">The log cannot be shared right now, because the part of the app that removes personal details from it is not running. Reporting without it still helps.</string>
+    <string name="error_report_what_failed">What failed</string>
+    <string name="error_report_body_import">The app could not read that file, and cannot say what is wrong with it — so trying again with the same file will not help.\n\nIf it came from the exporter it should have worked, which makes this worth reporting. The log usually says which part it stopped on.</string>
+    <string name="imported_but_not_located_title">Your tags are imported</string>
+    <string name="imported_but_not_located_body">They are saved on this phone and will stay there. What did not work was asking Apple where they are:\n\n%1$s\n\nThat is usually the Anisette server your sign-in goes through — when a public one is down, locations stop arriving while everything else looks fine. Producing sign-in data on this device instead avoids depending on anyone else’s server.\n\nThe app keeps trying every minute, so a brief outage sorts itself out.</string>
+    <string name="imported_but_not_located_open_settings">Sign-in data</string>
+    <string name="error_report_close">Close</string>
+    <string name="error_report_log_how">How do you want the log?</string>
+    <string name="error_report_log_copy">Copy it, to paste into the report</string>
+    <string name="error_report_log_save">Save it as a file, to attach</string>
+    <string name="error_report_log_copied">The log has been copied</string>
+    <string name="export_logs_cannot_be_cleaned">The log could not be saved, because the part of the app that removes personal details from it is not running. Nothing was written — an uncleaned log is not worth handing out.</string>
+    <string name="export_logs_cleaned">Log saved. It was cleaned first: %1$s</string>
+    <string name="exported_with">Exported with</string>
+    <string name="exported_with_something_unrecorded">Not recorded — an older exporter</string>
 </resources>

--- a/app/src/test/java/dev/wander/android/opentagviewer/ui/error/TheIssueLinkPointsSomewhereRealTest.java
+++ b/app/src/test/java/dev/wander/android/opentagviewer/ui/error/TheIssueLinkPointsSomewhereRealTest.java
@@ -1,0 +1,69 @@
+package dev.wander.android.opentagviewer.ui.error;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import java.io.File;
+
+/**
+ * The report link names a template that exists.
+ *
+ * <p><b>Because GitHub does not complain when it does not.</b> An unknown {@code ?template=} is
+ * not an error there: the reporter is dropped on a blank issue, with none of the questions the
+ * form asks and none of the labels it applies. So renaming
+ * {@code .github/ISSUE_TEMPLATE/app-bug.yml} breaks the error page silently, and the only symptom
+ * is worse bug reports for however many months it takes somebody to notice.
+ *
+ * <p>The exporter has the same assertion over its own link, for the same reason.
+ */
+public class TheIssueLinkPointsSomewhereRealTest {
+
+    @Test
+    public void thetemplateTheLinkNamesIsInTheRepository() {
+        final File templates = findTemplateDirectory();
+
+        final File named = new File(templates, IssueReport.TEMPLATE);
+        assertTrue("the error page links at " + IssueReport.TEMPLATE + ", which is not in "
+                        + templates + " - GitHub will silently serve a blank issue form instead",
+                named.isFile());
+    }
+
+    /**
+     * And the URL really does name it, rather than having drifted from the constant beside it.
+     */
+    @Test
+    public void thelinkCarriesThatTemplateAndNotLabels() {
+        assertTrue("the link must name the template: " + IssueReport.NEW_APP_BUG,
+                IssueReport.NEW_APP_BUG.contains("template=" + IssueReport.TEMPLATE));
+
+        // Labels in a URL are applied only for somebody who can already label the repository -
+        // which a bug reporter is not - so a link relying on them would arrive unlabelled.
+        assertTrue("labels belong in the template's front matter, not the URL: "
+                        + IssueReport.NEW_APP_BUG,
+                !IssueReport.NEW_APP_BUG.contains("labels="));
+    }
+
+    /**
+     * Walks up from wherever the test runner started, because that is not fixed.
+     *
+     * <p>Gradle runs unit tests with the module directory as the working directory, but that is a
+     * convention rather than a promise, and a test that hardcoded {@code ../.github} would fail
+     * for a reason having nothing to do with its subject.
+     */
+    private static File findTemplateDirectory() {
+        File here = new File(System.getProperty("user.dir")).getAbsoluteFile();
+
+        while (here != null) {
+            final File candidate = new File(here, ".github/ISSUE_TEMPLATE");
+            if (candidate.isDirectory()) {
+                return candidate;
+            }
+            here = here.getParentFile();
+        }
+
+        fail("no .github/ISSUE_TEMPLATE directory above " + System.getProperty("user.dir"));
+        return null;
+    }
+}

--- a/app/src/test/java/dev/wander/android/opentagviewer/ui/importing/WhichHalfOfAnImportFailedTest.java
+++ b/app/src/test/java/dev/wander/android/opentagviewer/ui/importing/WhichHalfOfAnImportFailedTest.java
@@ -1,0 +1,105 @@
+package dev.wander.android.opentagviewer.ui.importing;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.io.EOFException;
+import java.net.SocketTimeoutException;
+
+import dev.wander.android.opentagviewer.util.parse.ZipImporterException;
+
+/**
+ * What the app decides to say about an import that did not finish.
+ *
+ * <p><b>On the JVM, because none of this touches Android</b> - it is an enum and a walk up a
+ * cause chain. See {@code AGENTS.md} rule 13.
+ *
+ * <p>The behaviour under test is the fix for issues
+ * <a href="https://github.com/parawanderer/OpenTagViewer/issues/19">#19</a> and
+ * <a href="https://github.com/parawanderer/OpenTagViewer/issues/26">#26</a>, where every failure
+ * anywhere in the import chain - including the network fetch that runs <i>after</i> the tags are
+ * committed - reported that importing had failed. The structural half of that fix is in
+ * {@code MapsActivity}, which now runs the two as separate chains so a fetch failure cannot
+ * reach this classifier at all. What is left for it to get right is the zip half.
+ */
+public class WhichHalfOfAnImportFailedTest {
+
+    /**
+     * <b>The trap this class replaces.</b>
+     *
+     * <p>{@code reasonOf} answers {@code UNKNOWN} for anything that is not a
+     * {@code ZipImporterException}, which is a perfectly reasonable thing for a function about
+     * zip problems to say - it means "not one of mine". The old caller read it as "an unknown
+     * import problem" and produced a message about importing, which is a different claim and,
+     * for the errors that actually arrived here, a false one.
+     */
+    @Test
+    public void anythingNotDiagnosedIsWorthReportingRatherThanExplaining() {
+        assertEquals(ImportOutcome.REPORT_THE_IMPORT,
+                ImportOutcome.of(new EOFException("Unexpected end of ZLIB input stream")));
+        assertEquals(ImportOutcome.REPORT_THE_IMPORT,
+                ImportOutcome.of(new ZipImporterException("something below us broke")));
+        assertEquals(ImportOutcome.REPORT_THE_IMPORT, ImportOutcome.of(null));
+    }
+
+    /** Every reason the importer can name has advice, so it gets a message and not a bug page. */
+    @Test
+    public void everyNamedReasonIsExplainedInPlace() {
+        for (final ZipImporterException.Reason reason : new ZipImporterException.Reason[] {
+                ZipImporterException.Reason.NOT_A_ZIP,
+                ZipImporterException.Reason.NOT_AN_EXPORT,
+                ZipImporterException.Reason.DAMAGED,
+                ZipImporterException.Reason.NO_TAGS,
+                ZipImporterException.Reason.UNREADABLE }) {
+
+            assertEquals("reason " + reason + " has advice and should not open a bug report",
+                    ImportOutcome.EXPLAIN_THE_FILE,
+                    ImportOutcome.of(new ZipImporterException(reason, "x")));
+        }
+    }
+
+    /** A locked bundle is the ordinary path for a current export, so it is a question. */
+    @Test
+    public void alockedBundleAsksRatherThanFails() {
+        assertEquals(ImportOutcome.ASK_FOR_THE_PASSCODE,
+                ImportOutcome.of(new ZipImporterException(
+                        ZipImporterException.Reason.LOCKED, "locked")));
+        assertEquals(ImportOutcome.ASK_FOR_THE_PASSCODE,
+                ImportOutcome.of(new ZipImporterException(
+                        ZipImporterException.Reason.WRONG_PASSCODE, "nope")));
+    }
+
+    /**
+     * Wrapped, because RxJava hands the subscriber its own exception rather than the thrown one.
+     *
+     * <p>Without the cause walk every real failure would classify as {@code REPORT_THE_IMPORT},
+     * so somebody who picked their holiday photos would be invited to file a bug about it.
+     */
+    @Test
+    public void areasonBuriedInACauseChainStillCounts() {
+        assertEquals(ImportOutcome.EXPLAIN_THE_FILE,
+                ImportOutcome.of(new RuntimeException("rx wrapper", new IllegalStateException(
+                        "another layer",
+                        new ZipImporterException(
+                                ZipImporterException.Reason.NOT_A_ZIP, "a jpeg")))));
+    }
+
+    /**
+     * <b>A network failure is not an import failure, and never was.</b>
+     *
+     * <p>Kept as a test rather than left to the structure, because the structure is what somebody
+     * would undo. If a future change rejoins the two chains, this classifier starts seeing
+     * timeouts again - and it will call them {@code REPORT_THE_IMPORT}, which sends every
+     * Anisette outage to the bug tracker. The assertion documents what the value means so that
+     * reading it back is enough to notice.
+     */
+    @Test
+    public void atimeoutMustNeverReachThisClassifier() {
+        assertEquals(
+                "a timeout classifies as an unexplained *import* failure, which is why fetching"
+                        + " must stay on its own chain",
+                ImportOutcome.REPORT_THE_IMPORT,
+                ImportOutcome.of(new SocketTimeoutException("connect timed out")));
+    }
+}

--- a/app/src/test/java/dev/wander/android/opentagviewer/util/DescribingTheBuildInALogTest.java
+++ b/app/src/test/java/dev/wander/android/opentagviewer/util/DescribingTheBuildInALogTest.java
@@ -1,0 +1,62 @@
+package dev.wander.android.opentagviewer.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * What a log says about the build that wrote it.
+ *
+ * <p><b>Because a bug report's first two questions were both answerable from the log and neither
+ * was answered in it.</b> The issue template asks for the app version and for which exporter made
+ * the bundle; the app knew both and said neither, so reporters guessed at the first and, for the
+ * second, were told to open an export zip full of their tags' private keys to read one line.
+ *
+ * <p>Only the composition is tested here - reading logcat needs a device and is not the part that
+ * can be subtly wrong. Rule 13.
+ */
+public class DescribingTheBuildInALogTest {
+
+    /**
+     * A release is exactly what its version says.
+     *
+     * <p>Built from a tag, so there is nothing a commit would add.
+     */
+    @Test
+    public void areleaseIsNamedByItsVersionAlone() {
+        assertEquals("1.0.5", LogCollectorUtil.describeBuild("1.0.5", null));
+    }
+
+    /**
+     * <b>A build from a checkout is named by its commit, because its version lies.</b>
+     *
+     * <p>{@code versionName} is a committed literal: every commit after 1.0.5 reports 1.0.5, and
+     * {@code build-debug.yml} publishes a debug APK, so this is not hypothetical - somebody can
+     * be running a months-stale version string. Without the commit, "1.0.5-debug" is
+     * indistinguishable between a build made today and one from the release itself.
+     */
+    @Test
+    public void acheckoutBuildCarriesTheCommitItsVersionCannotGive() {
+        final String described = LogCollectorUtil.describeBuild("1.0.5-debug", "25e1679");
+
+        assertTrue("the commit is what identifies this build: " + described,
+                described.contains("25e1679"));
+        assertTrue("and the version is still worth having", described.contains("1.0.5-debug"));
+    }
+
+    /**
+     * Nothing is invented when there is no commit to name.
+     *
+     * <p>A source zip off a release tag is not a checkout - there is no git to ask - and the
+     * version is right again. Printing "unknown" or an empty bracket would be noise dressed as
+     * information.
+     */
+    @Test
+    public void amissingCommitIsAbsentRatherThanGuessedAt() {
+        final String described = LogCollectorUtil.describeBuild("1.0.5", null);
+
+        assertEquals("1.0.5", described);
+        assertTrue("no empty brackets, no 'unknown'", described.indexOf('(') < 0);
+    }
+}

--- a/python/exporter/redact.py
+++ b/python/exporter/redact.py
@@ -98,6 +98,63 @@ RULES: tuple[Rule, ...] = (
 
     # Record and beacon identifiers. Not secret, but unique to one account's accessories.
     Rule("uuid", re.compile(r"\b[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}\b")),
+
+    # ------------------------------------------------------------------ only the app produces these
+    #
+    # The exporter never sees a location or a bundle password, so none of the rules below will
+    # ever fire on a wizard log. They live here anyway, because the alternative is a second
+    # redactor with its own answer to "is my data in this file", and the one thing worse than a
+    # rule that never matches is two sets of rules that disagree.
+
+    # **A location is the most personal thing this app handles**, and four decimal places is
+    # about eleven metres - somebody's home, not a neighbourhood. Labelled first, so the
+    # placeholder keeps the label's meaning.
+    Rule("coordinate", re.compile(r"(?i)\b(?:lat|lon|lng|latitude|longitude)\s*[=:]\s*(-?\d+\.\d+)"), group=1),
+
+    # And unlabelled, as a pair - which is how the app actually writes them:
+    # `String.format("%.4f,%.4f", …)` for a geocoding cache key, and `point=(lat, lon)` for a
+    # tapped marker.
+    #
+    # **Three decimals minimum, and both halves must have them.** Without that this eats version
+    # numbers, durations and byte counts. With it, the shape is specific enough that a false
+    # positive is a pair of precise decimals next to each other, which in a log of this app is
+    # very likely a coordinate anyway.
+    Rule("coordinate", re.compile(r"-?\b\d{1,3}\.\d{3,}\s*,\s*-?\d{1,3}\.\d{3,}\b")),
+
+    # A reverse-geocoded place name: a street, a town, whatever Google or AMap resolved a
+    # coordinate to.
+    #
+    # **Labelled only, because prose has no shape.** "221B Baker St, London NW1 6XE" cannot be
+    # told from any other sentence by regex, and a rule loose enough to catch it would redact
+    # half the log. So this catches it where it is announced as an address and no further -
+    # which is worth having precisely because nothing logs one *today*: the day somebody adds
+    # `Log.d(TAG, "resolved to " + address)`, this is already in place, and nobody has to
+    # remember to come back here.
+    Rule(
+        "place",
+        re.compile(
+            r"(?i)\b(?:address|addressLine|locality|thoroughfare|place|placeName"
+            r"|geocoded(?:\s*to)?)\s*[=:]\s*(.+?)(?=$|[;|]|\s{2,})",
+            re.MULTILINE,
+        ),
+        group=1,
+    ),
+
+    # The code that unlocks an export bundle, as `format_passcode` writes it: three groups of
+    # four from Crockford's base32.
+    #
+    # Grouped form only. The bare twelve characters are indistinguishable from a hash fragment or
+    # half a serial, and redacting every twelve-character uppercase run would take out things the
+    # log is read for. The grouped form is what a person copies, types and pastes.
+    #
+    # **A password in a log is not the same risk as an identifier.** Whoever holds an export and
+    # this can locate the tags in it indefinitely, and unpairing is the only way to withdraw that.
+    Rule("passcode", re.compile(r"\b[0-9A-HJKMNP-TV-Z]{4}-[0-9A-HJKMNP-TV-Z]{4}-[0-9A-HJKMNP-TV-Z]{4}\b")),
+
+    # The number Apple offers to text a code to, which `main.py` prints when it lists the second
+    # factor methods: `Option: SMS (+44 7700 900123)`. Partly masked by Apple already, and the
+    # unmasked digits are still somebody's phone number.
+    Rule("phone", re.compile(r"(?i)\bSMS\s*\(([^)]+)\)"), group=1),
 )
 
 

--- a/python/test/test_redact.py
+++ b/python/test/test_redact.py
@@ -72,6 +72,91 @@ class TestWhatItRemoves:
         assert "725A989D" not in clean("Record 725A989D-D871-49A7-B2FE-948C24F356AB carries a field")
 
 
+class TestTheThingsOnlyTheAppProduces:
+    """
+    Locations, place names, bundle passwords and the number Apple texts a code to.
+
+    None of these appear in a wizard log - the exporter never sees a coordinate or a password.
+    They are here rather than in a second redactor because two sets of rules mean two answers to
+    "is my data in this file", and only one of them would get maintained.
+    """
+
+    @pytest.mark.parametrize("line", [
+        "tapped, point=(51.5074, -0.1278)",
+        "Error reverse geocoding location: 51.5074, -0.1278",
+        "Got geocoding data for 51.5074,-0.1278 (rounded) from cache!",
+        "lat=51.5074 lon=-0.1278",
+        "latitude: 51.5074, longitude: -0.1278",
+    ])
+    def test_a_coordinate_is_somebodys_home(self, line):
+        # Four decimal places is about eleven metres. This is the most personal thing the app
+        # handles, and it is the one identifier that is not a name or a number but a place.
+        out = clean(line)
+
+        assert "51.5074" not in out
+        assert "0.1278" not in out
+
+    def test_the_line_is_still_readable_around_it(self):
+        out = clean("tapped, point=(51.5074, -0.1278)")
+
+        assert out.startswith("tapped, point=(")
+        assert out.endswith(")")
+
+    def test_a_resolved_place_name(self):
+        # Nothing logs one today. The rule is here so that the day somebody adds
+        # `Log.d(TAG, "resolved to " + address)`, nobody has to remember to come back here.
+        out = clean("resolved to address=221B Baker Street, London NW1 6XE")
+
+        assert "Baker Street" not in out
+        assert "NW1" not in out
+
+    def test_a_bundle_passcode(self):
+        # Whoever holds an export and its code can locate those tags indefinitely - unpairing is
+        # the only way to withdraw it. A password in a log is not the same risk as an identifier.
+        out = clean("Trying passcode 4RTZ-9KMX-P2W7 against the bundle")
+
+        assert "4RTZ" not in out
+        assert "P2W7" not in out
+
+    def test_the_number_apple_would_text(self):
+        assert "900123" not in clean("Option: SMS (+44 7700 900123)")
+
+
+class TestItDoesNotEatTheLogLookingForCoordinates:
+    """
+    A coordinate is two decimals side by side, and so is half of everything else in a log.
+
+    This is the rule most likely to over-match, and over-matching is not a cosmetic problem: a
+    redactor that removes the durations and version numbers is one people stop using, and then
+    they post the raw log instead.
+    """
+
+    @pytest.mark.parametrize("line", [
+        # **The one that actually exercises the boundary.** Two adjacent floats is the shape
+        # the rule keys on; what saves this line is that neither has three decimal places.
+        # Without a case like it the guard passes for the wrong reason - the first version of
+        # this list was floats with words between them, which the rule would never have matched
+        # however loose it was, and loosening it to \d+ left every test green.
+        "Render scale factors 1.25, 0.75 applied",
+        "Fetch took 1.25 seconds, parse took 0.5",
+        "FindMy 0.9.1, anisette 3.0",
+        "Key search window is 290 indices wide",
+        "Zone ProtectedCloudStorage fully synced after page 1",
+        "Reading the Manatee view with classA: 64 bytes",
+        "escrowed 2024-03-11",
+    ])
+    def test_what_is_not_a_coordinate(self, line):
+        assert clean(line) == line
+
+    @pytest.mark.parametrize("line", [
+        "Beacon ID F2LX9QABCDEF has 12 reports",
+        "SHA256 fingerprint check passed",
+        "version 1.1.0-beta",
+    ])
+    def test_what_is_not_a_passcode(self, line):
+        assert clean(line) == line
+
+
 class TestWhatItKeeps:
     """
     A log that cannot be read is not a safer log, it is a second round trip.


### PR DESCRIPTION
## The app told four reporters their import failed. It hadn't.

Picking a zip started **one** Rx chain that parsed the file, committed the tags to the database,
and then went to Apple for their locations. One error handler covered all three, so a network
timeout, an expired session or a bad Anisette server — none of which are consulted while reading
a zip — all reported:

> Error occurred while importing new devices. Try to restart the app and retry.

…for an import that had already succeeded and whose tags were visible in the device list.

[#19](https://github.com/parawanderer/OpenTagViewer/issues/19) and
[#26](https://github.com/parawanderer/OpenTagViewer/issues/26) are 34 comments of people working
that out for themselves. Three of them fixed their "import error" by changing their **Anisette
server**, which is the proof: nothing about Anisette is touched while parsing a file.

Three things were wrong, in order of cost:

1. **It named the wrong phase.** The import was done and committed.
2. **The advice could not work.** Restarting does not re-run a failed fetch, and the import it
   suggested retrying had succeeded.
3. **It threw away the diagnosis.** The real exception went to `Log.e` and nowhere a user could
   see it — which is why none of those reports can be attributed to a cause.

## What changed

**The chain is split at the commit point.** Reading the zip and storing the tags is one
operation; asking Apple where they are is another, started only once the first has succeeded. A
phase marker would have fixed the message; splitting makes the wrong message impossible to write,
because there is no longer one handler that could say it.

Each half now says its own thing:

| | |
| --- | --- |
| **The zip could not be read** | a named reason where there is one, and otherwise a page that can be reported |
| **The tags arrived, the locations did not** | *"Your tags are imported"* — they are on the phone and stay there — plus the real exception, Anisette named as the likely cause, and the setting that fixes it |

**No bug report on the fetch side, deliberately.** That half fails when somebody's server is down
or a phone is on a train, and it retries by itself every minute. Inviting a report each time
would fill the tracker with weather. The bug page belongs to the half that reads the zip.

### A page for a failure nobody can act on

`UnhandledProtocolError` and anything reaching `REASON_UNKNOWN` now land on a page carrying the
three things a report needs and a person otherwise has to hunt for: which build this is, which
exporter made their bundle, and the failure verbatim. Never for a rejected passcode, an account
with no tags, a network that is down, or a session wanting a code — each has advice this page
would be strictly worse than.

**Get the log** asks which of two things is wanted, because they are not the same thing: copy it
for pasting into the issue form's log box, or save it through the document picker to attach. It
shipped as a share sheet, which serves neither — with text and no stream, Drive and Files do not
appear as targets at all.

### Both routes out of the app now clean the log

Settings → **Export Logs** wrote a raw logcat while the error page's copy went through the
redactor. Two answers from one app to *"is my Apple ID in this file"*. Same rule on both now, and
the same refusal: if redaction cannot run, **nothing is written** rather than a raw log handed to
somebody on their way to attaching it somewhere public.

`redact.py` gains four rules for things only the app produces — coordinates (labelled and as bare
pairs, since the app writes `%.4f,%.4f`), reverse-geocoded place names, bundle passcodes, and the
phone number `main.py` prints when it lists second-factor methods. They live with the exporter's
rules rather than in a second redactor, because two sets of rules mean two answers and only one
of them would get maintained.

### Which exporter made a bundle, in both places it is asked

The issue template asks, and the only place the answer lived was inside the export zip — a file
holding the private keys to somebody's tags, which the same template tells them in bold not to
open.

- **Information screen** lists every distinct producer, newest-used first. Not the most recent
  one: importing twice is ordinary, and naming one producer implies it accounts for every tag on
  the phone.
- **A tag's own page** says which exporter made *that* tag. When a report is about one tag out of
  twelve, the aggregate cannot tell you that. The row was nearly free — the page already read the
  same `Import` for its "Exported by" and "Exported at" rows.

## Testing

| | |
| --- | --- |
| JVM | `WhichHalfOfAnImportFailedTest`, `DescribingTheBuildInALogTest`, `TheIssueLinkPointsSomewhereRealTest` |
| Python | 42 in `test_redact.py`, including the false-positive guards for the coordinate rule |
| Instrumented | the error page, both import halves, the dialog's two dismissal routes, the DAO, the device page, the Information screen |

Every new assertion was mutation-checked. Two were decorations and are fixed:

- `thesharedLogIsTheRedactedOne` asserted only that *a chooser opened* — its own comment claimed
  otherwise. It would have stayed green while shipping an unredacted log, which is the one
  outcome here that cannot be taken back. It now asserts on the payload, and bypassing redaction
  reddens exactly the three tests that should go red.
- A coordinate false-positive guard used floats that were not adjacent, so the rule would never
  have matched them however loose it got — loosening `\d{3,}` to `\d+` left all 41 green. Replaced
  with a case that sits on the boundary.

`ImportDao` gains a query and no schema change, so there is no migration.

## Not verified

The Apple-facing paths are unchanged by this, but nothing here was exercised against a real
account or a real failing Anisette server — the fetch-failure dialog was driven with a fabricated
exception, not a live outage. The claim being made is about which message appears for which
failure, not about the failures themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
