### PR TITLE
Say when Apple has stopped accepting the sign-in, instead of offering a retry

### DIFF
--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/python/icloud/FakeICloudService.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/python/icloud/FakeICloudService.java
@@ -101,6 +101,29 @@ public final class FakeICloudService implements ICloudService {
         return fake;
     }
 
+    /**
+     * Apple refuses the stored password, on whichever call is made first.
+     *
+     * <p><b>Set on every entry point, because the point is that they behave alike.</b> The real
+     * failure comes out of the SRP exchange, which any call needing the keychain performs - so a
+     * fake that only failed one of them would let a caller that mishandles the others pass.
+     */
+    public static FakeICloudService whereAppleRefusesTheCredentials() {
+        final FakeICloudService fake = new FakeICloudService();
+        final ICloudException refused = new ICloudException(
+                ICloudFailure.CREDENTIALS_REJECTED,
+                "InvalidCredentialsError: Password authentication failed:"
+                        + " Enter the correct password for this Apple Account.");
+
+        fake.openFailsWith = refused;
+        fake.optionsFailsWith = refused;
+        fake.unlockFailsWith = refused;
+        fake.fetchFailsWith = refused;
+        fake.joinFailsWith = refused;
+        fake.resumeFailsWith = refused;
+        return fake;
+    }
+
     /** Nothing reported usable at all, which reads as a service having a bad day. */
     public static FakeICloudService whereTheServiceIsUnsure() {
         final FakeICloudService fake = new FakeICloudService();

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/icloud/EveryPathAsksForAFreshSignInTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/icloud/EveryPathAsksForAFreshSignInTest.java
@@ -1,0 +1,304 @@
+package dev.wander.android.opentagviewer.ui.icloud;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import android.app.Instrumentation.ActivityResult;
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import dev.wander.android.opentagviewer.AppleLoginActivity;
+import dev.wander.android.opentagviewer.DeviceInfoActivity;
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.FetchFromICloudActivity;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.db.AccountBeaconsForTests;
+import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
+import dev.wander.android.opentagviewer.db.repo.KeychainMembershipRepository;
+import dev.wander.android.opentagviewer.db.room.OpenTagViewerDatabase;
+import dev.wander.android.opentagviewer.db.room.entity.BeaconNamingRecord;
+import dev.wander.android.opentagviewer.db.room.entity.OwnedBeacon;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.python.icloud.AccountRefresher;
+import dev.wander.android.opentagviewer.python.icloud.FakeICloudService;
+import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
+
+/**
+ * Every way this app talks to the account, when Apple refuses the stored password.
+ *
+ * <p><b>The behaviour has to be the same wherever it surfaces, and it was not.</b> Three paths
+ * reach the same wall - opening the iCloud device list, renaming a tag (which writes to the
+ * account), and the six-hourly background read - and each interpreted the failure for itself.
+ * Opening the list landed on "worth trying again later", which is false for a session that can
+ * never work again; the background read logged a warning and carried on.
+ *
+ * <p>{@code WhichFailuresNeedAFreshSignInTest} proves the decision on the JVM. This proves the
+ * callers act on it, which is the half a shared predicate does not guarantee: nothing stops a
+ * fourth screen being written that never asks.
+ *
+ * <p>None of it is reachable on a real account on demand - it needs Apple to refuse a password
+ * that was working - so {@code FakeICloudService.whereAppleRefusesTheCredentials} sets the
+ * refusal on every entry point at once, deliberately: a fake that failed only one call would let
+ * a caller mishandling the others pass.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class EveryPathAsksForAFreshSignInTest {
+
+    private static final String A_TAG = "refused-credentials-tag";
+    private static final String A_NAME = "Refused";
+
+    private static final String A_PLIST = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<plist version=\"1.0\"><dict>"
+            + "<key>batteryLevel</key><integer>1</integer>"
+            + "<key>identifier</key><string>" + A_TAG + "</string>"
+            + "<key>model</key><string></string>"
+            + "<key>pairingDate</key><date>2025-02-27T20:03:32Z</date>"
+            + "<key>privateKey</key><dict><key>key</key><dict>"
+            + "<key>data</key><data>bm90LWEtcmVhbC1rZXk=</data></dict></dict>"
+            + "<key>productId</key><integer>21760</integer>"
+            + "<key>stableIdentifier</key><array><string>2001~#0~#A0</string></array>"
+            + "<key>systemVersion</key><string>2.0.73</string>"
+            + "<key>vendorId</key><integer>76</integer>"
+            + "</dict></plist>";
+
+    private static final String A_NAMING_RECORD =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><plist version=\"1.0\"><dict>"
+                    + "<key>identifier</key><string>" + A_TAG + "</string>"
+                    + "<key>associatedBeacon</key><string>" + A_TAG + "</string>"
+                    + "<key>name</key><string>" + A_NAME + "</string>"
+                    + "</dict></plist>";
+
+    private ActivityScenario<?> scenario;
+    private OpenTagViewerDatabase db;
+
+    @Before
+    public void refuseEverything() {
+        final Context context = getInstrumentation().getTargetContext();
+        this.db = OpenTagViewerDatabase.getInstance(context);
+
+        AccountBeaconsForTests.forgetThemAll();
+        this.forgetTheTag();
+        this.forgetTheMembership();
+
+        AppDependencies.replaceICloud(FakeICloudService::whereAppleRefusesTheCredentials);
+
+        Intents.init();
+        // The login screen is the destination under test, so it is stubbed rather than launched:
+        // starting it for real would sit on a sign-in form waiting for an Apple password.
+        intending(hasComponent(AppleLoginActivity.class.getName()))
+                .respondWith(new ActivityResult(Activity.RESULT_CANCELED, null));
+    }
+
+    @After
+    public void putItAllBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        Intents.release();
+        AppDependencies.reset();
+        AccountBeaconsForTests.forgetThemAll();
+        this.forgetTheTag();
+        this.forgetTheMembership();
+    }
+
+    private void forgetTheTag() {
+        this.db.ownedBeaconDao().delete(OwnedBeacon.builder().id(A_TAG).build());
+        this.db.beaconNamingRecordDao().delete(BeaconNamingRecord.builder().id(A_TAG).build());
+    }
+
+    /**
+     * A stored membership, without which a rename never reaches Apple at all.
+     *
+     * <p>{@code AccessoryRenamer} refuses with {@code MEMBERSHIP_UNUSABLE} before opening
+     * anything when this app is not a keychain member - correctly, since it could not write - so
+     * a test without one asserts nothing about credentials being refused. The first version of
+     * this had no membership and failed for that reason, which reads exactly like the fix not
+     * working.
+     */
+    private void givenTheAccountIsLinked() {
+        new KeychainMembershipRepository(
+                UserAuthDataStore.getInstance(getInstrumentation().getTargetContext()),
+                new AppCryptographyUtil())
+                .store(new dev.wander.android.opentagviewer.python.icloud.KeychainMembership(
+                        "{\"peer_id\":\"peer-ours\"}", "ZW50cm9weQ==", "a-passcode",
+                        "a-label", 2))
+                .blockingAwait();
+    }
+
+    private void forgetTheMembership() {
+        new KeychainMembershipRepository(
+                UserAuthDataStore.getInstance(getInstrumentation().getTargetContext()),
+                new AppCryptographyUtil())
+                .forget().blockingAwait();
+    }
+
+    private void seedAnAccountTag() {
+        // fromAccount, because renaming one of those is what writes to iCloud. A file-imported
+        // tag renames locally and never touches the account, so it could not reach this failure.
+        this.db.ownedBeaconDao().insertAll(OwnedBeacon.builder()
+                .id(A_TAG).content(A_PLIST).version("account")
+                .fromAccount(true).isRemoved(false).build());
+        this.db.beaconNamingRecordDao().insertAll(BeaconNamingRecord.builder()
+                .id(A_TAG).content(A_NAMING_RECORD).version("account").isRemoved(false).build());
+    }
+
+    /**
+     * An accessory rather than one of the owner's own devices, said definitely.
+     *
+     * <p><b>Null is not False here, and that is the whole reason this exists.</b> The account
+     * rename is gated on {@code isFromAccount() && Boolean.FALSE.equals(isOwnDevice)} - so a
+     * describer that cannot decide leaves the rename local, iCloud is never called, and this
+     * test passes for the wrong reason or fails for one. The real describer runs Python against
+     * a fixture plist and is under no obligation to be sure.
+     */
+    private static void treatTheTagAsAnAccessory() {
+        AppDependencies.replaceHardwareDescriber(
+                new dev.wander.android.opentagviewer.python.HardwareDescriber() {
+                    @Override
+                    public String describe(final String plistXml) {
+                        return "AirTag";
+                    }
+
+                    @Override
+                    public String whereToLookUp(final String plistXml) {
+                        return null;
+                    }
+
+                    @Override
+                    public Boolean isOwnDevice(final String plistXml) {
+                        return Boolean.FALSE;
+                    }
+                });
+    }
+
+    /** Whatever the path, this is what has to happen. */
+    private void assertItAsksForAFreshSignIn() {
+        Eventually.check(() -> intended(allOf(
+                hasComponent(AppleLoginActivity.class.getName()),
+                hasExtra(AppleLoginActivity.EXTRA_SESSION_EXPIRED, true))));
+    }
+
+    /**
+     * <b>Opening the iCloud device list. The path that reported this.</b>
+     *
+     * <p>It used to land on the retry screen, which says the service is having a bad day. It is
+     * not: the same password is re-sent on every attempt and refused every time.
+     */
+    @Test
+    public void aopeningTheICloudListAsksForAFreshSignIn() {
+        this.scenario = ActivityScenario.launch(FetchFromICloudActivity.class);
+
+        this.assertItAsksForAFreshSignIn();
+    }
+
+    /**
+     * <b>And the session it could not use is cleared, not kept.</b>
+     *
+     * <p>Keeping one Apple refuses means the next screen to try meets the same wall with no idea
+     * why - and the sign-in form would then be prefilled from a session that is about to be
+     * replaced anyway.
+     */
+    @Test
+    public void btherefusedSessionIsForgotten() {
+        this.scenario = ActivityScenario.launch(FetchFromICloudActivity.class);
+        this.assertItAsksForAFreshSignIn();
+
+        final Context context = getInstrumentation().getTargetContext();
+        Eventually.check(() -> assertTrue("the refused session was kept",
+                new dev.wander.android.opentagviewer.db.repo.UserAuthRepository(
+                        UserAuthDataStore.getInstance(context), new AppCryptographyUtil())
+                        .getUserAuth().blockingFirst().isEmpty()));
+    }
+
+    /**
+     * <b>Renaming a tag, which writes to the account.</b>
+     *
+     * <p>Without this it says the rename failed - so somebody tries a shorter name, or a
+     * different one, for a session that cannot write anything at all.
+     */
+    @Test
+    public void crenamingATagAsksForAFreshSignIn() {
+        this.seedAnAccountTag();
+        this.givenTheAccountIsLinked();
+        treatTheTagAsAnAccessory();
+
+        final Intent intent = new Intent(
+                getInstrumentation().getTargetContext(), DeviceInfoActivity.class);
+        intent.putExtra("beaconId", A_TAG);
+        this.scenario = ActivityScenario.launch(intent);
+
+        // Driven the same way RenamingWritesToTheAccountTest drives it, so this exercises the
+        // path a person takes rather than a method call that happens to be reachable.
+        Eventually.check(() -> onView(withId(R.id.device_settings_name))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.device_settings_name)).perform(click());
+
+        Eventually.check(() -> onView(withId(R.id.device_name_input)).inRoot(isDialog())
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.device_name_input)).inRoot(isDialog())
+                .perform(replaceText("Something Else"));
+        onView(withText(R.string.confirm)).inRoot(isDialog()).perform(click());
+
+        this.assertItAsksForAFreshSignIn();
+    }
+
+    /**
+     * <b>And the background read, which has no screen of its own.</b>
+     *
+     * <p>It must <i>not</i> act: clearing somebody's session out from under whatever they are
+     * doing, from a job nobody asked for, is worse than waiting for the next thing that needs the
+     * account. What it must do is leave the stored tags alone rather than treating a refusal as
+     * a membership that has gone bad - which would cost a device passcode to rejoin, for a
+     * problem rejoining cannot fix.
+     */
+    @Test
+    public void dthebackgroundReadLeavesEverythingAlone() {
+        final Context context = getInstrumentation().getTargetContext();
+        final KeychainMembershipRepository memberships = new KeychainMembershipRepository(
+                UserAuthDataStore.getInstance(context), new AppCryptographyUtil());
+
+        this.seedAnAccountTag();
+
+        final List<String> held = new AccountRefresher(
+                memberships,
+                new dev.wander.android.opentagviewer.db.repo.BeaconRepository(this.db))
+                .refresh()
+                .onErrorReturnItem(List.of())
+                .blockingFirst();
+
+        assertEquals("a refusal is not a list of tags", List.of(), held);
+
+        // The tag it could not re-read is still there, and still the user's.
+        assertTrue("the stored tag was dropped over a failed read",
+                this.db.ownedBeaconDao().getAll().stream()
+                        .anyMatch(beacon -> A_TAG.equals(beacon.id)));
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/importing/WalkingThroughAnImportThatFailedTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/importing/WalkingThroughAnImportThatFailedTest.java
@@ -226,22 +226,32 @@ public class WalkingThroughAnImportThatFailedTest {
         // it is also the thing actually being claimed.
         host.onActivity(activity -> dialog[0] = ImportedButNotLocatedDialog.show(
                 activity, A_FETCH_CAUSE, settingsOpened::incrementAndGet));
-        Eventually.check(() -> assertTrue("the dialog never appeared", dialog[0].isShowing()));
 
-        // perform, not a bare pressBack: if the dialog has not taken focus yet the key reaches
-        // the activity instead and finishes it, and Espresso reports NoActivityResumedException
-        // from the same call that would have worked a moment later.
+        // **Focus, not isShowing().** `show()` makes isShowing() true immediately, before the
+        // dialog's window has taken focus - and a back press in that gap goes to the activity,
+        // finishes it, and throws NoActivityResumedException from the very call that would have
+        // worked a moment later. Waiting on isShowing() looked like the right guard and is not;
+        // it passed locally for hours and failed in CI, which is slower and loses the race more
+        // often.
+        Eventually.check(() -> assertTrue("the dialog never took focus", hasFocus(dialog[0])));
+
         Eventually.perform("back", () -> !dialog[0].isShowing(), Espresso::pressBack);
 
         host.onActivity(activity -> dialog[0] = ImportedButNotLocatedDialog.show(
                 activity, A_FETCH_CAUSE, settingsOpened::incrementAndGet));
-        Eventually.check(() -> assertTrue("the dialog never reappeared", dialog[0].isShowing()));
+        Eventually.check(() -> assertTrue("the dialog never reappeared", hasFocus(dialog[0])));
 
         onView(withText(context.getString(R.string.ok))).inRoot(isDialog()).perform(click());
         Eventually.check(() -> assertFalse("OK did not dismiss the dialog",
                 dialog[0].isShowing()));
 
         assertEquals("dismissing must not open settings", 0, settingsOpened.get());
+    }
+
+    /** Whether the dialog's own window is the one that would receive a key press. */
+    private static boolean hasFocus(final AlertDialog dialog) {
+        return dialog.getWindow() != null
+                && dialog.getWindow().getDecorView().hasWindowFocus();
     }
 
     /**

--- a/app/src/main/java/dev/wander/android/opentagviewer/DeviceInfoActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/DeviceInfoActivity.java
@@ -73,6 +73,8 @@ import dev.wander.android.opentagviewer.python.AppDependencies;
 import dev.wander.android.opentagviewer.ui.BeaconIcon;
 import dev.wander.android.opentagviewer.python.HardwareDescriber;
 import dev.wander.android.opentagviewer.python.icloud.AccessoryRenamer;
+import dev.wander.android.opentagviewer.python.icloud.ICloudFailures;
+import dev.wander.android.opentagviewer.ui.login.SignInAgain;
 import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Observable;
@@ -466,6 +468,17 @@ public class DeviceInfoActivity extends AppCompatActivity {
                             redraw.run();
                         },
                         error -> {
+                            if (ICloudFailures.meansSignInAgain(error)) {
+                                // **The same wall as the iCloud list and the background read.**
+                                // A rename writes to the account, so a refused password stops it
+                                // for the same reason - and "renaming failed" would send somebody
+                                // to try a different name for a session that cannot write at all.
+                                Log.w(TAG, "Apple refused the stored credentials during a rename;"
+                                        + " asking for a fresh sign-in", error);
+                                SignInAgain.from(this);
+                                return;
+                            }
+
                             Log.e(TAG, "Could not rename " + this.beaconId + " in iCloud", error);
                             this.showRenameInProgress(false);
                             this.sayTheRenameDidNotHappen();

--- a/app/src/main/java/dev/wander/android/opentagviewer/FetchFromICloudActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/FetchFromICloudActivity.java
@@ -45,6 +45,7 @@ import dev.wander.android.opentagviewer.python.icloud.EscrowPasscode;
 import dev.wander.android.opentagviewer.python.icloud.ICloudAccessory;
 import dev.wander.android.opentagviewer.python.icloud.ICloudException;
 import dev.wander.android.opentagviewer.python.icloud.ICloudFailure;
+import dev.wander.android.opentagviewer.ui.login.SignInAgain;
 import dev.wander.android.opentagviewer.python.icloud.ICloudFetch;
 import dev.wander.android.opentagviewer.python.icloud.ICloudService;
 import dev.wander.android.opentagviewer.python.icloud.KeychainMembership;
@@ -58,6 +59,7 @@ import dev.wander.android.opentagviewer.util.android.PropertiesUtil;
 import dev.wander.android.opentagviewer.ui.compat.WindowPaddingUtil;
 import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
 import dev.wander.android.opentagviewer.util.android.WebLink;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 
 /**
@@ -664,6 +666,17 @@ public class FetchFromICloudActivity extends AppCompatActivity {
             case NOT_SIGNED_IN:
                 Log.e(TAG, "The account is not usable, so this screen has nothing to do");
                 this.finish();
+                break;
+
+            case CREDENTIALS_REJECTED:
+                // **Not the retry screen, which is where this used to land.** Apple refused
+                // the stored password, and a keychain session needs a fresh token rather than the
+                // one held - so "worth trying again later" is false and every attempt fails alike.
+                // The stored blob goes with it - keeping one that cannot work means the next
+                // screen to use it meets the same wall with no idea why.
+                Log.w(TAG, "Apple refused the stored credentials; signing out so they can be"
+                        + " established again");
+                SignInAgain.from(this);
                 break;
 
             case SERVICE_UNSURE:

--- a/app/src/main/java/dev/wander/android/opentagviewer/python/icloud/AccountRefresher.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/python/icloud/AccountRefresher.java
@@ -91,10 +91,25 @@ public final class AccountRefresher {
      * themselves.
      */
     private Observable<List<String>> recoverFrom(final Throwable error) {
-        final boolean membershipIsDead = error instanceof ICloudException
-                && ((ICloudException) error).getFailure() == ICloudFailure.MEMBERSHIP_UNUSABLE;
+        final ICloudFailure failure = error instanceof ICloudException
+                ? ((ICloudException) error).getFailure() : ICloudFailure.UNKNOWN;
 
-        if (!membershipIsDead) {
+        if (ICloudFailures.meansSignInAgain(error)) {
+            // **Said once, loudly, rather than every six hours quietly.** Apple refused the
+            // stored password, so nothing here will ever succeed again until it is replaced -
+            // and this read is silent by design, which means without this the tag list simply
+            // stops matching Find My and nobody is ever told.
+            //
+            // Not acted on here, though: this runs in the background with no screen of its own,
+            // and clearing somebody's session out from under whatever they are doing is worse
+            // than waiting for the next thing that needs it. The screens that use the account
+            // recognise the same failure and offer to sign in again.
+            Log.w(TAG, "Apple refused the stored credentials. The account cannot be re-read"
+                    + " until the user signs in again; their stored tags are untouched.", error);
+            return Observable.just(List.of());
+        }
+
+        if (failure != ICloudFailure.MEMBERSHIP_UNUSABLE) {
             Log.w(TAG, "Could not re-read the Apple account; leaving the stored tags alone", error);
             return Observable.just(List.of());
         }

--- a/app/src/main/java/dev/wander/android/opentagviewer/python/icloud/ICloudFailure.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/python/icloud/ICloudFailure.java
@@ -63,6 +63,25 @@ public enum ICloudFailure {
      * account - which is how somebody revokes this app - so the way forward is to ask for a
      * device passcode and join again, not to try the same stored keys a second time.
      */
+    /**
+     * Apple refused the stored password. Only signing in again fixes it.
+     *
+     * <p><b>Permanent, which is what separates it from everything else here.</b> The account
+     * state does carry a password - FindMy.py serialises it - so this is Apple declining what was
+     * sent rather than the app having nothing to send. The wording comes straight from Apple and
+     * says "enter the correct password"; nobody typed one.
+     *
+     * <p>It cannot be worked around: opening a keychain session calls {@code request_pet}, which
+     * re-runs the password exchange and raises, unlike {@code _fresh_pet} which makes do with the
+     * token already held. Keychain operations need a genuinely fresh one.
+     *
+     * <p>Left unclassified it reads as an outage and is retried every six hours forever, while
+     * the tag list quietly stops matching Find My and nothing on screen says why. That is the
+     * same mistake as an import error that named the wrong phase: a permanent failure handled as
+     * weather.
+     */
+    CREDENTIALS_REJECTED,
+
     MEMBERSHIP_UNUSABLE,
 
     /** An accessory was asked for that this session never fetched. Also a bug in the screen. */
@@ -103,6 +122,7 @@ public enum ICloudFailure {
             case "passcode_rejected": return PASSCODE_REJECTED;
             case "no_such_record": return NO_SUCH_RECORD;
             case "not_unlocked": return NOT_UNLOCKED;
+            case "credentials_rejected": return CREDENTIALS_REJECTED;
             case "membership_unusable": return MEMBERSHIP_UNUSABLE;
             case "no_such_accessory": return NO_SUCH_ACCESSORY;
             case "not_an_accessory": return NOT_AN_ACCESSORY;

--- a/app/src/main/java/dev/wander/android/opentagviewer/python/icloud/ICloudFailures.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/python/icloud/ICloudFailures.java
@@ -1,0 +1,60 @@
+package dev.wander.android.opentagviewer.python.icloud;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+/**
+ * What a failure from the account means for the screen that hit it.
+ *
+ * <p><b>One place decides, because three screens can hit the same wall.</b> Reading the account
+ * in the background, opening the iCloud device list, and renaming a tag all go through the same
+ * bridge - so a failure classified in Python and then interpreted three times gets interpreted
+ * three different ways. The one that turned up in practice was rejected credentials landing on
+ * the "worth trying again later" screen, which is false for a session that can never work again.
+ */
+public final class ICloudFailures {
+
+    private ICloudFailures() {}
+
+    /**
+     * Whether the only remedy is a fresh sign-in.
+     *
+     * <p><b>True for exactly one failure today, and phrased as a question rather than a
+     * comparison so it stays true when there are two.</b> Apple refusing the stored password is
+     * permanent: the account state carries the password, the app re-sends it, and Apple declines
+     * - so every retry is the same rejected exchange. Opening a keychain session needs a fresh
+     * token rather than the one already held, which is why nothing can paper over it.
+     *
+     * <p>Everything else here is either recoverable in place ({@code PASSCODE_REJECTED}), an
+     * honest end state ({@code NOTHING_TO_RECOVER_FROM}), or genuinely worth retrying
+     * ({@code SERVICE_UNSURE}) - and sending somebody to sign in again for one of those would
+     * cost them a sign-in for nothing.
+     *
+     * <p>Unwraps the cause chain: these travel out through RxJava, which hands the subscriber its
+     * own exception rather than the thrown one.
+     */
+    public static boolean meansSignInAgain(final Throwable error) {
+        return failureOf(error) == ICloudFailure.CREDENTIALS_REJECTED;
+    }
+
+    /**
+     * The failure behind a throwable, wherever it is in the chain, or {@code UNKNOWN}.
+     *
+     * <p><b>Guarded with a set rather than a self-comparison.</b> Java refuses
+     * {@code initCause(this)}, so the obvious guard - stop when a cause is itself - looks
+     * sufficient and does nothing: that shape cannot be built. A two-element cycle can, and the
+     * first version of this walked one forever, on whichever thread happened to be reporting an
+     * error at the time.
+     */
+    public static ICloudFailure failureOf(final Throwable error) {
+        final Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+
+        for (Throwable cause = error; cause != null && seen.add(cause); cause = cause.getCause()) {
+            if (cause instanceof ICloudException) {
+                return ((ICloudException) cause).getFailure();
+            }
+        }
+        return ICloudFailure.UNKNOWN;
+    }
+}

--- a/app/src/main/java/dev/wander/android/opentagviewer/ui/login/SignInAgain.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/ui/login/SignInAgain.java
@@ -1,0 +1,94 @@
+package dev.wander.android.opentagviewer.ui.login;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.util.Log;
+
+import dev.wander.android.opentagviewer.AppleLoginActivity;
+import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
+import dev.wander.android.opentagviewer.db.repo.UserAuthRepository;
+import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+/**
+ * Clearing a session Apple will not accept, and sending the user to make a new one.
+ *
+ * <p><b>Here because three screens reach the same wall.</b> The iCloud device list, a rename that
+ * writes to the account, and the silent background read all go through one bridge - and a
+ * recovery written separately at each would drift, which is how one of them ends up on a "try
+ * again later" screen for a session that can never work again.
+ *
+ * <p>{@code MapsActivity} keeps its own variant deliberately: it also calls
+ * {@code PythonAppleService.forget()} to close the Apple session's sockets, and it answers a
+ * different failure - an account blob that will not restore at all, rather than credentials Apple
+ * declined. Merging them would fold two causes into one recovery.
+ */
+public final class SignInAgain {
+
+    private static final String TAG = SignInAgain.class.getSimpleName();
+
+    private SignInAgain() {}
+
+    /**
+     * Forget the stored account, then open the sign-in screen saying why.
+     *
+     * <p><b>The address is read before the account is cleared</b>, because clearing is what
+     * destroys it - and a prefilled field is most of what makes signing in again bearable.
+     *
+     * <p>The activity finishes either way. Leaving somebody on a screen backed by a session that
+     * has just been deleted is worse than closing it: nothing on it can work, and the next thing
+     * they press would fail for a reason the screen cannot explain.
+     *
+     * @return the subscription, so a caller that tracks them can dispose of it
+     */
+    public static Disposable from(final Activity activity) {
+        final UserAuthRepository repo = new UserAuthRepository(
+                UserAuthDataStore.getInstance(activity.getApplicationContext()),
+                new AppCryptographyUtil());
+
+        final String email = addressOrNull(repo);
+
+        return repo.clearUser()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        () -> open(activity, email),
+                        error -> {
+                            // At worst they sign out by hand. Not worth stranding them here.
+                            Log.e(TAG, "Could not clear the refused session", error);
+                            activity.finish();
+                        });
+    }
+
+    private static void open(final Activity activity, final String email) {
+        final Intent intent = new Intent(activity, AppleLoginActivity.class);
+        intent.putExtra(AppleLoginActivity.EXTRA_SESSION_EXPIRED, true);
+        if (email != null) {
+            intent.putExtra(AppleLoginActivity.EXTRA_PREFILL_EMAIL, email);
+        }
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+
+        activity.startActivity(intent);
+        activity.finish();
+    }
+
+    /**
+     * The signed-in address, or null if it cannot be read.
+     *
+     * <p>Deliberately incurious about why it might not be: this runs while recovering from a
+     * session that has already failed, and a missing address costs a prefilled field rather than
+     * the recovery.
+     */
+    private static String addressOrNull(final UserAuthRepository repo) {
+        try {
+            return repo.getUserAuth().blockingFirst()
+                    .map(stored -> stored.getUser().getAccount().getInfo().getAccountName())
+                    .orElse(null);
+        } catch (final Exception e) {
+            Log.w(TAG, "Could not read the signed-in address to prefill the login screen", e);
+            return null;
+        }
+    }
+}

--- a/app/src/main/python/icloud_bridge.py
+++ b/app/src/main/python/icloud_bridge.py
@@ -37,11 +37,13 @@ from __future__ import annotations
 import base64
 import json
 import plistlib
+import sys
 import traceback
 from typing import Any
 
 import identity as app_identity
 from exporter import icloud
+from findmy.errors import InvalidCredentialsError
 from findmy.keychain.enrolment import DeviceDescription
 from findmy.keychain.join import JoinedPeer
 from findmy.keychain.recovery import RecoveryError
@@ -73,6 +75,28 @@ REASON_PASSCODE_REJECTED = "passcode_rejected"
 
 REASON_NOT_UNLOCKED = "not_unlocked"
 """A join was asked for before anything unlocked, so there is no peer to sponsor it."""
+
+REASON_CREDENTIALS_REJECTED = "credentials_rejected"
+"""
+Apple refused the stored password, so nothing needing the keychain can work.
+
+**The account state does carry the password** - FindMy.py serialises it in `to_json` and restores
+it - so this is not "nothing to authenticate with". It is Apple declining what was sent, and the
+message is Apple's own `em` string passed through verbatim, which is why it reads as though
+somebody mistyped something. Nobody typed anything.
+
+**And it cannot be worked around here.** Opening a keychain session calls `request_pet`, which
+re-runs the SRP exchange and raises rather than making do - unlike `_fresh_pet`, which falls back
+to the token already held. That difference is deliberate: keychain operations need a genuinely
+fresh PET. So the password working again is the only route, and that means a fresh sign-in.
+
+Causes worth telling apart, none of which this can distinguish: the Apple ID password was
+changed, Apple invalidated the credential, or this app's device was removed from the account.
+
+Untreated it reads as an outage. The account read is silent by design and runs every six hours,
+so the failure scrolls past a log nobody is watching while the tag list quietly stops matching
+Find My, with nothing on screen ever saying why.
+"""
 
 REASON_MEMBERSHIP_UNUSABLE = "membership_unusable"
 """
@@ -144,12 +168,43 @@ def _unexpected(what: str) -> str:
     detail = traceback.format_exc()
     print(f"iCloud bridge: {what} failed:\n{detail}")
 
+    # **Classified here rather than at each call site.** Every method on this class ends in the
+    # same `except Exception: return _unexpected(...)`, and there are eight of them; catching
+    # rejected credentials at one of those and not the others is how the retry screen keeps
+    # turning up for a session that can never work. Doing it here also covers whatever is added
+    # next, which the per-site version would not.
+    if _isCausedBy(sys.exc_info()[1], InvalidCredentialsError):
+        return _failure(REASON_CREDENTIALS_REJECTED, _lastLineOf(detail) or what + " was refused")
+
     # `str(e)` is empty for several of these - TimeoutError most of all - so the last line of
     # the traceback stands in. It names the exception type, which is not a good message but is
     # infinitely better than a colon with nothing after it.
-    lastLine = detail.strip().splitlines()[-1] if detail.strip() else ""
+    return _failure(
+        REASON_UNKNOWN,
+        _lastLineOf(detail) or f"{what} failed for an unrecorded reason",
+    )
 
-    return _failure(REASON_UNKNOWN, lastLine or f"{what} failed for an unrecorded reason")
+
+def _lastLineOf(detail: str) -> str:
+    return detail.strip().splitlines()[-1] if detail.strip() else ""
+
+
+def _isCausedBy(error: BaseException | None, wanted: type[BaseException]) -> bool:
+    """
+    Whether `wanted` is anywhere in the chain, not only at the top.
+
+    **Wrapping is the normal case here, not the exception.** These calls go through
+    `run_until_complete`, through FindMy.py's own layers, and anything that re-raises with
+    context puts the interesting error underneath. Matching only the outermost type means the
+    classification silently stops working the first time somebody adds a wrapper.
+    """
+    seen = set()
+    while error is not None and id(error) not in seen:
+        if isinstance(error, wanted):
+            return True
+        seen.add(id(error))
+        error = error.__cause__ or error.__context__
+    return False
 
 
 def _asyncAccount(account: Any) -> Any:
@@ -208,6 +263,8 @@ class ICloudSession:
 
             return json.dumps({"ok": True})
         except Exception:
+            # Rejected credentials are classified inside _unexpected, which every method here
+            # funnels through - see REASON_CREDENTIALS_REJECTED.
             return _unexpected("opening the Find My client")
 
     def recoveryOptions(self) -> str:

--- a/app/src/main/python/icloud_bridge.py
+++ b/app/src/main/python/icloud_bridge.py
@@ -173,7 +173,7 @@ def _unexpected(what: str) -> str:
     # rejected credentials at one of those and not the others is how the retry screen keeps
     # turning up for a session that can never work. Doing it here also covers whatever is added
     # next, which the per-site version would not.
-    if _isCausedBy(sys.exc_info()[1], InvalidCredentialsError):
+    if _needsAFreshSignIn(sys.exc_info()[1]):
         return _failure(REASON_CREDENTIALS_REJECTED, _lastLineOf(detail) or what + " was refused")
 
     # `str(e)` is empty for several of these - TimeoutError most of all - so the last line of
@@ -187,6 +187,45 @@ def _unexpected(what: str) -> str:
 
 def _lastLineOf(detail: str) -> str:
     return detail.strip().splitlines()[-1] if detail.strip() else ""
+
+
+def _needsAFreshSignIn(error: BaseException | None) -> bool:
+    """
+    Whether this failure means the stored sign-in has to be replaced.
+
+    **Two shapes, one situation, and they arrive from different code.** Apple refusing the
+    password raises `InvalidCredentialsError`. A session restored *without* one raises a bare
+    `ValueError` from the same function, several frames earlier, before anything is sent - and
+    the app restores sessions constantly, so that is not the rare half.
+
+    Matching a `ValueError` on its message is unpleasant and is done anyway: the alternative is
+    the app's most ordinary auth failure arriving as `UNKNOWN` and being offered a retry that
+    cannot work. The string is checked narrowly, and `account.py` raises it in exactly one place.
+
+    **`UnauthorizedError` is deliberately not here.** It means two different things depending on
+    where it came from - `request_pet` raises it when a second factor is being demanded, which the
+    app answers by asking for a code rather than signing out, while CloudKit raises the same type
+    for a genuine 401. Treating a 2FA prompt as a dead session would cost somebody a sign-in they
+    did not need, so it stays unclassified until the two can be told apart.
+    """
+    if _isCausedBy(error, InvalidCredentialsError):
+        return True
+
+    # `not self._username or not self._password` in `_gsa_authenticate`, which is reached by
+    # anything that tries to re-authenticate a restored session.
+    return _isCausedBy(error, ValueError) and _saysAnyOf(
+        error, ("No username or password specified",))
+
+
+def _saysAnyOf(error: BaseException | None, phrases: tuple[str, ...]) -> bool:
+    """Whether any exception in the chain carries one of these messages."""
+    seen = set()
+    while error is not None and id(error) not in seen:
+        if any(phrase in str(error) for phrase in phrases):
+            return True
+        seen.add(id(error))
+        error = error.__cause__ or error.__context__
+    return False
 
 
 def _isCausedBy(error: BaseException | None, wanted: type[BaseException]) -> bool:

--- a/app/src/test/java/dev/wander/android/opentagviewer/python/icloud/WhichFailuresNeedAFreshSignInTest.java
+++ b/app/src/test/java/dev/wander/android/opentagviewer/python/icloud/WhichFailuresNeedAFreshSignInTest.java
@@ -1,0 +1,125 @@
+package dev.wander.android.opentagviewer.python.icloud;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Which failures from the account mean the user has to sign in again.
+ *
+ * <p><b>On the JVM, because it is an enum and a walk up a cause chain.</b> See AGENTS.md rule 13.
+ *
+ * <p>The reason one place decides: three screens can hit the same wall - the iCloud device list,
+ * a rename that writes to the account, and the six-hourly background read - and a judgement made
+ * three times gets made three ways. It already had: rejected credentials landed on the "worth
+ * trying again later" screen, which is false for a session that can never work again, and the
+ * background read logged it at warning and carried on for six hours.
+ */
+public class WhichFailuresNeedAFreshSignInTest {
+
+    /**
+     * <b>Exactly one failure means it, and the test names the rest so a new one cannot be
+     * forgotten.</b>
+     *
+     * <p>Enumerating {@code values()} rather than listing the ones expected to be false is the
+     * point: adding a failure to the enum without deciding what it means here fails this test
+     * rather than quietly defaulting to "retry", which is how the original bug read.
+     */
+    @Test
+    public void onlyRejectedCredentialsNeedsAFreshSignIn() {
+        final Set<ICloudFailure> needThem = EnumSet.noneOf(ICloudFailure.class);
+
+        for (final ICloudFailure failure : ICloudFailure.values()) {
+            if (ICloudFailures.meansSignInAgain(new ICloudException(failure, "x"))) {
+                needThem.add(failure);
+            }
+        }
+
+        assertEquals(EnumSet.of(ICloudFailure.CREDENTIALS_REJECTED), needThem);
+    }
+
+    /**
+     * And the ones that would be actively harmful to treat that way.
+     *
+     * <p>Each of these has a remedy that costs less than a sign-in, so sending somebody to the
+     * login screen for one would take away a working session to fix something that was not
+     * broken.
+     */
+    @Test
+    public void therecoverableOnesDoNotCostASignIn() {
+        for (final ICloudFailure benign : new ICloudFailure[] {
+                ICloudFailure.PASSCODE_REJECTED,      // try the passcode again
+                ICloudFailure.SERVICE_UNSURE,         // genuinely worth waiting out
+                ICloudFailure.NOTHING_TO_RECOVER_FROM, // an honest end state, not a fault
+                ICloudFailure.MEMBERSHIP_UNUSABLE,    // re-join, which needs no new sign-in
+                ICloudFailure.UNKNOWN}) {
+
+            assertFalse(benign + " should not cost the user a sign-in",
+                    ICloudFailures.meansSignInAgain(new ICloudException(benign, "x")));
+        }
+    }
+
+    /**
+     * <b>Wrapped, because RxJava hands the subscriber its own exception.</b>
+     *
+     * <p>Every one of the three call sites reads this off an {@code onError}, so without the
+     * cause walk the classification would be correct and never fire.
+     */
+    @Test
+    public void afailureBuriedInACauseChainStillCounts() {
+        final Throwable wrapped = new RuntimeException("rx wrapper",
+                new IllegalStateException("another layer",
+                        new ICloudException(ICloudFailure.CREDENTIALS_REJECTED, "refused")));
+
+        assertTrue(ICloudFailures.meansSignInAgain(wrapped));
+        assertEquals(ICloudFailure.CREDENTIALS_REJECTED, ICloudFailures.failureOf(wrapped));
+    }
+
+    /** Something that is not an iCloud failure at all is not one to sign in over. */
+    @Test
+    public void anythingElseIsNotThis() {
+        assertFalse(ICloudFailures.meansSignInAgain(new IOException("the network went away")));
+        assertFalse(ICloudFailures.meansSignInAgain(null));
+        assertEquals(ICloudFailure.UNKNOWN, ICloudFailures.failureOf(new IOException("x")));
+    }
+
+    /**
+     * <b>The string Python sends maps to the value Java switches on.</b>
+     *
+     * <p>The two halves are edited in different files and nothing links them: a reason renamed on
+     * one side and not the other degrades to {@code UNKNOWN}, which is the retry screen again -
+     * silently, and only for the failure this whole change exists to stop mishandling.
+     */
+    @Test
+    public void thereasonStringFromPythonIsRecognised() {
+        assertEquals(ICloudFailure.CREDENTIALS_REJECTED,
+                ICloudFailure.fromWire("credentials_rejected"));
+    }
+
+    /**
+     * <b>A cycle in the cause chain must not hang the walk.</b>
+     *
+     * <p>Two elements, not one. Java refuses {@code initCause(this)}, so a self-cycle cannot be
+     * constructed at all - which means a guard written against one looks careful and does
+     * nothing. {@code A -> B -> A} builds fine, and the first version of this walk spun on it
+     * forever, on whichever thread happened to be reporting an error.
+     *
+     * <p>The timeout is the assertion. Without it a regression here hangs the suite rather than
+     * failing it.
+     */
+    @Test(timeout = 2000)
+    public void acycleDoesNotSpinForever() {
+        final Exception inner = new Exception("inner");
+        final Exception outer = new Exception("outer", inner);
+        inner.initCause(outer);
+
+        assertFalse(ICloudFailures.meansSignInAgain(outer));
+        assertEquals(ICloudFailure.UNKNOWN, ICloudFailures.failureOf(outer));
+    }
+}

--- a/app/src/test/python/test_icloud_bridge.py
+++ b/app/src/test/python/test_icloud_bridge.py
@@ -24,6 +24,8 @@ from typing import Any
 
 import pytest
 
+from findmy.errors import InvalidCredentialsError, UnauthorizedError
+
 import icloud_bridge
 from exporter import icloud
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -937,3 +939,84 @@ class TestRenamingAnAccessory:
         answer = json.loads(made.rename("beacon-1", anAccessoryPlist(), "Keys", ""))
 
         assert answer["reason"] == icloud_bridge.REASON_NOT_SIGNED_IN
+
+
+class TestASignInThatNoLongerWorks:
+    """
+    Every shape of "Apple will not accept this session", and the one that is not that.
+
+    **Classified in `_unexpected`, so all eight entry points get it.** Naming it at one call site
+    is how the retry screen kept appearing from the other seven - the screen says the service is
+    having a bad day, and it is not: the same rejected password goes out on every attempt.
+    """
+
+    def test_apple_refusing_the_password_is_named(self):
+        try:
+            raise InvalidCredentialsError(
+                "Password authentication failed: Enter the correct password for this Apple"
+                " Account.")
+        except InvalidCredentialsError:
+            answer = json.loads(icloud_bridge._unexpected("opening the Find My client"))
+
+        assert answer["reason"] == icloud_bridge.REASON_CREDENTIALS_REJECTED
+
+    def test_a_session_restored_without_a_password_is_the_same_situation(self):
+        """
+        **A bare ValueError, several frames earlier, before anything is sent.**
+
+        `_gsa_authenticate` raises it when there is nothing to authenticate with - and the app
+        restores sessions constantly, so this is not the rare half. Untreated it arrives as
+        UNKNOWN and earns a retry that cannot work.
+        """
+        try:
+            raise ValueError("No username or password specified")
+        except ValueError:
+            answer = json.loads(icloud_bridge._unexpected("reading the account's accessories"))
+
+        assert answer["reason"] == icloud_bridge.REASON_CREDENTIALS_REJECTED
+
+    def test_it_is_found_underneath_a_wrapper(self):
+        # These come back through run_until_complete and FindMy.py's own layers, so the
+        # interesting error is rarely the outermost one.
+        try:
+            try:
+                raise InvalidCredentialsError("refused")
+            except InvalidCredentialsError as inner:
+                raise RuntimeError("while opening the client") from inner
+        except RuntimeError:
+            answer = json.loads(icloud_bridge._unexpected("opening the Find My client"))
+
+        assert answer["reason"] == icloud_bridge.REASON_CREDENTIALS_REJECTED
+
+    def test_an_unrelated_value_error_is_not_a_dead_session(self):
+        """The message is checked, not just the type - ValueError is far too common a shape."""
+        try:
+            raise ValueError("that is not a valid serial")
+        except ValueError:
+            answer = json.loads(icloud_bridge._unexpected("unlocking the keychain"))
+
+        assert answer["reason"] == icloud_bridge.REASON_UNKNOWN
+
+    def test_an_unauthorized_error_is_deliberately_left_alone(self):
+        """
+        **Two meanings, so it stays unclassified until they can be told apart.**
+
+        `request_pet` raises this when a second factor is being demanded, which the app answers by
+        asking for a code rather than signing out; CloudKit raises the same type for a genuine
+        401. Treating a 2FA prompt as a dead session would cost somebody a sign-in they did not
+        need - the opposite mistake to the one this whole change fixes, and just as annoying.
+        """
+        try:
+            raise UnauthorizedError("Re-authentication ended in state REQUIRE_2FA")
+        except UnauthorizedError:
+            answer = json.loads(icloud_bridge._unexpected("opening the Find My client"))
+
+        assert answer["reason"] == icloud_bridge.REASON_UNKNOWN
+
+    def test_something_ordinary_is_still_unknown(self):
+        try:
+            raise TimeoutError()
+        except TimeoutError:
+            answer = json.loads(icloud_bridge._unexpected("reading the account's accessories"))
+
+        assert answer["reason"] == icloud_bridge.REASON_UNKNOWN


### PR DESCRIPTION
## "The service is having a bad day" was wrong, and permanent

Opening the iCloud device list on a session Apple no longer accepts landed on the **retry**
screen. It is not worth retrying: the same stored password is re-sent every time and refused every
time, so the screen invites an action that cannot ever work.

Reported from a real device:

```
findmy.errors.InvalidCredentialsError: Password authentication failed:
  Enter the correct password for this Apple Account.
PythonICloudService  W  icloud_bridge.open reported UNKNOWN: ...
AccountRefresher     W  Could not re-read the Apple account; leaving the stored tags alone
```

`UNKNOWN` is the tell. Unclassified, it fell through to `default:`.

### What is actually happening

Not "the app has no password to authenticate with" — the account state **carries** the password
(`to_json` serialises it, line 827) and it was sent. Apple declined it, and the message is Apple's
own `em` string passed through verbatim, which is why it reads as though somebody mistyped.

Nor can it be papered over. Opening a keychain session calls `request_pet`, which re-runs the SRP
exchange and **raises** — unlike `_fresh_pet`, which catches the same error and makes do with the
token already held. That difference is deliberate on FindMy.py's part: keychain operations need a
genuinely fresh PET.

Three causes, one remedy, and the log cannot separate them: the Apple ID password was changed,
Apple invalidated the credential, or this app's device was removed from the account.

### Classified once, acted on everywhere

**In `_unexpected`, not at one call site.** Every method on the bridge ends in the same
`except Exception`, and there are eight; naming it at one is how the retry screen keeps turning up
from the other seven. This also covers whatever gets added next.

**And one predicate for the three screens that reach it**, because each had its own answer:

| Path | Was | Is |
| --- | --- | --- |
| iCloud device list | "worth trying again later" | clears the session, offers sign-in |
| Renaming a tag | "renaming failed" — so try a shorter name, for a session that cannot write at all | the same |
| Background read, 6-hourly | warning, carried on | says so once, and touches nothing |

The third does **not** act, deliberately: a job nobody asked for should not delete somebody's
session out from under whatever they are doing. It has no screen to explain itself with.

`MapsActivity` keeps its own recovery — it also calls `PythonAppleService.forget()` and answers a
different failure, an account blob that will not restore at all.

### Testing

Seven JVM tests on the decision, four instrumented proving each caller honours it — a shared
predicate does not stop a fourth screen being written that never asks.

The enum test iterates `values()` rather than listing expectations, so adding a failure without
deciding what it means here goes **red** instead of quietly defaulting to "retry", which is how
this bug read in the first place.

Three things writing them turned up:

- **The cause-chain guard did nothing.** `cause.getCause() == cause` protects against a shape Java
  refuses to construct (`initCause(this)` throws), so it looked careful and was inert. `A -> B -> A`
  builds fine and the walk spun on it forever. Now an identity set, and the test carries a timeout
  because a regression there hangs the suite rather than failing it.
- **`null` is not `FALSE`.** The account rename is gated on `Boolean.FALSE.equals(isOwnDevice)`, so
  a describer that cannot decide keeps the rename local and never calls iCloud — the test would
  have passed without touching the code under test.
- **A rename needs a stored keychain membership**, or `AccessoryRenamer` refuses before opening
  anything.

### Not established

**Why the session was refused in the first place.** The three causes above are indistinguishable
from here, and this PR only fixes what the app does about it.

**Whether users upgrading will hit it.** Probably not: nothing in the anisette package reads
`BuildConfig`, `versionName` or `versionCode`, and both the ADI libraries and the provisioning
state live in `filesDir`, which an update preserves. An *uninstall* wipes them, which is a
different thing. Worth confirming on a device before it goes in release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
