### PR TITLE
Re-read the account when somebody would notice, and explain the device once

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,6 +344,46 @@ python -m venv .venv && .venv/bin/pip install -r app/src/test/python/requirement
 The same applies to every other shared dependency, not just FindMy.py: `PyYAML` is pinned in
 `app/build.gradle.kts` and `python/pyproject.toml` for exactly this reason.
 
+### 15. Every call to iCloud has to answer "is this session dead?"
+
+A failed call to Apple is one of two things, and they need opposite screens. Most are weather -
+a timeout, a bad afternoon at iCloud - and the answer is to try again later. **A refused sign-in
+is permanent**, and the only remedy is one the user has to perform.
+
+Getting it the wrong way round is not cosmetic. The retry screen for a dead session invites an
+action that fails identically every time and explains nothing; a forced sign-out for a transient
+failure costs somebody a working session for nothing.
+
+**So anything that reaches the account handles it, and through the shared decision rather than
+its own.** `ICloudFailures.meansSignInAgain(error)` is the question; `SignInAgain.from(activity)`
+is the answer. Three screens had written the judgement separately, and all three had it
+differently — the iCloud list said retry, a failed rename said "renaming failed" so people tried
+a shorter name, and the six-hourly account read logged a warning and carried on for another six
+hours.
+
+**Classify in `icloud_bridge._unexpected`, not at the call site.** Every method on that class
+ends in the same `except Exception`, and there are eight of them; naming a failure at one leaves
+the other seven reporting `UNKNOWN`, which is the retry screen again. Classifying centrally also
+covers whatever gets added next.
+
+**A 401 does not arrive as one type.** Apple refusing the password is
+`InvalidCredentialsError`; a session restored *without* a password raises a bare
+`ValueError("No username or password specified")` several frames earlier, before anything is
+sent. Both mean the same thing to a user. `UnauthorizedError` does **not** join them: `request_pet`
+raises it when a second factor is being demanded — which the app answers with a code, not a
+sign-out — while CloudKit raises the same type for a genuine 401. Same class, opposite remedies.
+
+**And the line is who asked.** A user-initiated call — opening the iCloud list, renaming a tag,
+pressing refresh — sends them to sign in again, because they are watching and a silent no-op is
+worse than a screen. An automatic one — the periodic read, a read on resume — says so in the log
+and touches nothing: deleting somebody's session out from under whatever they are doing, from a
+job nobody asked for, is its own bug.
+
+Every one of these is tested twice: `WhichFailuresNeedAFreshSignInTest` on the JVM for the
+decision, `EveryPathAsksForAFreshSignInTest` on a device for each caller honouring it. A shared
+predicate does not stop a fourth screen being written that never asks.
+
+
 ---
 
 ## Building and testing

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/icloud/TheDeviceNoteIsShownOnceTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/icloud/TheDeviceNoteIsShownOnceTest.java
@@ -1,0 +1,176 @@
+package dev.wander.android.opentagviewer.ui.icloud;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.FetchFromICloudActivity;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.db.AccountBeaconsForTests;
+import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
+import dev.wander.android.opentagviewer.db.repo.KeychainMembershipRepository;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.python.icloud.FakeICloudService;
+import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
+
+/**
+ * The page explaining what this app put on somebody's Apple account, and when it is worth showing.
+ *
+ * <p><b>It describes something that happened, so it belongs to the run where it happened.</b>
+ * Connecting an account registers a device: a row appears in the user's Apple device list, titled
+ * after a Mac they do not own, next to a button offering to remove things they do not recognise -
+ * and removing it breaks the session. That is worth a screen.
+ *
+ * <p>Re-reading an already-linked account registers nothing. Showing the same page again explains
+ * an event that did not occur, to somebody who read it the first time - and a page that turns up
+ * when nothing has happened is one people learn to tap past, including on the run where it
+ * matters.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class TheDeviceNoteIsShownOnceTest {
+
+    private static final String PASSCODE = "123456";
+
+    private FakeICloudService icloud;
+    private ActivityScenario<FetchFromICloudActivity> scenario;
+    private KeychainMembershipRepository memberships;
+
+    @Before
+    public void startWithNothingStored() {
+        this.memberships = new KeychainMembershipRepository(
+                UserAuthDataStore.getInstance(getInstrumentation().getTargetContext()),
+                new AppCryptographyUtil());
+
+        // The membership lives in the real encrypted datastore and outlives a test class, so a
+        // run that crashed leaves this screen resuming as a member. Cleared before as well as
+        // after for that reason.
+        this.memberships.forget().blockingAwait();
+        AccountBeaconsForTests.forgetThemAll();
+    }
+
+    @After
+    public void putItBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        AppDependencies.reset();
+        this.memberships.forget().blockingAwait();
+        AccountBeaconsForTests.forgetThemAll();
+    }
+
+    private void open() {
+        this.icloud = FakeICloudService.withTags();
+        AppDependencies.replaceICloud(() -> this.icloud);
+        this.scenario = ActivityScenario.launch(FetchFromICloudActivity.class);
+    }
+
+    /** Pick the first device and unlock with a passcode, which is what a first run does. */
+    private void connectForTheFirstTime() {
+        Eventually.check(() -> onView(withId(R.id.icloud_device_container))
+                .check(matches(isDisplayed())));
+        onView(withText(containsString(FakeICloudService.AN_IPHONE.getSerial()))).perform(click());
+
+        Eventually.check(() -> onView(withId(R.id.icloud_passcode_input))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.icloud_passcode_input)).perform(replaceText(PASSCODE));
+
+        final long before = this.icloud.timesCalled("unlock");
+        Eventually.perform("unlock", () -> this.icloud.timesCalled("unlock") > before,
+                () -> onView(withId(R.id.icloud_primary_button)).perform(click()));
+    }
+
+    private void waitForTheResults() {
+        Eventually.check(() -> onView(withId(R.id.icloud_results_container))
+                .check(matches(isDisplayed())));
+    }
+
+    /**
+     * <b>A first connection registers a device, so it explains one.</b>
+     *
+     * <p>The button on the results step says Next rather than Done precisely because there is a
+     * step after it.
+     */
+    @Test
+    public void aafirstConnectionExplainsTheDeviceItJustRegistered() {
+        this.open();
+        this.connectForTheFirstTime();
+        this.waitForTheResults();
+
+        onView(withId(R.id.icloud_primary_button))
+                .check(matches(withText(R.string.icloud_results_next)));
+        onView(withId(R.id.icloud_primary_button)).perform(click());
+
+        Eventually.check(() -> onView(withId(R.id.icloud_registered_container))
+                .check(matches(isDisplayed())));
+    }
+
+    /**
+     * <b>And re-reading a linked account does not, because nothing was registered.</b>
+     *
+     * <p>The one this exists for. The second run resumes as the member it already is - no device
+     * list, no passcode, no join - and the page describing a new entry in the Apple device list
+     * would be describing an entry that has been there since the first run.
+     */
+    @Test
+    public void bareadOfALinkedAccountDoesNotShowItAgain() {
+        this.open();
+        this.connectForTheFirstTime();
+        Eventually.check(() -> assertTrue("the first run did not store a membership",
+                this.memberships.get().blockingFirst().isPresent()));
+        this.scenario.close();
+        AppDependencies.reset();
+
+        this.open();
+        this.waitForTheResults();
+
+        // Done, not Next: there is no step after this one now.
+        onView(withId(R.id.icloud_primary_button))
+                .check(matches(withText(R.string.icloud_results_done)));
+
+        // A GONE view still matches withId, so "not on screen" is asserted rather than expecting
+        // a NoMatchingViewException - the container is inflated on every run either way.
+        onView(withId(R.id.icloud_registered_container)).check(matches(not(isDisplayed())));
+    }
+
+    /**
+     * And pressing it leaves, rather than landing on the note by another route.
+     *
+     * <p>Separate from the assertion above because the label and the action are set together and
+     * could disagree: a button reading Done that still walks to the next step is worse than one
+     * that reads Next.
+     */
+    @Test
+    public void cpressingDoneOnAReadJustLeaves() {
+        this.open();
+        this.connectForTheFirstTime();
+        Eventually.check(() -> assertTrue(this.memberships.get().blockingFirst().isPresent()));
+        this.scenario.close();
+        AppDependencies.reset();
+
+        this.open();
+        this.waitForTheResults();
+        onView(withId(R.id.icloud_primary_button)).perform(click());
+
+        Eventually.check(() -> assertTrue("the screen should have closed",
+                this.scenario.getState() == androidx.lifecycle.Lifecycle.State.DESTROYED));
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/mydevices/RefreshingFromTheAccountTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/mydevices/RefreshingFromTheAccountTest.java
@@ -1,0 +1,191 @@
+package dev.wander.android.opentagviewer.ui.mydevices;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.app.Activity;
+import android.app.Instrumentation.ActivityResult;
+import android.content.Context;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import dev.wander.android.opentagviewer.AppleLoginActivity;
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.MyDevicesListActivity;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.db.AccountBeaconsForTests;
+import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
+import dev.wander.android.opentagviewer.db.repo.KeychainMembershipRepository;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.python.icloud.FakeICloudService;
+import dev.wander.android.opentagviewer.python.icloud.KeychainMembership;
+import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
+
+/**
+ * Reading the account again from the list, because somebody asked.
+ *
+ * <p><b>The account was re-read every six hours, and an iPad does it in seconds.</b> So a tag
+ * renamed on the owner's own iPad kept its old name here for the rest of the afternoon. This is
+ * the on-demand half of the fix - the automatic reads got shorter intervals, and this is the
+ * button for when even a minute is too long to wonder.
+ *
+ * <p>It is also the one refresh path where a refused sign-in sends the user to sign in again.
+ * They pressed something and are watching it; a tap that does nothing visible is
+ * indistinguishable from a broken button. The periodic and on-resume reads only log, because
+ * nobody asked for those. See AGENTS.md rule 14.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class RefreshingFromTheAccountTest {
+
+    private ActivityScenario<MyDevicesListActivity> scenario;
+    private KeychainMembershipRepository memberships;
+
+    @Before
+    public void linkTheAccount() {
+        final Context context = getInstrumentation().getTargetContext();
+        this.memberships = new KeychainMembershipRepository(
+                UserAuthDataStore.getInstance(context), new AppCryptographyUtil());
+
+        AccountBeaconsForTests.forgetThemAll();
+
+        // The item only appears once linked - it is the mirror of "link an account", and only
+        // one of the two is ever what somebody wants.
+        this.memberships.store(new KeychainMembership(
+                "{\"peer_id\":\"peer-ours\"}", "ZW50cm9weQ==", "a-passcode", "a-label", 2))
+                .blockingAwait();
+
+        Intents.init();
+        intending(hasComponent(AppleLoginActivity.class.getName()))
+                .respondWith(new ActivityResult(Activity.RESULT_CANCELED, null));
+    }
+
+    @After
+    public void putItBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        Intents.release();
+        AppDependencies.reset();
+        this.memberships.forget().blockingAwait();
+        AccountBeaconsForTests.forgetThemAll();
+    }
+
+    private void openTheMenu(final FakeICloudService fake) {
+        AppDependencies.replaceICloud(() -> fake);
+        this.scenario = ActivityScenario.launch(MyDevicesListActivity.class);
+
+        Eventually.check(() -> onView(withId(R.id.page_menu_button))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.page_menu_button)).perform(click());
+    }
+
+    /**
+     * <b>The item is there once an account is linked, and it is the one that fits.</b>
+     *
+     * <p>"Link an account" describes work already done by then, so the two swap rather than both
+     * being offered - a menu with both reads as three ways in rather than two.
+     */
+    @Test
+    public void atherefreshItemReplacesTheLinkItemOnceLinked() {
+        this.openTheMenu(FakeICloudService.withTags());
+
+        Eventually.check(() -> onView(withText(R.string.refresh_from_account))
+                .check(matches(isDisplayed())));
+
+        assertTrue("linking should not still be offered once linked",
+                nothingOnScreenSays(getInstrumentation().getTargetContext()
+                        .getString(R.string.icloud_link_account_action)));
+    }
+
+    /** And pressing it actually reads the account rather than only saying it did. */
+    @Test
+    public void bpressingItReadsTheAccount() {
+        final FakeICloudService fake = FakeICloudService.withTags();
+        this.openTheMenu(fake);
+
+        onView(withText(R.string.refresh_from_account)).perform(click());
+
+        Eventually.check(() -> assertTrue("the account was never read",
+                fake.timesCalled("fetch") > 0));
+    }
+
+    /**
+     * <b>And a refused sign-in sends them to sign in again, unlike the automatic reads.</b>
+     *
+     * <p>The difference is who asked. This one has somebody watching it, so a toast saying
+     * something vague - or worse, nothing at all - leaves them pressing a button that cannot ever
+     * work. The six-hourly read hitting the same wall only writes a log line, because a screen
+     * appearing out of a background job is its own bug.
+     */
+    @Test
+    public void carefusedSignInSendsThemToSignInAgain() {
+        this.openTheMenu(FakeICloudService.whereAppleRefusesTheCredentials());
+
+        onView(withText(R.string.refresh_from_account)).perform(click());
+
+        Eventually.check(() -> intended(allOf(
+                hasComponent(AppleLoginActivity.class.getName()),
+                hasExtra(AppleLoginActivity.EXTRA_SESSION_EXPIRED, true))));
+    }
+
+    /**
+     * An ordinary failure is not worth a sign-in, and says so instead.
+     *
+     * <p>The mirror of the test above, and the reason the predicate exists rather than a check
+     * for "did anything go wrong": sending somebody to the login screen because iCloud had a bad
+     * afternoon takes away a working session to fix nothing.
+     */
+    @Test
+    public void danoutageJustSaysSo() {
+        final FakeICloudService fake = FakeICloudService.whereTheServiceIsUnsure();
+        this.openTheMenu(fake);
+
+        onView(withText(R.string.refresh_from_account)).perform(click());
+
+        // **Waited on by asking the fake, not by matching the toast.** A Toast lives in its own
+        // window, so `inRoot(withDecorView(not(...)))` sends Espresso's root picker hunting - and
+        // when the toast is not up yet it retries internally for seconds per attempt, inside a
+        // retry loop. Written that way this class ran for over ten minutes and had to be killed.
+        // A call count answers instantly whether the work has finished.
+        Eventually.check(() -> assertTrue("the read never happened",
+                fake.timesCalled("open") > 0));
+
+        try {
+            intended(hasComponent(AppleLoginActivity.class.getName()));
+            fail("an outage must not cost the user a sign-in");
+        } catch (final AssertionError expected) {
+            // Nothing was launched, which is the point.
+        }
+    }
+
+    private static boolean nothingOnScreenSays(final String text) {
+        try {
+            onView(withText(text)).check(matches(isDisplayed()));
+            return false;
+        } catch (final NoMatchingViewException expected) {
+            return true;
+        }
+    }
+}

--- a/app/src/main/java/dev/wander/android/opentagviewer/FetchFromICloudActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/FetchFromICloudActivity.java
@@ -140,6 +140,15 @@ public class FetchFromICloudActivity extends AppCompatActivity {
     private KeychainMembershipRepository membershipRepo;
 
     /**
+     * Whether this app was already a member of the keychain when this screen opened.
+     *
+     * <p><b>What separates connecting an account from re-reading one.</b> The two run almost the
+     * same flow, and only the first registers anything with Apple - so only the first has
+     * anything to explain about a device appearing in somebody's list.
+     */
+    private boolean wasAlreadyLinked;
+
+    /**
      * The one button, at the bottom, relabelled per step.
      *
      * <p>It was four - one at the bottom of whatever content each step happened to have - so it
@@ -294,6 +303,10 @@ public class FetchFromICloudActivity extends AppCompatActivity {
             this.askForADevice();
             return;
         }
+
+        // Held before anything else runs: from here on the flow is identical to a first
+        // connection, and afterwards there is no way to tell which one this was.
+        this.wasAlreadyLinked = true;
 
         this.showWaiting(R.string.icloud_loading_importing);
 
@@ -524,9 +537,11 @@ public class FetchFromICloudActivity extends AppCompatActivity {
      * a different machine than the one on the account would send somebody hunting for a row that
      * is not there, and possibly deleting one that is.
      *
-     * <p>Shown on every connect. The entries accumulate - each fresh install adds another, all
-     * with this same title and model - so the person who saw this a year ago is precisely the one
-     * who has since forgotten which row it was.
+     * <p><b>Shown when a connection registers a device, and not when one is merely re-read.</b>
+     * The entries do accumulate - each fresh install adds another, all with this same title and
+     * model - so somebody who saw this a year ago has since forgotten which row it was, and a
+     * fresh install genuinely needs telling again. Re-reading a linked account adds nothing to
+     * the list, so the page would be describing something that did not happen.
      */
     private void showWhatWeRegisteredAs() {
         final AdiDeviceIdentity.Hardware hardware = LocalAnisette.profileToShow(this);
@@ -848,8 +863,17 @@ public class FetchFromICloudActivity extends AppCompatActivity {
         if (stepId == R.id.icloud_passcode_container) {
             this.setPrimaryButton(R.string.icloud_unlock_action, this::submitPasscode);
         } else if (stepId == R.id.icloud_results_container) {
-            // Not the last step any more - what this app put on their account comes after.
-            this.setPrimaryButton(R.string.icloud_results_next, this::showWhatWeRegisteredAs);
+            // **The device note is for the connection that created the device, and nothing
+            // else.** It explains a row that has just appeared in somebody's Apple account, why
+            // it is there and why deleting it breaks their session - which is worth a screen
+            // once. Re-reading a linked account registers nothing and shows the same page again
+            // to somebody who has already read it, and a page that turns up when nothing has
+            // happened is one people learn to tap past, including the time it matters.
+            if (this.wasAlreadyLinked) {
+                this.setPrimaryButton(R.string.icloud_results_done, this::finish);
+            } else {
+                this.setPrimaryButton(R.string.icloud_results_next, this::showWhatWeRegisteredAs);
+            }
         } else if (stepId == R.id.icloud_registered_container) {
             this.setPrimaryButton(R.string.icloud_results_done, this::finish);
         } else if (stepId == R.id.icloud_no_tags_container) {

--- a/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
@@ -100,6 +100,7 @@ import dev.wander.android.opentagviewer.db.repo.BeaconRepository;
 import dev.wander.android.opentagviewer.db.repo.model.ImportData;
 import dev.wander.android.opentagviewer.db.util.BeaconCombinerUtil;
 import dev.wander.android.opentagviewer.python.AccessoryRequest;
+import dev.wander.android.opentagviewer.python.icloud.ICloudFailures;
 import dev.wander.android.opentagviewer.python.AppDependencies;
 import dev.wander.android.opentagviewer.python.LogRedactor;
 import dev.wander.android.opentagviewer.ui.BeaconIcon;
@@ -638,7 +639,19 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         held -> Log.i(TAG, "Background account read holds " + held.size() + " tags"),
-                        error -> Log.w(TAG, "Background account read failed", error));
+                        error -> {
+                            // **Logged and nothing else, even for a refused sign-in.** Nobody
+                            // asked for this read, so nothing may appear because of it - being
+                            // thrown onto a login screen the moment the app opens, before the
+                            // map has drawn and while locations may still be fetching perfectly
+                            // well, is its own bug. The screens somebody presses handle it.
+                            if (ICloudFailures.meansSignInAgain(error)) {
+                                Log.w(TAG, "The account cannot be re-read until the user signs"
+                                        + " in again; nothing is being changed from here", error);
+                                return;
+                            }
+                            Log.w(TAG, "Background account read failed", error);
+                        });
     }
 
     private void rememberWhetherAnAccountIsLinked() {

--- a/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/MapsActivity.java
@@ -230,10 +230,27 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
      * also decrypts every record on the account and queues behind the location fetches, so doing
      * it eagerly costs the user's own work rather than just bandwidth.
      */
-    private static final long WAIT_BEFORE_REREADING_ACCOUNT = 6L * 60 * 60 * 1000;
+    /**
+     * How often a running app re-reads the account.
+     *
+     * <p><b>Six hours, until somebody pointed out what that looks like.</b> An iPad picks up a
+     * renamed AirTag in seconds; this app showed the old name for the rest of the afternoon. The
+     * read is a CloudKit query for the account's accessories - and the location fetch beside it
+     * runs every <i>minute</i>, so four of these an hour is not the expensive thing here.
+     */
+    private static final long WAIT_BEFORE_REREADING_ACCOUNT = 15L * 60 * 1000;
 
-    private final AccountReadPolicy accountReadPolicy =
-            new AccountReadPolicy(WAIT_BEFORE_REREADING_ACCOUNT);
+    /**
+     * And the floor for the read on resume, which is the one that makes it feel immediate.
+     *
+     * <p>The moment a stale name is noticed is the moment the app is opened. Short enough that
+     * opening it after a rename shows the new one; long enough that flicking between two apps
+     * does not spend a Python call each time.
+     */
+    private static final long WAIT_BEFORE_REREADING_ON_RESUME = 60L * 1000;
+
+    private final AccountReadPolicy accountReadPolicy = new AccountReadPolicy(
+            WAIT_BEFORE_REREADING_ACCOUNT, WAIT_BEFORE_REREADING_ON_RESUME);
 
     /**
      * Whether an Apple account is linked, as of the last time this screen resumed.
@@ -529,6 +546,10 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
 
         this.rememberWhetherAnAccountIsLinked();
         this.refreshIfAllowed();
+        // **The account too, not only the locations.** Resuming already refetched where the tags
+        // are and never asked what the tags *were* - so a tag renamed elsewhere kept its old name
+        // on this screen until the periodic read came round.
+        this.rereadTheAccountIfAllowed(true);
         this.reSchedulePeriodicTagLocationRefresher();
         
         // 调用高德地图的生命周期方法
@@ -555,7 +576,7 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
         this.nextLocationRefreshTask = () -> {
             refreshSchedulerHandler.postDelayed(this.nextLocationRefreshTask, WAIT_BEFORE_REFETCH);
             this.refreshIfAllowed();
-            this.rereadTheAccountIfAllowed();
+            this.rereadTheAccountIfAllowed(false);
         };
         refreshSchedulerHandler.postDelayed(this.nextLocationRefreshTask, WAIT_BEFORE_REFETCH);
     }
@@ -590,11 +611,14 @@ public class MapsActivity extends AppCompatActivity implements IMapProvider.OnMa
      * <p>The device list is only rebuilt when something actually changed, because rebuilding it
      * moves rows under whoever is reading them.
      */
-    private void rereadTheAccountIfAllowed() {
+    private void rereadTheAccountIfAllowed(final boolean justResumed) {
         final long now = System.currentTimeMillis();
 
-        final AccountReadPolicy.Decision decision = this.accountReadPolicy.decide(
-                now, this.accountIsLinked, PythonAppleService.isBusy());
+        final AccountReadPolicy.Decision decision = justResumed
+                ? this.accountReadPolicy.decideOnResume(
+                        now, this.accountIsLinked, PythonAppleService.isBusy())
+                : this.accountReadPolicy.decide(
+                        now, this.accountIsLinked, PythonAppleService.isBusy());
 
         if (!decision.shouldRead()) {
             return;

--- a/app/src/main/java/dev/wander/android/opentagviewer/MyDevicesListActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/MyDevicesListActivity.java
@@ -46,6 +46,9 @@ import dev.wander.android.opentagviewer.databinding.ActivityMyDevicesListBinding
 import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
 import dev.wander.android.opentagviewer.db.datastore.UserSettingsDataStore;
 import dev.wander.android.opentagviewer.db.repo.BeaconRepository;
+import dev.wander.android.opentagviewer.ui.login.SignInAgain;
+import dev.wander.android.opentagviewer.python.icloud.ICloudFailures;
+import dev.wander.android.opentagviewer.python.icloud.AccountRefresher;
 import dev.wander.android.opentagviewer.db.repo.UserSettingsRepository;
 import dev.wander.android.opentagviewer.db.repo.model.UserSettings;
 import dev.wander.android.opentagviewer.util.TagOrder;
@@ -612,11 +615,20 @@ public class MyDevicesListActivity extends AppCompatActivity {
         menu.getMenu().findItem(R.id.action_fetch_from_account)
                 .setVisible(!Boolean.TRUE.equals(this.accountIsLinked));
 
+        // The mirror of the item above: one of the two is what somebody wants, never both. Link
+        // while it is not linked, refresh once it is.
+        menu.getMenu().findItem(R.id.action_refresh_from_account)
+                .setVisible(Boolean.TRUE.equals(this.accountIsLinked));
+
         menu.setOnMenuItemClickListener(item -> {
             final int id = item.getItemId();
 
             if (id == R.id.action_fetch_from_account) {
                 this.openTheAccountFetch();
+                return true;
+            }
+            if (id == R.id.action_refresh_from_account) {
+                this.refreshFromTheAccount();
                 return true;
             }
             if (id == R.id.action_import_from_file) {
@@ -627,6 +639,53 @@ public class MyDevicesListActivity extends AppCompatActivity {
         });
 
         menu.show();
+    }
+
+    /**
+     * Read the account now, because somebody asked.
+     *
+     * <p><b>Asked for, so it answers - which is what separates it from the automatic reads.</b>
+     * The periodic and on-resume reads are silent by design: nobody requested them, so there is
+     * nothing to report and a screen appearing out of a background job is its own bug. This one
+     * has a person watching it, and a tap that does nothing visible is indistinguishable from a
+     * broken button.
+     *
+     * <p>So a refused sign-in sends them to sign in again here, where the same failure in the
+     * background only writes a log line. See AGENTS.md rule 15 - the line is who asked.
+     */
+    private void refreshFromTheAccount() {
+        var async = new AccountRefresher(
+                new KeychainMembershipRepository(
+                        UserAuthDataStore.getInstance(this.getApplicationContext()),
+                        new AppCryptographyUtil()),
+                this.beaconRepo)
+                .refresh()
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        held -> {
+                            Log.i(TAG, "Read " + held.size() + " tag(s) from the account");
+                            // **Rebuilt rather than appended to**, the same way an iCloud
+                            // import result is. This screen accumulates into `beaconInfo` on
+                            // load, so re-reading without a rebuild lists everything twice - and
+                            // a renamed tag only shows its new name because the rows underneath
+                            // were rewritten.
+                            this.devicesListChanged = true;
+                            this.recreate();
+                            Toast.makeText(this, R.string.refresh_from_account_done,
+                                    LENGTH_LONG).show();
+                        },
+                        error -> {
+                            if (ICloudFailures.meansSignInAgain(error)) {
+                                Log.w(TAG, "Apple refused the stored credentials during a"
+                                        + " refresh the user asked for", error);
+                                SignInAgain.from(this);
+                                return;
+                            }
+
+                            Log.w(TAG, "Could not refresh from the account", error);
+                            Toast.makeText(this, R.string.refresh_from_account_failed,
+                                    LENGTH_LONG).show();
+                        });
     }
 
     private void rememberWhetherTheAccountIsLinked() {

--- a/app/src/main/java/dev/wander/android/opentagviewer/python/icloud/AccountRefresher.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/python/icloud/AccountRefresher.java
@@ -95,18 +95,19 @@ public final class AccountRefresher {
                 ? ((ICloudException) error).getFailure() : ICloudFailure.UNKNOWN;
 
         if (ICloudFailures.meansSignInAgain(error)) {
-            // **Said once, loudly, rather than every six hours quietly.** Apple refused the
-            // stored password, so nothing here will ever succeed again until it is replaced -
-            // and this read is silent by design, which means without this the tag list simply
-            // stops matching Find My and nobody is ever told.
+            // **Reported, not decided.** Apple refused the stored password, so nothing here will
+            // ever succeed again until it is replaced - and what to do about that depends
+            // entirely on who asked. A refresh somebody pressed should send them to sign in; the
+            // six-hourly one should write a line and touch nothing. This class cannot tell those
+            // apart, and the first version of it swallowed the failure into an empty list, which
+            // made the difference impossible for the caller to act on: the manual refresh looked
+            // like a successful read of nothing.
             //
-            // Not acted on here, though: this runs in the background with no screen of its own,
-            // and clearing somebody's session out from under whatever they are doing is worse
-            // than waiting for the next thing that needs it. The screens that use the account
-            // recognise the same failure and offer to sign in again.
-            Log.w(TAG, "Apple refused the stored credentials. The account cannot be re-read"
-                    + " until the user signs in again; their stored tags are untouched.", error);
-            return Observable.just(List.of());
+            // So it goes up. See AGENTS.md rule 14 - the line is who asked, and only the caller
+            // knows.
+            Log.w(TAG, "Apple refused the stored credentials; the account cannot be re-read"
+                    + " until the user signs in again. Their stored tags are untouched.", error);
+            return Observable.error(error);
         }
 
         if (failure != ICloudFailure.MEMBERSHIP_UNUSABLE) {

--- a/app/src/main/java/dev/wander/android/opentagviewer/util/rx/AccountReadPolicy.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/util/rx/AccountReadPolicy.java
@@ -46,14 +46,28 @@ public final class AccountReadPolicy {
     private final long minIntervalMillis;
 
     /**
+     * The shorter floor for a read the user has effectively asked for by opening the app.
+     *
+     * <p><b>Not the same number, because the two reads answer different questions.</b> The
+     * periodic one keeps a running app roughly current; the one on resume exists because
+     * somebody renamed a tag on their iPad thirty seconds ago and is now looking at this screen
+     * wondering why it says the old name. An iPad updates that in seconds.
+     *
+     * <p>A floor at all, though: resuming happens on every task switch, and reading the account
+     * each time would be a Python call and a CloudKit query for flicking between two apps.
+     */
+    private final long resumeIntervalMillis;
+
+    /**
      * Zero means "never read", which is the honest starting state and not "read at the epoch".
      * A first tick after linking therefore reads, which is what somebody expects to happen
      * shortly after they connect an account.
      */
     private long lastReadAt = 0L;
 
-    public AccountReadPolicy(final long minIntervalMillis) {
+    public AccountReadPolicy(final long minIntervalMillis, final long resumeIntervalMillis) {
         this.minIntervalMillis = minIntervalMillis;
+        this.resumeIntervalMillis = resumeIntervalMillis;
     }
 
     /**
@@ -62,6 +76,21 @@ public final class AccountReadPolicy {
      * @param busy     whether a call into Python is already running
      */
     public Decision decide(final long now, final boolean linked, final boolean busy) {
+        return this.decide(now, linked, busy, this.minIntervalMillis);
+    }
+
+    /**
+     * The same question, asked when the user has just opened the screen.
+     *
+     * <p>Everything except the interval is identical - a read that would trample a running fetch
+     * is still skipped, and an unlinked account still has nothing to read.
+     */
+    public Decision decideOnResume(final long now, final boolean linked, final boolean busy) {
+        return this.decide(now, linked, busy, this.resumeIntervalMillis);
+    }
+
+    private Decision decide(
+            final long now, final boolean linked, final boolean busy, final long interval) {
         if (!linked) {
             return Decision.NOT_LINKED;
         }
@@ -72,7 +101,7 @@ public final class AccountReadPolicy {
         if (busy) {
             return Decision.BUSY;
         }
-        if (this.hasEverRead() && now < this.lastReadAt + this.minIntervalMillis) {
+        if (this.hasEverRead() && now < this.lastReadAt + interval) {
             return Decision.TOO_SOON;
         }
         return Decision.READ;

--- a/app/src/main/res/menu/my_devices_menu.xml
+++ b/app/src/main/res/menu/my_devices_menu.xml
@@ -28,6 +28,16 @@
         android:id="@+id/action_fetch_from_account"
         android:title="@string/icloud_link_account_action" />
 
+    <!--
+        **The other half of the same row, and the one shown once linking is done.** The comment
+        above says re-reading on demand lives in Settings; it does, behind a button that opens the
+        whole iCloud flow. That is a lot of screen for "did the name I just changed arrive", and
+        this is the list where somebody would notice it had not.
+    -->
+    <item
+        android:id="@+id/action_refresh_from_account"
+        android:title="@string/refresh_from_account" />
+
     <item
         android:id="@+id/action_import_from_file"
         android:title="@string/icloud_import_from_file" />

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -306,4 +306,7 @@ Du kannst das jetzt einrichten oder jederzeit später in den Einstellungen.</str
     <string name="error_report_body_export">Die App konnte aus den gewählten Tags kein Bundle erstellen und kann nicht sagen, warum – ein erneuter Versuch mit denselben Tags hilft also nicht.\n\nEs wurde nichts verschickt und auf diesem Telefon hat sich nichts geändert. Deine Tags sind weiterhin da.</string>
     <string name="imported_from_x">Zuletzt importiert aus %1$s</string>
     <string name="imported_from_nothing">Keine Tags aus einer Datei importiert</string>
+    <string name="refresh_from_account">Vom Apple-Konto aktualisieren</string>
+    <string name="refresh_from_account_done">Auf dem Stand deines Apple-Kontos</string>
+    <string name="refresh_from_account_failed">Dein Apple-Konto war gerade nicht erreichbar. An deinen Tags hat sich nichts geändert.</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -306,4 +306,7 @@ You can set this up now, or any time later from Settings.</string>
     <string name="error_report_body_export">The app could not build a bundle from the tags you picked, and cannot say why — so trying again with the same tags will not help.\n\nNothing was sent and nothing on this phone has changed. Your tags are still here.</string>
     <string name="imported_from_x">Most recently imported from %1$s</string>
     <string name="imported_from_nothing">No tags imported from a file</string>
+    <string name="refresh_from_account">Refresh from Apple account</string>
+    <string name="refresh_from_account_done">Up to date with your Apple account</string>
+    <string name="refresh_from_account_failed">Could not reach your Apple account just now. Your tags are unchanged.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -306,4 +306,7 @@ Vous pouvez configurer cela maintenant, ou à tout moment depuis les réglages.<
     <string name="error_report_body_export">L’app n’a pas pu créer d’archive à partir des tags choisis et ne sait pas dire pourquoi : réessayer avec les mêmes tags n’y changera rien.\n\nRien n’a été envoyé et rien n’a changé sur ce téléphone. Vos tags sont toujours là.</string>
     <string name="imported_from_x">Dernier import depuis %1$s</string>
     <string name="imported_from_nothing">Aucun tag importé depuis un fichier</string>
+    <string name="refresh_from_account">Actualiser depuis le compte Apple</string>
+    <string name="refresh_from_account_done">À jour avec votre compte Apple</string>
+    <string name="refresh_from_account_failed">Impossible de joindre votre compte Apple pour le moment. Vos tags sont inchangés.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -306,4 +306,7 @@
     <string name="error_report_body_export">選んだタグからバンドルを作成できず、その理由も判別できませんでした。同じタグで再試行しても解決しません。\n\n何も送信されておらず、この端末側も変わっていません。タグはそのまま残っています。</string>
     <string name="imported_from_x">直近の取得元：%1$s</string>
     <string name="imported_from_nothing">ファイルから取得したタグはありません</string>
+    <string name="refresh_from_account">Apple アカウントから更新</string>
+    <string name="refresh_from_account_done">Apple アカウントと同じ状態になりました</string>
+    <string name="refresh_from_account_failed">いま Apple アカウントに接続できませんでした。タグはそのままです。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -306,4 +306,7 @@
     <string name="error_report_body_export">선택한 태그로 번들을 만들지 못했고, 이유도 알 수 없습니다. 같은 태그로 다시 시도해도 해결되지 않습니다.\n\n아무것도 전송되지 않았고 이 휴대폰에서 바뀐 것도 없습니다. 태그는 그대로 있습니다.</string>
     <string name="imported_from_x">가장 최근에 가져온 곳: %1$s</string>
     <string name="imported_from_nothing">파일에서 가져온 태그가 없습니다</string>
+    <string name="refresh_from_account">Apple 계정에서 새로 고침</string>
+    <string name="refresh_from_account_done">Apple 계정과 동기화되었습니다</string>
+    <string name="refresh_from_account_failed">지금은 Apple 계정에 연결하지 못했습니다. 태그는 그대로입니다.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -306,4 +306,7 @@ Je kunt dit nu instellen, of later altijd nog via Instellingen.</string>
     <string name="error_report_body_export">De app kon van de gekozen tags geen bundel maken en kan niet zeggen waarom — het opnieuw proberen met dezelfde tags helpt dus niet.\n\nEr is niets verstuurd en er is niets veranderd op deze telefoon. Je tags staan er nog.</string>
     <string name="imported_from_x">Laatst geïmporteerd uit %1$s</string>
     <string name="imported_from_nothing">Geen tags uit een bestand geïmporteerd</string>
+    <string name="refresh_from_account">Vernieuwen vanaf Apple-account</string>
+    <string name="refresh_from_account_done">Bijgewerkt met je Apple-account</string>
+    <string name="refresh_from_account_failed">Je Apple-account was even niet bereikbaar. Je tags zijn ongewijzigd.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -306,4 +306,7 @@
     <string name="error_report_body_export">Приложение не смогло собрать пакет из выбранных меток и не может сказать почему, — повторная попытка с теми же метками не поможет.\n\nНичего не отправлено, и на телефоне ничего не изменилось. Ваши метки на месте.</string>
     <string name="imported_from_x">Последний импорт из %1$s</string>
     <string name="imported_from_nothing">Метки из файла не импортировались</string>
+    <string name="refresh_from_account">Обновить из учётной записи Apple</string>
+    <string name="refresh_from_account_done">Данные соответствуют учётной записи Apple</string>
+    <string name="refresh_from_account_failed">Сейчас не удалось связаться с учётной записью Apple. Метки не изменились.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -306,4 +306,7 @@
     <string name="error_report_body_export">应用无法用你选中的标签生成包，也说不出原因——用同样的标签重试没有用。\n\n没有发送任何东西，这台手机上也没有任何改变。你的标签都还在。</string>
     <string name="imported_from_x">最近一次导入自 %1$s</string>
     <string name="imported_from_nothing">没有从文件导入的标签</string>
+    <string name="refresh_from_account">从 Apple 账户刷新</string>
+    <string name="refresh_from_account_done">已与你的 Apple 账户同步</string>
+    <string name="refresh_from_account_failed">此刻无法连接你的 Apple 账户。标签没有变化。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -306,4 +306,7 @@
     <string name="error_report_body_export">App 無法用你選取的標籤產生包，也說不出原因——用同樣的標籤重試沒有用。\n\n沒有傳送任何東西，這支手機上也沒有任何改變。你的標籤都還在。</string>
     <string name="imported_from_x">最近一次匯入自 %1$s</string>
     <string name="imported_from_nothing">沒有從檔案匯入的標籤</string>
+    <string name="refresh_from_account">從 Apple 帳戶重新整理</string>
+    <string name="refresh_from_account_done">已與你的 Apple 帳戶同步</string>
+    <string name="refresh_from_account_failed">此刻無法連線到你的 Apple 帳戶。標籤沒有變化。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -338,4 +338,7 @@ You can set this up now, or any time later from Settings.</string>
     <string name="error_report_body_export">The app could not build a bundle from the tags you picked, and cannot say why — so trying again with the same tags will not help.\n\nNothing was sent and nothing on this phone has changed. Your tags are still here.</string>
     <string name="imported_from_x">Most recently imported from %1$s</string>
     <string name="imported_from_nothing">No tags imported from a file</string>
+    <string name="refresh_from_account">Refresh from Apple account</string>
+    <string name="refresh_from_account_done">Up to date with your Apple account</string>
+    <string name="refresh_from_account_failed">Could not reach your Apple account just now. Your tags are unchanged.</string>
 </resources>

--- a/app/src/test/java/dev/wander/android/opentagviewer/util/rx/AccountReadPolicyTest.java
+++ b/app/src/test/java/dev/wander/android/opentagviewer/util/rx/AccountReadPolicyTest.java
@@ -4,10 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 /**
  * When the app re-reads the Apple account on its own.
@@ -15,15 +12,26 @@ import org.junit.runner.RunWith;
  * <p>Pure bookkeeping, so it is tested by handing it clock values rather than by waiting. What it
  * decides is invisible either way: reading too often queues in front of the user's own work,
  * reading too rarely means a tag added in Find My never turns up, and neither throws.
+ *
+ * <p><b>On the JVM, where it always belonged.</b> This ran on the emulator for arithmetic and
+ * three booleans - see AGENTS.md rule 13. Moving it also made the change below visible: adding a
+ * parameter to the constructor broke nothing in the JVM suite, because the only test of this
+ * class was somewhere the JVM suite does not look.
  */
-@RunWith(AndroidJUnit4.class)
 public class AccountReadPolicyTest {
 
     private static final long SIX_HOURS = 6L * 60 * 60 * 1000;
+    private static final long FIFTEEN_MINUTES = 15L * 60 * 1000;
+    private static final long A_MINUTE = 60L * 1000;
     private static final long NOON = 1_700_000_000_000L;
 
     private AccountReadPolicy aPolicy() {
-        return new AccountReadPolicy(SIX_HOURS);
+        return new AccountReadPolicy(SIX_HOURS, A_MINUTE);
+    }
+
+    /** What the app actually ships now: fifteen minutes on the timer, one on resume. */
+    private AccountReadPolicy theRealOne() {
+        return new AccountReadPolicy(FIFTEEN_MINUTES, A_MINUTE);
     }
 
     /** Nothing to read, and nothing to say about it. */
@@ -128,5 +136,75 @@ public class AccountReadPolicyTest {
         for (final AccountReadPolicy.Decision decision : AccountReadPolicy.Decision.values()) {
             assertFalse(decision + " has nothing to say", decision.reason().isBlank());
         }
+    }
+
+    /**
+     * <b>Resuming reads sooner than the timer would, and that difference is the feature.</b>
+     *
+     * <p>Six hours was the old interval, and an iPad picks up a renamed AirTag in seconds - so a
+     * tag renamed on somebody's own iPad kept its old name here for the rest of the afternoon.
+     * The moment that is noticed is the moment the app is opened, which is why resuming has a
+     * floor of its own rather than sharing the timer's.
+     *
+     * <p>Asserted as the difference rather than as two numbers: at five minutes one goes and the
+     * other does not, and swapping the intervals flips exactly this.
+     */
+    @Test
+    public void resumingReadsSoonerThanTheTimerWould() {
+        final AccountReadPolicy policy = theRealOne();
+        policy.markRead(NOON);
+
+        final long fiveMinutesLater = NOON + 5L * 60 * 1000;
+
+        assertFalse("the timer should still be waiting at five minutes",
+                policy.decide(fiveMinutesLater, true, false).shouldRead());
+        assertTrue("opening the app at five minutes should read",
+                policy.decideOnResume(fiveMinutesLater, true, false).shouldRead());
+    }
+
+    /** But resuming still has a floor, or flicking between two apps costs a Python call each. */
+    @Test
+    public void resumingTwiceInAMomentOnlyReadsOnce() {
+        final AccountReadPolicy policy = theRealOne();
+        policy.markRead(NOON);
+
+        assertEquals(AccountReadPolicy.Decision.TOO_SOON,
+                policy.decideOnResume(NOON + 30_000L, true, false));
+        assertTrue("and it opens up again once the floor has passed",
+                policy.decideOnResume(NOON + A_MINUTE + 1, true, false).shouldRead());
+    }
+
+    /** The timer does come round, and fifteen minutes is when. */
+    @Test
+    public void thetimerReadsAgainAfterFifteenMinutes() {
+        final AccountReadPolicy policy = theRealOne();
+        policy.markRead(NOON);
+
+        assertFalse(policy.decide(NOON + FIFTEEN_MINUTES - 1, true, false).shouldRead());
+        assertTrue(policy.decide(NOON + FIFTEEN_MINUTES, true, false).shouldRead());
+    }
+
+    /** Resuming is subject to the same two guards as the timer, not a way round them. */
+    @Test
+    public void resumingObeysBusyAndUnlinkedToo() {
+        assertEquals(AccountReadPolicy.Decision.NOT_LINKED,
+                theRealOne().decideOnResume(NOON, false, false));
+        assertEquals(AccountReadPolicy.Decision.BUSY,
+                theRealOne().decideOnResume(NOON, true, true));
+    }
+
+    /**
+     * And zero really is "never read" rather than "read in 1970".
+     *
+     * <p>{@code hasEverRead()} is {@code lastReadAt > 0}, so marking a read at the epoch marks
+     * nothing - which is worth pinning, because a test that does it by accident passes every
+     * interval check and looks like the policy is broken.
+     */
+    @Test
+    public void markingAReadAtTheEpochMarksNothing() {
+        final AccountReadPolicy policy = theRealOne();
+        policy.markRead(0L);
+
+        assertTrue(policy.decide(1L, true, false).shouldRead());
     }
 }


### PR DESCRIPTION
## Six hours to notice a rename, when an iPad takes seconds

Renaming an AirTag on your own iPad shows up there almost immediately. This app re-read the
account **every six hours**, so the old name sat on screen for the rest of the afternoon — which
reads as the app being broken rather than patient.

Four ways it updates now, and the difference between them is **who asked**:

| Route | When | A refused sign-in |
| --- | --- | --- |
| Settings → read all devices | on demand | → sign in again *(#151)* |
| **My Devices → overflow menu** | on demand | → sign in again |
| **On resume** | 60-second floor | logs, changes nothing |
| **Every 15 minutes** while open | was 6 hours | logs, changes nothing |

Fifteen minutes is not reckless: the location fetch beside it runs **every minute**, so four
account reads an hour is not the expensive thing here. The floor on resume exists because
resuming happens on every task switch, and a Python call for flicking between two apps is waste.

The menu item replaces "Link an account" once linking is done — only one of the two is ever what
somebody wants, and offering both reads as three ways in rather than two.

## The device-registration page appeared every time

The page explaining what this app put on your Apple account — a row titled after a Mac you do not
own, next to a button offering to remove things you do not recognise, where removing it breaks
your session — was shown on **every** run of the iCloud flow.

It describes an event. Re-reading a linked account causes none of it, so the page was explaining
something that had not happened, to somebody who read it the first time. A page that turns up
when nothing has happened is one people learn to tap past, including on the run where it matters.

It now shows only when the connection actually registered a device. A fresh install still gets it,
because each one really does add another row.

## A design flaw the tests found

`AccountRefresher` **swallowed** a refused sign-in into an empty list — so the manual refresh's
`onError` never fired, and a read that failed looked identical to a successful read of nothing.
The "who asked" decision was sitting inside the one component that cannot know the answer.

It now reports, and each caller decides. Found only because the test drove the menu item rather
than the refresher directly.

## Testing

`AccountReadPolicyTest` **moves to the JVM**, where arithmetic and three booleans always belonged
(rule 13). That move is also what exposed the gap: adding a parameter to the constructor broke
nothing in the JVM suite, because the only test of the class lived somewhere the JVM suite does
not look.

New: `RefreshingFromTheAccountTest` (the menu item, including that an *outage* must **not** cost a
sign-in) and `TheDeviceNoteIsShownOnceTest` (shown on a first connection, absent on a re-read, and
the button reads Done rather than Next).

One test hung the suite before it worked: a Toast matched with `inRoot(withDecorView(not(...)))`
sends Espresso's root picker hunting for a window that is not up yet, retrying for seconds per
attempt inside a retry loop. Killed after ten minutes at three tests of seven. A call count on the
fake answers instantly.

## Also

**AGENTS.md rule 14** — every call reaching the account has to answer "is this session dead?",
through the shared decision rather than its own, with the who-asked line written down.

## Stacked on #151

Branched from `fix/a-dead-icloud-session-says-so`, because a manual refresh that meets a dead
session needs the classification that PR adds. Merge #151 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
