### PR TITLE
Refresh the wiki's screenshots from the running app, and get the last Settings row out from under the navigation bar

### DIFF
--- a/.claude/skills/device-screenshots/SKILL.md
+++ b/.claude/skills/device-screenshots/SKILL.md
@@ -40,6 +40,26 @@ my_device_list_item-wallpaper.png                                    variant "wa
 
 Needs Pillow (`python -m pip install pillow`).
 
+## Screenshots that go somewhere public
+
+A capture destined for the wiki or an issue is a screenshot of *a real build on a real device*,
+and some of what is on it belongs to whoever took it. The AMap key dialog is the worked example:
+it prints the package name and signing fingerprint, because that is exactly what AMap's console
+asks you to paste — correct behaviour, and not something to publish.
+
+```bash
+py -3 .claude/skills/device-screenshots/blur.py shot.png --band 0.42 0.55
+```
+
+`--band` takes fractions of the height, so it survives a change of device resolution; repeat it
+for more than one strip. Blur rather than crop — a cropped dialog looks like it has fewer fields
+than it does, and the next person wonders what was removed. It pixelates before blurring, so the
+characters are gone rather than merely soft.
+
+Worth a look before publishing any capture: a signed-in email address, a real street name from
+the geocoder, a `XXXX-XXXX-XXXX` bundle passcode, coordinates. The capture classes fabricate all
+of those on purpose; a hand-taken screenshot does not.
+
 ## Getting the screenshots
 
 `SystemColorsLayoutTest` is the working example. Inflate a layout — or load a drawable —

--- a/.claude/skills/device-screenshots/blur.py
+++ b/.claude/skills/device-screenshots/blur.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Blur a horizontal band of a screenshot, for images that go on the wiki.
+
+The AMap key dialog prints the package name and signing fingerprint of whatever build took
+the screenshot, because that is exactly what AMap asks you to paste into its console. On a
+debug build those identify one developer's machine, and they have no business on a public
+page - the reader needs to see *that the dialog shows them*, not what mine are.
+
+Blurring rather than cropping on purpose: a cropped screenshot looks like the dialog has two
+fields, and the next person wonders where the other lines went.
+
+    python scripts/blur_wiki_lines.py shot.png --band 0.42 0.55
+
+--band takes fractions of the image height, so it does not depend on the device's resolution.
+Repeat it for more than one band. Writes in place unless --out is given.
+"""
+import argparse
+import sys
+
+try:
+    # Suppressed for the reason spelled out in sheet.py beside this.
+    from PIL import Image, ImageFilter  # pyright: ignore[reportMissingImports]
+except ImportError:
+    sys.exit("needs Pillow: py -3 -m pip install pillow")
+
+
+def blur_band(image, top, bottom, radius):
+    """Blur one horizontal strip, given as fractions of the height."""
+    box = (0, int(image.height * top), image.width, int(image.height * bottom))
+    region = image.crop(box)
+
+    # Downscale and back up before blurring. A Gaussian blur alone leaves text legible to
+    # anything that sharpens it, and the point here is that the characters are gone, not
+    # merely soft.
+    small = region.resize((max(1, region.width // 12), max(1, region.height // 12)))
+    region = small.resize(region.size, Image.NEAREST).filter(ImageFilter.GaussianBlur(radius))
+
+    image.paste(region, box)
+    return image
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("image")
+    parser.add_argument("--band", nargs=2, type=float, action="append", metavar=("TOP", "BOTTOM"),
+                        required=True, help="fractions of image height, e.g. --band 0.42 0.55")
+    parser.add_argument("--radius", type=float, default=6.0)
+    parser.add_argument("--out", help="defaults to overwriting the input")
+    args = parser.parse_args()
+
+    image = Image.open(args.image).convert("RGB")
+    for top, bottom in args.band:
+        if not 0.0 <= top < bottom <= 1.0:
+            sys.exit(f"band {top}-{bottom} is not a fraction of the height, low to high")
+        blur_band(image, top, bottom, args.radius)
+
+    out = args.out or args.image
+    image.save(out)
+    print(f"blurred {len(args.band)} band(s) -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/device-screenshots/blur.py
+++ b/.claude/skills/device-screenshots/blur.py
@@ -24,9 +24,16 @@ except ImportError:
     sys.exit("needs Pillow: py -3 -m pip install pillow")
 
 
-def blur_band(image, top, bottom, radius):
-    """Blur one horizontal strip, given as fractions of the height."""
-    box = (0, int(image.height * top), image.width, int(image.height * bottom))
+def blur_band(image, top, bottom, radius, left=0.0, right=1.0):
+    """Blur one strip, given as fractions of the height (and optionally the width).
+
+    Bounding it horizontally matters more than it sounds. A band across the full width of a
+    screenshot of a *dialog* also blurs the dimmed page behind it, and the result is a pale
+    rectangle running off both sides of the dialog - which reads as a rendering fault rather
+    than as a redaction.
+    """
+    box = (int(image.width * left), int(image.height * top),
+           int(image.width * right), int(image.height * bottom))
     region = image.crop(box)
 
     # Downscale and back up before blurring. A Gaussian blur alone leaves text legible to
@@ -45,15 +52,21 @@ def main():
     parser.add_argument("image")
     parser.add_argument("--band", nargs=2, type=float, action="append", metavar=("TOP", "BOTTOM"),
                         required=True, help="fractions of image height, e.g. --band 0.42 0.55")
+    parser.add_argument("--x", nargs=2, type=float, metavar=("LEFT", "RIGHT"), default=[0.0, 1.0],
+                        help="fractions of the width to bound every band to, e.g. --x 0.1 0.9")
     parser.add_argument("--radius", type=float, default=6.0)
     parser.add_argument("--out", help="defaults to overwriting the input")
     args = parser.parse_args()
+
+    left, right = args.x
+    if not 0.0 <= left < right <= 1.0:
+        sys.exit(f"--x {left} {right} is not a fraction of the width, low to high")
 
     image = Image.open(args.image).convert("RGB")
     for top, bottom in args.band:
         if not 0.0 <= top < bottom <= 1.0:
             sys.exit(f"band {top}-{bottom} is not a fraction of the height, low to high")
-        blur_band(image, top, bottom, args.radius)
+        blur_band(image, top, bottom, args.radius, left, right)
 
     out = args.out or args.image
     image.save(out)

--- a/.claude/skills/device-screenshots/sheet.py
+++ b/.claude/skills/device-screenshots/sheet.py
@@ -40,7 +40,10 @@ from collections import OrderedDict
 from pathlib import Path
 
 try:
-    from PIL import Image, ImageDraw
+    # Pillow is not in the exporter venv pyright resolves against, so the pre-commit hook would
+    # reject this file for a dependency it is right not to have. Suppressed at the line rather
+    # than in pyrightconfig.json, which would hide genuinely missing imports everywhere else.
+    from PIL import Image, ImageDraw  # pyright: ignore[reportMissingImports]
 except ImportError:  # pragma: no cover - the message is the whole point
     sys.exit("Pillow is required: python -m pip install pillow")
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -729,6 +729,19 @@ The instrumented job needs KVM on the runner; the workflow enables it first. It 
 `:app:testEmulatorDebugAndroidTest` managed device you run locally, so there is no second
 emulator definition in CI to keep in step with `app/build.gradle.kts`.
 
+### A PR stacked on another PR gets no checks at all
+
+Every workflow above filters on `pull_request: branches: ["main"]`, and that filter matches the
+**base** of the PR, not the branch the changes are on. So a PR opened against another PR's branch
+runs nothing — no translation check, no tests, no build.
+
+It does not look like a problem. The checks section is simply absent rather than red or pending,
+which reads as "nothing to run here" and not as "nothing ran". Merge the base, retarget the child
+at `main`, and the whole suite appears.
+
+Stacking is still often the right shape for a chain of dependent work. Just know that the second
+PR is unverified until it points at `main`, and do not read its empty checks list as a pass.
+
 ---
 
 ## Releasing the exporter

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,7 @@ wizard).
 | Android instrumented tests | `app/src/androidTest/java/` | Gradle / JUnit + emulator | provisioned for you |
 | Anisette tests | `app/src/androidTest/java/.../anisette/` | as above, **opt-in** | yes, and network |
 | UI tests | `AppleLoginFlowTest`, `app/src/androidTest/java/.../ui/` | Espresso, on the managed device | provisioned for you |
+| Wiki screenshots | `app/src/androidTest/java/.../ui/WikiScreenshots*Test` | as above, **opt-in** | a windowed emulator |
 | Chaquopy bridge tests | `app/src/test/python/` | pytest | no |
 | Desktop exporter tests | `python/test/` | pytest | no |
 | Shared export package | `python/opentagviewer_export/tests/` | pytest | no |
@@ -373,6 +374,39 @@ the verification manifest, then run them again:
 python scripts/update_adi_stub_symbols.py           # regenerate
 python scripts/update_adi_stub_symbols.py --check   # what CI runs weekly
 ```
+
+### Wiki screenshots (skipped by default)
+
+`WikiScreenshotsTest`, `WikiScreenshotsFromTheMapTest` and `WikiScreenshotsOfSigningInTest`
+photograph the app's screens for the wiki. They are a documentation tool rather than tests —
+each one ends in a `Shot` and asserts almost nothing — so they are skipped unless asked for:
+
+```bash
+ANDROID_SERIAL=emulator-5554 ./gradlew :app:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.captureScreenshots=true \
+  -Pandroid.testInstrumentationRunnerArguments.class=dev.wander.android.opentagviewer.ui.WikiScreenshotsTest
+```
+
+Images land in `app/build/outputs/connected_android_test_additional_output/…`. **Copy them out
+before the next run** — AGP wipes that directory when a run starts, which has already lost a
+full set.
+
+Three things they need, and one that will surprise you:
+
+- **A windowed emulator with Play Services**, not the managed device: two of them photograph a
+  real Google map, and the managed `aosp-atd` image cannot draw one. Keep its window focused or
+  Espresso fails with `RootViewWithoutFocusException`.
+- **`connectedDebugAndroidTest` uninstalls the app afterwards**, wiping that device's session,
+  settings and imported beacons. Only ever aim it at a throwaway emulator, and set
+  `ANDROID_SERIAL` so it cannot reach a phone.
+- **The map class is slow, and it is the teardown.** About 50s per test, of which ~45s is
+  `AMapWithTagsOnIt.putItBack` — measured; setup is around two seconds. Worth knowing before
+  concluding that the map, the dialogs or the tile wait are responsible, all of which look
+  guilty and are not.
+
+Before publishing one, look at what is actually on it — a signed-in address, a real street name
+from the geocoder, a bundle passcode, a signing fingerprint.
+`.claude/skills/device-screenshots/blur.py` takes bands out by height fraction.
 
 ### Android unit tests
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -554,3 +554,28 @@ dependencies {
 
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 }
+
+/**
+ * **Stop a locked results directory failing the run before it starts.**
+ *
+ * Gradle hashes this task's outputs for up-to-date checks, and on Windows Android Studio holds
+ * `app/build/outputs/androidTest-results/connected/` open - so the hash fails and the build dies
+ * with `Cannot access output property 'resultsDir' ... Failed to create MD5 hash for file
+ * content`, or a `FileSystemException` naming a logcat file. Neither message mentions the real
+ * cause, and deleting the directory appears to succeed while silently leaving the locked file
+ * behind. It cost three runs here before Studio was identified as the holder.
+ *
+ * Nothing is lost by not tracking it: an instrumented run is never up to date anyway - it has to
+ * talk to a device - so the caching this disables was never doing anything. Gradle's own error
+ * suggests exactly this.
+ *
+ * The managed-device task is untouched, because `managedDevice/` is not the directory Studio
+ * watches.
+ */
+tasks.matching { it.name.startsWith("connected") && it.name.endsWith("AndroidTest") }
+    .configureEach {
+        doNotTrackState(
+            "Android Studio holds the connected results directory open on Windows, and an" +
+                " instrumented run is never up to date regardless.",
+        )
+    }

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/python/icloud/FakeICloudService.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/python/icloud/FakeICloudService.java
@@ -124,6 +124,12 @@ public final class FakeICloudService implements ICloudService {
         return fake;
     }
 
+    /** Make the next unlock fail. For screenshots and for tests of the wrong-code state. */
+    public FakeICloudService failUnlockWith(final ICloudException failure) {
+        this.unlockFailsWith = failure;
+        return this;
+    }
+
     /** Nothing reported usable at all, which reads as a service having a bad day. */
     public static FakeICloudService whereTheServiceIsUnsure() {
         final FakeICloudService fake = new FakeICloudService();

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/OnlyWhenCapturing.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/OnlyWhenCapturing.java
@@ -1,0 +1,46 @@
+package dev.wander.android.opentagviewer.ui;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Assume;
+
+/**
+ * The switch that keeps the wiki capture classes out of an ordinary run.
+ *
+ * <p><b>They are a documentation tool, not tests.</b> Every one of them ends in a screenshot and
+ * asserts almost nothing, so a green run of them says nothing about the app - and they are
+ * expensive: seven captures of the map screens took six minutes on a windowed emulator, which is
+ * most of it teardown, and two of them need Play Services and a real Maps key that the managed
+ * device does not have. Left switched on they would add twenty minutes to a suite people are
+ * meant to run constantly, which is how a suite stops being run.
+ *
+ * <p>So they are skipped unless asked for:
+ *
+ * <pre>
+ * ANDROID_SERIAL=emulator-5554 ./gradlew :app:connectedDebugAndroidTest \
+ *   -Pandroid.testInstrumentationRunnerArguments.captureScreenshots=true \
+ *   -Pandroid.testInstrumentationRunnerArguments.class=dev.wander.android.opentagviewer.ui.WikiScreenshotsTest
+ * </pre>
+ *
+ * <p>Skipped rather than deleted because the point of them is that the images can be made again -
+ * the wiki's previous set came from several phones over several years, and nothing recorded how
+ * any of them was taken. Same mechanism as the Anisette live tests, for the same reason.
+ *
+ * <p>Note {@code connectedDebugAndroidTest} <b>uninstalls the app afterwards</b>, so only ever
+ * aim this at a throwaway emulator - see AGENTS.md.
+ */
+public final class OnlyWhenCapturing {
+
+    private static final String ARG = "captureScreenshots";
+
+    private OnlyWhenCapturing() {}
+
+    /** Call from {@code @Before}. Skips the class unless the argument was passed. */
+    public static void wasAskedFor() {
+        Assume.assumeTrue(
+                "skipped: pass -Pandroid.testInstrumentationRunnerArguments." + ARG + "=true to "
+                        + "capture the wiki's screenshots. These take screenshots rather than "
+                        + "asserting, and the map ones need Play Services.",
+                "true".equals(InstrumentationRegistry.getArguments().getString(ARG)));
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsFromTheMapTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsFromTheMapTest.java
@@ -27,8 +27,12 @@ import androidx.test.filters.LargeTest;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+
+import java.util.Set;
 
 import java.nio.charset.StandardCharsets;
 import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
@@ -68,6 +72,20 @@ public class WikiScreenshotsFromTheMapTest {
     /** How long to let Google fetch tiles before photographing the map. */
     private static final long TILES_TAKE_A_MOMENT = 6000L;
 
+    /**
+     * The captures with a map actually in shot - everything else here photographs Settings.
+     *
+     * <p>Named rather than annotated because the decision is made in {@code @Before}, before any
+     * test body runs, and a name is the only thing available there. The cost of getting it wrong
+     * is visible either way: forget to add a map capture and it is photographed over a blank grey
+     * rectangle.
+     */
+    private static final Set<String> NEEDS_A_DRAWN_MAP =
+            Set.of("atheoverflowMenuOnTheMap", "gtheexportLogsButton");
+
+    @Rule
+    public final TestName testName = new TestName();
+
     private final AMapWithTagsOnIt theMap = new AMapWithTagsOnIt();
 
     @Before
@@ -87,18 +105,32 @@ public class WikiScreenshotsFromTheMapTest {
 
         this.theMap.seed("Bike", "Keys");
 
-        // **The real Google map, not the fake one.** The fixture substitutes FakeMapProvider
-        // because the managed device has no Play Services - but these are captured on a windowed
-        // emulator that has them, and the wiki page these replace shows a real map. Everything
-        // else the fixture arranges is still needed; only the drawing is handed back.
+        // **The real Google map, but only for the two captures that photograph one.** The fixture
+        // substitutes FakeMapProvider because the managed device has no Play Services; these are
+        // captured on a windowed emulator that has them, and the wiki page these replace shows a
+        // real map. Everything else the fixture arranges is still needed.
         //
         // The pin sits at 48.85837, 2.29448 - the Eiffel Tower - which is recognisable, obviously
         // nobody's home, and paired with a geocoder that answers "A made-up street, in a made-up
         // town" so no real address reaches a public page.
-        MapProviderFactory.reset();
+        //
+        // **It is handed back per test because it costs about fifty seconds.** Measured: the same
+        // fixture with the fake provider runs a test in 1.3-2.8s, and with the real Google map
+        // every test in this class landed between 52.4s and 55.0s - including the two that only
+        // open a dialog. Bringing the Maps SDK up and tearing it down again dominates everything
+        // else, and five of these seven screens are Settings, a full-screen activity with no map
+        // behind it at all. Paying for it there bought a blank sixth of a screenshot nobody sees.
+        final boolean weArePhotographingTheMap =
+                NEEDS_A_DRAWN_MAP.contains(this.testName.getMethodName());
+        if (weArePhotographingTheMap) {
+            MapProviderFactory.reset();
+        }
         givenSomebodyIsSignedIn();
 
         this.theMap.open();
+
+        Eventually.check(() -> onView(withId(R.id.button_more_settings))
+                .check(matches(isDisplayed())));
 
         // **Waiting for the chrome is not waiting for the map.** The overflow button is drawn
         // immediately; Google's tiles arrive over the network seconds later, and a screenshot
@@ -106,9 +138,9 @@ public class WikiScreenshotsFromTheMapTest {
         // a loading one. There is no callback to hang this on from out here, so it is a wait -
         // the one place in this repo where sleeping is the honest answer, because what is being
         // waited for is a third party's tile download and not anything the app decides.
-        Eventually.check(() -> onView(withId(R.id.button_more_settings))
-                .check(matches(isDisplayed())));
-        android.os.SystemClock.sleep(TILES_TAKE_A_MOMENT);
+        if (weArePhotographingTheMap) {
+            android.os.SystemClock.sleep(TILES_TAKE_A_MOMENT);
+        }
     }
 
     @After
@@ -180,7 +212,11 @@ public class WikiScreenshotsFromTheMapTest {
     public void ctheanisetteServerDialog() {
         this.openSettingsAndTap(R.id.setting_app_anisette_server);
 
-        Eventually.check(() -> onView(withText(R.string.anisette_server_url)).inRoot(isDialog())
+        // **Waited for by id, not by its label.** This matched the text "Anisette Server URL" and
+        // stopped matching when the dialog grew a local/remote mode dropdown: that string is now
+        // the field's helper text rather than a TextView of its own. The id survived the redesign
+        // and the wording will not.
+        Eventually.check(() -> onView(withId(R.id.anisetteServerUrl)).inRoot(isDialog())
                 .check(matches(isDisplayed())));
         Shot.ofTheScreen("settings-2-anisette-server");
     }
@@ -235,9 +271,14 @@ public class WikiScreenshotsFromTheMapTest {
         this.openTheOverflow();
         onView(withText(R.string.settings)).inRoot(isPlatformPopup()).perform(click());
 
+        // **Scroll first, then assert it is on screen** - not the other way round. The switch is
+        // the last row of the Settings ScrollView, so isDisplayed() is false until something
+        // brings it into view: Espresso reported it VISIBLE with a 832x126 size and an empty
+        // global visible rect, which reads as a contradiction until you notice it means
+        // "laid out, off screen". scrollTo() only needs the view to exist.
         Eventually.check(() -> onView(withId(R.id.settings_app_debug_data_enabled))
-                .check(matches(isDisplayed())));
-        onView(withId(R.id.settings_app_debug_data_enabled)).perform(scrollTo(), click());
+                .perform(scrollTo()));
+        onView(withId(R.id.settings_app_debug_data_enabled)).perform(click());
 
         // Photographed switched on, since that is the state the next step needs. The fixture's
         // DeviceStateGuard puts the setting back afterwards.
@@ -262,9 +303,14 @@ public class WikiScreenshotsFromTheMapTest {
         this.openTheOverflow();
         onView(withText(R.string.settings)).inRoot(isPlatformPopup()).perform(click());
 
+        // **Scroll first, then assert it is on screen** - not the other way round. The switch is
+        // the last row of the Settings ScrollView, so isDisplayed() is false until something
+        // brings it into view: Espresso reported it VISIBLE with a 832x126 size and an empty
+        // global visible rect, which reads as a contradiction until you notice it means
+        // "laid out, off screen". scrollTo() only needs the view to exist.
         Eventually.check(() -> onView(withId(R.id.settings_app_debug_data_enabled))
-                .check(matches(isDisplayed())));
-        onView(withId(R.id.settings_app_debug_data_enabled)).perform(scrollTo(), click());
+                .perform(scrollTo()));
+        onView(withId(R.id.settings_app_debug_data_enabled)).perform(click());
         Eventually.check(() -> onView(withId(R.id.settings_app_debug_data_enabled))
                 .check(matches(isChecked())));
 

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsFromTheMapTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsFromTheMapTest.java
@@ -27,7 +27,6 @@ import androidx.test.filters.LargeTest;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -90,21 +89,28 @@ public class WikiScreenshotsFromTheMapTest {
     private final AMapWithTagsOnIt theMap = new AMapWithTagsOnIt();
 
     /**
-     * <b>{@code @BeforeClass}, not {@code @Before}, and that distinction is the whole of it.</b>
+     * <b>Skipped per test, and the teardown knows setup never ran.</b>
      *
-     * <p>An assumption failure in {@code @Before} skips the test body and then runs {@code @After}
-     * anyway - which tore down Intents that were never initialised and reported every test as
-     * FAILED with "init() must be called prior to using this method". Skipped tests that report as
-     * failures are worse than tests that run. From {@code @BeforeClass} the class is passed over
-     * whole, and neither hook runs.
+     * <p>Two wrong shapes were tried first, and each broke the suite a different way. In
+     * {@code @Before} alone, the assumption skips the test body but JUnit runs {@code @After}
+     * regardless, which tore down Intents that were never initialised and reported every test as
+     * FAILED. Moved to {@code @BeforeClass}, the class is passed over in silence - and the
+     * instrumentation then reports fewer results than the APK declares tests, so AGP calls the
+     * whole run aborted: "Expected 640 tests, received 623", where the 17 missing are exactly the
+     * contents of these three classes. Zero failures, and a red build that reads as a dead
+     * emulator.
+     *
+     * <p>So the assumption stays here, where each test is reported as skipped and counted, and
+     * {@link #putEverythingBack} returns early rather than undoing work that was never done.
      */
-    @BeforeClass
-    public static void onlyWhenCapturing() {
-        OnlyWhenCapturing.wasAskedFor();
-    }
+    /** False when the assumption above skipped setup, so teardown undoes nothing. */
+    private boolean setUpRan;
 
     @Before
     public void openTheMap() {
+        OnlyWhenCapturing.wasAskedFor();
+        this.setUpRan = true;
+
         Intents.init();
 
         // **Everything except the two screens this actually walks into.** The test this was
@@ -160,6 +166,10 @@ public class WikiScreenshotsFromTheMapTest {
 
     @After
     public void putEverythingBack() {
+        if (!this.setUpRan) {
+            return;
+        }
+
         this.theMap.putItBack();
         Intents.release();
     }

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsFromTheMapTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsFromTheMapTest.java
@@ -27,6 +27,7 @@ import androidx.test.filters.LargeTest;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -88,10 +89,22 @@ public class WikiScreenshotsFromTheMapTest {
 
     private final AMapWithTagsOnIt theMap = new AMapWithTagsOnIt();
 
+    /**
+     * <b>{@code @BeforeClass}, not {@code @Before}, and that distinction is the whole of it.</b>
+     *
+     * <p>An assumption failure in {@code @Before} skips the test body and then runs {@code @After}
+     * anyway - which tore down Intents that were never initialised and reported every test as
+     * FAILED with "init() must be called prior to using this method". Skipped tests that report as
+     * failures are worse than tests that run. From {@code @BeforeClass} the class is passed over
+     * whole, and neither hook runs.
+     */
+    @BeforeClass
+    public static void onlyWhenCapturing() {
+        OnlyWhenCapturing.wasAskedFor();
+    }
+
     @Before
     public void openTheMap() {
-        OnlyWhenCapturing.wasAskedFor();
-
         Intents.init();
 
         // **Everything except the two screens this actually walks into.** The test this was

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsFromTheMapTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsFromTheMapTest.java
@@ -1,0 +1,286 @@
+package dev.wander.android.opentagviewer.ui;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.pressBack;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.RootMatchers.isPlatformPopup;
+import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import android.app.Instrumentation.ActivityResult;
+
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.nio.charset.StandardCharsets;
+import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
+import dev.wander.android.opentagviewer.db.repo.UserAuthRepository;
+import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.MapsActivity;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.SettingsActivity;
+import dev.wander.android.opentagviewer.Shot;
+import dev.wander.android.opentagviewer.ui.maps.MapProviderFactory;
+import dev.wander.android.opentagviewer.ui.maps.AMapWithTagsOnIt;
+
+/**
+ * The screens that only exist once somebody is signed in, for the wiki.
+ *
+ * <p><b>Split from {@code WikiScreenshotsTest} because reaching a drawn map is eight steps.</b>
+ * A stored session, the Python double, a substituted map provider, a geocoder, beacons with
+ * usable accessory JSON, somewhere to draw them, and a refresh policy that does not skip the
+ * first fetch - {@code AMapWithTagsOnIt} arranges all of it, and the screens in the other class
+ * need none of it.
+ *
+ * <p><b>The map is the real Google one.</b> The fixture substitutes a fake because the managed
+ * device has no Play Services; these are captured on a windowed emulator that has them and with
+ * a real Maps key, so the drawing is handed back and the page looks like the app does. Only the
+ * map is real - the session, the tags, the locations and the address are all fabricated.
+ *
+ * <p><b>So this class cannot run on the managed device</b>, and does not pretend to: without
+ * Play Services the map never initialises and the captures would be of a blank screen.
+ *
+ * <p>Everything on screen is fabricated. See the sibling class for the rest of the caveats.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class WikiScreenshotsFromTheMapTest {
+
+    /** How long to let Google fetch tiles before photographing the map. */
+    private static final long TILES_TAKE_A_MOMENT = 6000L;
+
+    private final AMapWithTagsOnIt theMap = new AMapWithTagsOnIt();
+
+    @Before
+    public void openTheMap() {
+        Intents.init();
+
+        // **Everything except the two screens this actually walks into.** The test this was
+        // copied from stubs everything-but-Maps because it only asserts intents and never
+        // navigates - so Settings was answered at the door and never launched, and three
+        // captures failed on a page that could not appear. Stubbing MapsActivity itself is the
+        // other half of the same trap: the map is then never allowed to exist, which presents as
+        // a six-minute hang rather than a failure. See EveryButtonOnTheMapGoesSomewhereTest.
+        intending(allOf(
+                not(hasComponent(MapsActivity.class.getName())),
+                not(hasComponent(SettingsActivity.class.getName()))))
+                .respondWith(new ActivityResult(Activity.RESULT_OK, null));
+
+        this.theMap.seed("Bike", "Keys");
+
+        // **The real Google map, not the fake one.** The fixture substitutes FakeMapProvider
+        // because the managed device has no Play Services - but these are captured on a windowed
+        // emulator that has them, and the wiki page these replace shows a real map. Everything
+        // else the fixture arranges is still needed; only the drawing is handed back.
+        //
+        // The pin sits at 48.85837, 2.29448 - the Eiffel Tower - which is recognisable, obviously
+        // nobody's home, and paired with a geocoder that answers "A made-up street, in a made-up
+        // town" so no real address reaches a public page.
+        MapProviderFactory.reset();
+        givenSomebodyIsSignedIn();
+
+        this.theMap.open();
+
+        // **Waiting for the chrome is not waiting for the map.** The overflow button is drawn
+        // immediately; Google's tiles arrive over the network seconds later, and a screenshot
+        // taken in between is of a blank grey rectangle that looks like a broken map rather than
+        // a loading one. There is no callback to hang this on from out here, so it is a wait -
+        // the one place in this repo where sleeping is the honest answer, because what is being
+        // waited for is a third party's tile download and not anything the app decides.
+        Eventually.check(() -> onView(withId(R.id.button_more_settings))
+                .check(matches(isDisplayed())));
+        android.os.SystemClock.sleep(TILES_TAKE_A_MOMENT);
+    }
+
+    @After
+    public void putEverythingBack() {
+        this.theMap.putItBack();
+        Intents.release();
+    }
+
+    /**
+     * A session that carries a name and an address, so Settings has something to show.
+     *
+     * <p><b>The fixture stores a deliberately unrestorable blob</b> - the tests that use it care
+     * that a session <i>exists</i>, not what is in it, and one that cannot be restored is the
+     * cheapest way to have one. Settings then finds no account details and leaves "Logged In As"
+     * blank above a lone Logout button, which is correct behaviour and a poor advertisement.
+     *
+     * <p>Written afterwards rather than by changing the fixture: every other test using it wants
+     * the unrestorable one, and a session that suddenly looks real could send one of them down a
+     * path it was never meant to take.
+     *
+     * <p>Invented, obviously. The name and the address belong to nobody.
+     */
+    private static void givenSomebodyIsSignedIn() {
+        new UserAuthRepository(
+                UserAuthDataStore.getInstance(
+                        getInstrumentation().getTargetContext().getApplicationContext()),
+                new AppCryptographyUtil())
+                .storeUserAuth(("{\"account\":{\"info\":{"
+                        + "\"account_name\":\"jamie.lang@example.com\","
+                        + "\"first_name\":\"Jamie\","
+                        + "\"last_name\":\"Lang\"}}}").getBytes(StandardCharsets.UTF_8))
+                .blockingAwait();
+    }
+
+    private void openTheOverflow() {
+        Eventually.check(() -> onView(withId(R.id.button_more_settings))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.button_more_settings)).perform(click());
+    }
+
+    /**
+     * The menu the wiki's "change your Anisette server" page starts from.
+     *
+     * <p>Its current image predates this UI: a different device, an older navigation bar and a
+     * clock from another year. Step one of three.
+     */
+    @Test
+    public void atheoverflowMenuOnTheMap() {
+        this.openTheOverflow();
+
+        Eventually.check(() -> onView(withText(R.string.settings)).inRoot(isPlatformPopup())
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("map-1-overflow-menu");
+    }
+
+    /** Step two: the settings page itself. */
+    @Test
+    public void bthesettingsPage() {
+        this.openTheOverflow();
+        onView(withText(R.string.settings)).inRoot(isPlatformPopup()).perform(click());
+
+        Eventually.check(() -> onView(withId(R.id.setting_app_anisette_server))
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("settings-1-page");
+    }
+
+    /** Step three: the Anisette server dialog, warning that changing it costs a sign-in. */
+    @Test
+    public void ctheanisetteServerDialog() {
+        this.openSettingsAndTap(R.id.setting_app_anisette_server);
+
+        Eventually.check(() -> onView(withText(R.string.anisette_server_url)).inRoot(isDialog())
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("settings-2-anisette-server");
+    }
+
+    /** Choosing between Google Maps and AMap. */
+    @Test
+    public void dthemapProviderChoice() {
+        this.openSettingsAndTap(R.id.setting_app_map_provider);
+
+        Eventually.check(() -> onView(withText(R.string.map_provider_amap)).inRoot(isDialog())
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("settings-3-map-provider");
+    }
+
+    /**
+     * And the key AMap needs, which this app deliberately does not ship.
+     *
+     * <p>AMap issues keys per developer account, bound to a package name and a signing
+     * fingerprint, and expects the holder to be the app's operator - so users supply their own.
+     * Picking AMap without one must not save, which is why this screen exists at all. See
+     * AGENTS.md rule 5.
+     */
+    @Test
+    public void etheamapKeyPrompt() {
+        this.openSettingsAndTap(R.id.setting_app_map_provider);
+
+        Eventually.check(() -> onView(withText(R.string.map_provider_amap)).inRoot(isDialog())
+                .check(matches(isDisplayed())));
+
+        // **Select, then Accept.** Tapping the row only moves the radio; the key prompt comes
+        // after the choice is confirmed. Without the second tap this waited for a dialog that
+        // was never going to open, which is what killed the run.
+        onView(withText(R.string.map_provider_amap)).inRoot(isDialog()).perform(click());
+        onView(withText(R.string.accept)).inRoot(isDialog()).perform(click());
+
+        Eventually.check(() -> onView(withText(R.string.amap_api_key)).inRoot(isDialog())
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("settings-4-amap-key");
+    }
+
+    /**
+     * Turning debug data on, which is where getting a log out begins.
+     *
+     * <p><b>Two screens because it is two places.</b> The switch is in Settings and the button it
+     * reveals is on the map, so anybody following the wiki looks for the button first, does not
+     * find it, and concludes the feature is missing. It is deliberately hidden - most people never
+     * need a log, and an Export Logs button in everyone's menu is an invitation to hand out a file
+     * full of their own coordinates. See the sibling capture for the second half.
+     */
+    @Test
+    public void ftheenableDebugDataSwitch() {
+        this.openTheOverflow();
+        onView(withText(R.string.settings)).inRoot(isPlatformPopup()).perform(click());
+
+        Eventually.check(() -> onView(withId(R.id.settings_app_debug_data_enabled))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.settings_app_debug_data_enabled)).perform(scrollTo(), click());
+
+        // Photographed switched on, since that is the state the next step needs. The fixture's
+        // DeviceStateGuard puts the setting back afterwards.
+        Eventually.check(() -> onView(withId(R.id.settings_app_debug_data_enabled))
+                .check(matches(isChecked())));
+        Shot.ofTheScreen("logs-1-enable-debug-data");
+    }
+
+    /**
+     * And the Export Logs item, which only exists once that switch is on.
+     *
+     * <p>Walks the whole way rather than writing the setting directly: the menu is rebuilt from
+     * the stored value on every press, so going through Settings and back is also the assertion
+     * that the switch reaches it. Writing the preference behind the app's back would capture the
+     * same picture while proving nothing about the path a reader is being told to follow.
+     *
+     * <p>The system file picker it opens belongs to another app and cannot be photographed from
+     * here - same limitation as the import flow.
+     */
+    @Test
+    public void gtheexportLogsButton() {
+        this.openTheOverflow();
+        onView(withText(R.string.settings)).inRoot(isPlatformPopup()).perform(click());
+
+        Eventually.check(() -> onView(withId(R.id.settings_app_debug_data_enabled))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.settings_app_debug_data_enabled)).perform(scrollTo(), click());
+        Eventually.check(() -> onView(withId(R.id.settings_app_debug_data_enabled))
+                .check(matches(isChecked())));
+
+        pressBack();
+
+        this.openTheOverflow();
+        Eventually.check(() -> onView(withText(R.string.export_logs)).inRoot(isPlatformPopup())
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("logs-2-export-logs");
+    }
+
+    private void openSettingsAndTap(final int rowId) {
+        this.openTheOverflow();
+        onView(withText(R.string.settings)).inRoot(isPlatformPopup()).perform(click());
+
+        Eventually.check(() -> onView(withId(rowId)).check(matches(isDisplayed())));
+        onView(withId(rowId)).perform(scrollTo(), click());
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsFromTheMapTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsFromTheMapTest.java
@@ -90,6 +90,8 @@ public class WikiScreenshotsFromTheMapTest {
 
     @Before
     public void openTheMap() {
+        OnlyWhenCapturing.wasAskedFor();
+
         Intents.init();
 
         // **Everything except the two screens this actually walks into.** The test this was

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsOfSigningInTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsOfSigningInTest.java
@@ -1,0 +1,163 @@
+package dev.wander.android.opentagviewer.ui;
+
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
+import android.app.Activity;
+import android.app.Instrumentation.ActivityResult;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import dev.wander.android.opentagviewer.AppleLoginActivity;
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.MapsActivity;
+import dev.wander.android.opentagviewer.MyDevicesListActivity;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.Shot;
+import dev.wander.android.opentagviewer.TestPace;
+import dev.wander.android.opentagviewer.db.AccountBeaconsForTests;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.anisette.FakeAnisetteSource;
+import dev.wander.android.opentagviewer.python.FakeAppleAuthService;
+
+/**
+ * Signing in, and getting tags in from the device list — for the wiki.
+ *
+ * <p>Replaces images taken on a different phone, in another year, with an older navigation bar.
+ * Mixing those with freshly captured ones on the same page is the thing this is for.
+ *
+ * <p><b>Nothing here talks to Apple.</b> {@code FakeAppleAuthService.wantsTwoFactor()} produces
+ * the second-factor screens on demand, which no real account will do to order, and
+ * {@code FakeAnisetteSource.ready()} keeps the screen from downloading Apple's ADI libraries.
+ * The address, the password and the phone numbers are invented.
+ *
+ * <p>The one screen not here is the system file picker in the import flow: it belongs to another
+ * app in another process, so Espresso can neither drive it nor photograph it. That stays a manual
+ * shot.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class WikiScreenshotsOfSigningInTest {
+
+    private static final String EMAIL = "someone@example.com";
+    private static final String PASSWORD = "hunter2";
+
+    private FakeAppleAuthService apple;
+    private ActivityScenario<?> scenario;
+
+    @Before
+    public void replaceApple() {
+        AccountBeaconsForTests.forgetThemAll();
+
+        this.apple = FakeAppleAuthService.wantsTwoFactor();
+        AppDependencies.replaceAuthService(this.apple);
+        AppDependencies.replaceAnisette(settings -> FakeAnisetteSource.ready());
+
+        Intents.init();
+        // The map is where a finished sign-in lands, and it needs Play Services. Stubbed for the
+        // same reason AppleLoginFlowTest stubs it - reaching it is the claim, not what it draws.
+        intending(hasComponent(MapsActivity.class.getName()))
+                .respondWith(new ActivityResult(Activity.RESULT_OK, null));
+    }
+
+    @After
+    public void putItBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        Intents.release();
+        AppDependencies.reset();
+        getInstrumentation().waitForIdleSync();
+        AccountBeaconsForTests.forgetThemAll();
+    }
+
+    /** 2a: the first screen the app ever shows. */
+    @Test
+    public void athewelcomeScreen() {
+        this.scenario = ActivityScenario.launch(AppleLoginActivity.class);
+
+        Eventually.check(() -> onView(withId(R.id.login_button_main))
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("login-1-welcome");
+    }
+
+    /** 2b: choosing where Apple should send the code. */
+    @Test
+    public void bthesecondFactorChoice() {
+        this.scenario = ActivityScenario.launch(AppleLoginActivity.class);
+        this.signIn();
+
+        Eventually.check(() -> onView(withText(FakeAppleAuthService.PHONE_ONE))
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("login-2-2fa-methods");
+    }
+
+    /**
+     * 3c: the six boxes.
+     *
+     * <p>The wiki's current version of this has Android's SMS-autofill chip above it, offering the
+     * code. That comes from a real message arriving, which a fake auth service cannot produce -
+     * see the note in CONTRIBUTING about sending one with {@code adb emu sms send} while this
+     * screen is up, which is how to get that shot rather than pasting the chip onto this one.
+     */
+    @Test
+    public void cthecodeEntry() {
+        this.scenario = ActivityScenario.launch(AppleLoginActivity.class);
+        this.signIn();
+
+        Eventually.check(() -> onView(withText(FakeAppleAuthService.PHONE_ONE))
+                .check(matches(isDisplayed())));
+        onView(withText(FakeAppleAuthService.PHONE_ONE)).perform(click());
+
+        Eventually.check(() -> onView(withId(R.id.twofa_sent_info_text))
+                .check(matches(isDisplayed())));
+
+        // Long enough for a message sent from the host to arrive and be offered, and harmless
+        // otherwise: TestPace does nothing at all unless slowMotion was asked for.
+        TestPace.afterAStep();
+        Shot.ofTheScreen("login-3-2fa-code");
+    }
+
+    /**
+     * The other way in: My Devices, for somebody who has no tags yet.
+     *
+     * <p>The wiki documents importing through the map's overflow menu. This is the same two
+     * actions from the list, which is where an empty install actually starts.
+     */
+    @Test
+    public void dtheemptyDeviceList() {
+        this.scenario = ActivityScenario.launch(MyDevicesListActivity.class);
+
+        Eventually.check(() -> onView(withText(R.string.icloud_import_from_file))
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("import-1-my-devices-empty");
+    }
+
+    private void signIn() {
+        onView(withId(R.id.email_or_phone_input_field)).perform(replaceText(EMAIL));
+        onView(withId(R.id.password_input_field))
+                .perform(replaceText(PASSWORD), closeSoftKeyboard());
+
+        // Retried until Apple was actually asked, not until nothing throws - the keyboard may
+        // still be over the button. See AGENTS.md on Eventually.perform.
+        Eventually.perform("the sign in button", () -> this.apple.timesCalled("login") > 0,
+                () -> onView(withId(R.id.login_button_main)).perform(click()));
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsOfSigningInTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsOfSigningInTest.java
@@ -70,6 +70,8 @@ public class WikiScreenshotsOfSigningInTest {
 
     @Before
     public void replaceApple() {
+        OnlyWhenCapturing.wasAskedFor();
+
         AccountBeaconsForTests.forgetThemAll();
         signOutFirst();
 

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsOfSigningInTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsOfSigningInTest.java
@@ -11,6 +11,9 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+// The row reads "SMS (+44 ******1234)", so an exact match on the number finds nothing. Matching
+// the number inside the label keeps this working whether or not the method is named around it.
+import static org.hamcrest.Matchers.containsString;
 
 import android.app.Activity;
 import android.app.Instrumentation.ActivityResult;
@@ -33,6 +36,9 @@ import dev.wander.android.opentagviewer.R;
 import dev.wander.android.opentagviewer.Shot;
 import dev.wander.android.opentagviewer.TestPace;
 import dev.wander.android.opentagviewer.db.AccountBeaconsForTests;
+import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
+import dev.wander.android.opentagviewer.db.repo.UserAuthRepository;
+import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
 import dev.wander.android.opentagviewer.python.AppDependencies;
 import dev.wander.android.opentagviewer.anisette.FakeAnisetteSource;
 import dev.wander.android.opentagviewer.python.FakeAppleAuthService;
@@ -65,6 +71,7 @@ public class WikiScreenshotsOfSigningInTest {
     @Before
     public void replaceApple() {
         AccountBeaconsForTests.forgetThemAll();
+        signOutFirst();
 
         this.apple = FakeAppleAuthService.wantsTwoFactor();
         AppDependencies.replaceAuthService(this.apple);
@@ -104,7 +111,7 @@ public class WikiScreenshotsOfSigningInTest {
         this.scenario = ActivityScenario.launch(AppleLoginActivity.class);
         this.signIn();
 
-        Eventually.check(() -> onView(withText(FakeAppleAuthService.PHONE_ONE))
+        Eventually.check(() -> onView(withText(containsString(FakeAppleAuthService.PHONE_ONE)))
                 .check(matches(isDisplayed())));
         Shot.ofTheScreen("login-2-2fa-methods");
     }
@@ -122,9 +129,9 @@ public class WikiScreenshotsOfSigningInTest {
         this.scenario = ActivityScenario.launch(AppleLoginActivity.class);
         this.signIn();
 
-        Eventually.check(() -> onView(withText(FakeAppleAuthService.PHONE_ONE))
+        Eventually.check(() -> onView(withText(containsString(FakeAppleAuthService.PHONE_ONE)))
                 .check(matches(isDisplayed())));
-        onView(withText(FakeAppleAuthService.PHONE_ONE)).perform(click());
+        onView(withText(containsString(FakeAppleAuthService.PHONE_ONE))).perform(click());
 
         Eventually.check(() -> onView(withId(R.id.twofa_sent_info_text))
                 .check(matches(isDisplayed())));
@@ -148,6 +155,28 @@ public class WikiScreenshotsOfSigningInTest {
         Eventually.check(() -> onView(withText(R.string.icloud_import_from_file))
                 .check(matches(isDisplayed())));
         Shot.ofTheScreen("import-1-my-devices-empty");
+    }
+
+    /**
+     * Make sure nobody is signed in, rather than hoping.
+     *
+     * <p><b>Every test here fails with {@code NoActivityResumedException} if a session exists</b>,
+     * and the reason is nowhere near the failure: AppleLoginActivity finishes itself and starts
+     * the map when it finds one, the map is stubbed out here, and Espresso then reports that no
+     * activity is resumed - which reads as a launch that did not happen rather than a screen that
+     * declined to appear.
+     *
+     * <p>It happened because a sibling capture class signs somebody in and puts it back in its
+     * {@code @After}, and three of its tests failed in a way that skipped the restore. Fixed on
+     * this side as well as that one: a class whose whole subject is the signed-out screens should
+     * establish signed-out itself, not inherit it from whatever ran before.
+     */
+    private static void signOutFirst() {
+        new UserAuthRepository(
+                UserAuthDataStore.getInstance(
+                        getInstrumentation().getTargetContext().getApplicationContext()),
+                new AppCryptographyUtil())
+                .clearUser().blockingAwait();
     }
 
     private void signIn() {

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsOfSigningInTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsOfSigningInTest.java
@@ -25,6 +25,7 @@ import androidx.test.filters.LargeTest;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -68,10 +69,22 @@ public class WikiScreenshotsOfSigningInTest {
     private FakeAppleAuthService apple;
     private ActivityScenario<?> scenario;
 
+    /**
+     * <b>{@code @BeforeClass}, not {@code @Before}, and that distinction is the whole of it.</b>
+     *
+     * <p>An assumption failure in {@code @Before} skips the test body and then runs {@code @After}
+     * anyway - which tore down Intents that were never initialised and reported every test as
+     * FAILED with "init() must be called prior to using this method". Skipped tests that report as
+     * failures are worse than tests that run. From {@code @BeforeClass} the class is passed over
+     * whole, and neither hook runs.
+     */
+    @BeforeClass
+    public static void onlyWhenCapturing() {
+        OnlyWhenCapturing.wasAskedFor();
+    }
+
     @Before
     public void replaceApple() {
-        OnlyWhenCapturing.wasAskedFor();
-
         AccountBeaconsForTests.forgetThemAll();
         signOutFirst();
 

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsOfSigningInTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsOfSigningInTest.java
@@ -25,7 +25,6 @@ import androidx.test.filters.LargeTest;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -70,21 +69,28 @@ public class WikiScreenshotsOfSigningInTest {
     private ActivityScenario<?> scenario;
 
     /**
-     * <b>{@code @BeforeClass}, not {@code @Before}, and that distinction is the whole of it.</b>
+     * <b>Skipped per test, and the teardown knows setup never ran.</b>
      *
-     * <p>An assumption failure in {@code @Before} skips the test body and then runs {@code @After}
-     * anyway - which tore down Intents that were never initialised and reported every test as
-     * FAILED with "init() must be called prior to using this method". Skipped tests that report as
-     * failures are worse than tests that run. From {@code @BeforeClass} the class is passed over
-     * whole, and neither hook runs.
+     * <p>Two wrong shapes were tried first, and each broke the suite a different way. In
+     * {@code @Before} alone, the assumption skips the test body but JUnit runs {@code @After}
+     * regardless, which tore down Intents that were never initialised and reported every test as
+     * FAILED. Moved to {@code @BeforeClass}, the class is passed over in silence - and the
+     * instrumentation then reports fewer results than the APK declares tests, so AGP calls the
+     * whole run aborted: "Expected 640 tests, received 623", where the 17 missing are exactly the
+     * contents of these three classes. Zero failures, and a red build that reads as a dead
+     * emulator.
+     *
+     * <p>So the assumption stays here, where each test is reported as skipped and counted, and
+     * {@link #putItBack} returns early rather than undoing work that was never done.
      */
-    @BeforeClass
-    public static void onlyWhenCapturing() {
-        OnlyWhenCapturing.wasAskedFor();
-    }
+    /** False when the assumption above skipped setup, so teardown undoes nothing. */
+    private boolean setUpRan;
 
     @Before
     public void replaceApple() {
+        OnlyWhenCapturing.wasAskedFor();
+        this.setUpRan = true;
+
         AccountBeaconsForTests.forgetThemAll();
         signOutFirst();
 
@@ -101,6 +107,10 @@ public class WikiScreenshotsOfSigningInTest {
 
     @After
     public void putItBack() {
+        if (!this.setUpRan) {
+            return;
+        }
+
         if (this.scenario != null) {
             this.scenario.close();
         }

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsTest.java
@@ -1,0 +1,298 @@
+package dev.wander.android.opentagviewer.ui;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.longClick;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.containsString;
+
+import android.app.Activity;
+import android.app.Instrumentation.ActivityResult;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import dev.wander.android.opentagviewer.Eventually;
+import dev.wander.android.opentagviewer.FetchFromICloudActivity;
+import dev.wander.android.opentagviewer.MyDevicesListActivity;
+import dev.wander.android.opentagviewer.R;
+import dev.wander.android.opentagviewer.Shot;
+import dev.wander.android.opentagviewer.db.AccountBeaconsForTests;
+import dev.wander.android.opentagviewer.db.datastore.UserAuthDataStore;
+import dev.wander.android.opentagviewer.db.repo.KeychainMembershipRepository;
+import dev.wander.android.opentagviewer.db.room.OpenTagViewerDatabase;
+import dev.wander.android.opentagviewer.db.room.entity.BeaconNamingRecord;
+import dev.wander.android.opentagviewer.db.room.entity.Import;
+import dev.wander.android.opentagviewer.db.room.entity.OwnedBeacon;
+import dev.wander.android.opentagviewer.python.AppDependencies;
+import dev.wander.android.opentagviewer.python.BundleBuilder;
+import dev.wander.android.opentagviewer.python.icloud.FakeICloudService;
+import dev.wander.android.opentagviewer.python.icloud.ICloudException;
+import dev.wander.android.opentagviewer.python.icloud.ICloudFailure;
+import dev.wander.android.opentagviewer.util.android.AppCryptographyUtil;
+
+/**
+ * Screens for the wiki, captured from the running app.
+ *
+ * <p><b>A documentation tool, not a test.</b> It asserts only enough to know it photographed the
+ * right screen - a shot of the wrong page is worse than none, because nobody checks a picture
+ * against the code. Everything real about these screens is covered by the classes named beside
+ * each capture.
+ *
+ * <p><b>Needs a device with a display.</b> {@code Shot.ofTheScreen} photographs the compositor,
+ * which is the only way to catch a dialog and the page behind it together - and on the headless
+ * managed device it returns black. It refuses to write a blank frame rather than producing one,
+ * so a headless run leaves no files rather than ten useless ones.
+ *
+ * <pre>
+ * ANDROID_SERIAL=emulator-5554 ./gradlew :app:connectedDebugAndroidTest \
+ *   -Pandroid.testInstrumentationRunnerArguments.class=dev.wander.android.opentagviewer.ui.WikiScreenshotsTest
+ * </pre>
+ *
+ * <p>Everything on screen is fabricated: the serials, the tag names and the code all come from
+ * fakes. No real account is touched, and nothing here belongs to anybody.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class WikiScreenshotsTest {
+
+    private static final String A_TAG = "wiki-shot-tag";
+    private static final String ANOTHER_TAG = "wiki-shot-tag-2";
+    private static final String A_NAME = "Bike";
+    private static final String ANOTHER_NAME = "Keys";
+    private static final String A_TEST_USER = "wikishots@example.invalid";
+
+    private static final String A_PLIST = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<plist version=\"1.0\"><dict>"
+            + "<key>batteryLevel</key><integer>1</integer>"
+            + "<key>model</key><string></string>"
+            + "<key>pairingDate</key><date>2025-02-27T20:03:32Z</date>"
+            + "<key>privateKey</key><dict><key>key</key><dict>"
+            + "<key>data</key><data>bm90LWEtcmVhbC1rZXk=</data></dict></dict>"
+            + "<key>productId</key><integer>21760</integer>"
+            + "<key>stableIdentifier</key><array><string>2001~#0~#A0</string></array>"
+            + "<key>systemVersion</key><string>2.0.73</string>"
+            + "<key>vendorId</key><integer>76</integer>"
+            + "</dict></plist>";
+
+    private ActivityScenario<?> scenario;
+    private OpenTagViewerDatabase db;
+    private File written;
+
+    @Before
+    public void cleanSlate() {
+        final Context context = getInstrumentation().getTargetContext();
+        this.db = OpenTagViewerDatabase.getInstance(context);
+        this.written = new File(context.getCacheDir(), "wiki-shot.zip");
+
+        this.forgetEverything();
+
+        Intents.init();
+        intending(hasAction(Intent.ACTION_CREATE_DOCUMENT)).respondWith(new ActivityResult(
+                Activity.RESULT_OK, new Intent().setData(Uri.fromFile(this.written))));
+    }
+
+    @After
+    public void putItBack() {
+        if (this.scenario != null) {
+            this.scenario.close();
+        }
+        Intents.release();
+        AppDependencies.reset();
+        this.forgetEverything();
+        if (this.written != null) {
+            this.written.delete();
+        }
+    }
+
+    private void forgetEverything() {
+        AccountBeaconsForTests.forgetThemAll();
+        for (final String id : new String[] {A_TAG, ANOTHER_TAG}) {
+            this.db.ownedBeaconDao().delete(OwnedBeacon.builder().id(id).build());
+            this.db.beaconNamingRecordDao().delete(BeaconNamingRecord.builder().id(id).build());
+        }
+        for (final Import stale : this.db.importDao().getImportsFromUser(A_TEST_USER)) {
+            this.db.importDao().delete(stale);
+        }
+        new KeychainMembershipRepository(
+                UserAuthDataStore.getInstance(getInstrumentation().getTargetContext()),
+                new AppCryptographyUtil()).forget().blockingAwait();
+    }
+
+    private void openTheICloudFlow(final FakeICloudService fake) {
+        AppDependencies.replaceICloud(() -> fake);
+        this.scenario = ActivityScenario.launch(FetchFromICloudActivity.class);
+    }
+
+    // ---------------------------------------------------------------- the iCloud flow
+
+    /** 1 and 2: choosing whose passcode you have, then typing it. */
+    @Test
+    public void athepasscodeSteps() {
+        this.openTheICloudFlow(FakeICloudService.withTags());
+
+        Eventually.check(() -> onView(withId(R.id.icloud_device_container))
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("icloud-1-which-device");
+
+        onView(withText(containsString(FakeICloudService.AN_IPHONE.getSerial()))).perform(click());
+
+        Eventually.check(() -> onView(withId(R.id.icloud_passcode_input))
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("icloud-2-enter-passcode");
+    }
+
+    /** 3: the same step after Apple declined the code. See FetchFromICloudErrorsTest. */
+    @Test
+    public void bthewrongPasscode() {
+        final FakeICloudService fake = FakeICloudService.withTags();
+        fake.failUnlockWith(new ICloudException(ICloudFailure.PASSCODE_REJECTED,
+                "The escrow service did not accept that passcode."));
+        this.openTheICloudFlow(fake);
+
+        Eventually.check(() -> onView(withId(R.id.icloud_device_container))
+                .check(matches(isDisplayed())));
+        onView(withText(containsString(FakeICloudService.AN_IPHONE.getSerial()))).perform(click());
+
+        Eventually.check(() -> onView(withId(R.id.icloud_passcode_input))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.icloud_passcode_input)).perform(replaceText("000000"));
+
+        final long before = fake.timesCalled("unlock");
+        Eventually.perform("unlock", () -> fake.timesCalled("unlock") > before,
+                () -> onView(withId(R.id.icloud_primary_button)).perform(click()));
+
+        Eventually.check(() -> onView(withId(R.id.icloud_passcode_error_container))
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("icloud-3-wrong-passcode");
+    }
+
+    /** 4 and 5: what was found, then what this app put on the account. */
+    @Test
+    public void ctheresultsAndTheRegisteredDevice() {
+        final FakeICloudService fake = FakeICloudService.withTags();
+        this.openTheICloudFlow(fake);
+
+        Eventually.check(() -> onView(withId(R.id.icloud_device_container))
+                .check(matches(isDisplayed())));
+        onView(withText(containsString(FakeICloudService.AN_IPHONE.getSerial()))).perform(click());
+
+        Eventually.check(() -> onView(withId(R.id.icloud_passcode_input))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.icloud_passcode_input)).perform(replaceText("123456"));
+
+        final long before = fake.timesCalled("unlock");
+        Eventually.perform("unlock", () -> fake.timesCalled("unlock") > before,
+                () -> onView(withId(R.id.icloud_primary_button)).perform(click()));
+
+        Eventually.check(() -> onView(withId(R.id.icloud_results_container))
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("icloud-4-tags-found");
+
+        // Next rather than Done, because this run registered a device - see
+        // TheDeviceNoteIsShownOnceTest for why a re-read does not reach this page.
+        onView(withId(R.id.icloud_primary_button)).perform(click());
+
+        Eventually.check(() -> onView(withId(R.id.icloud_registered_container))
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("icloud-5-device-registered");
+    }
+
+    /** 6: an account with nothing that can ever unlock a keychain. Final, not a retry. */
+    @Test
+    public void dtheaccountWithNothingToRecoverFrom() {
+        this.openTheICloudFlow(FakeICloudService.withNothingToRecoverFrom());
+
+        Eventually.check(() -> onView(withId(R.id.icloud_no_tags_container))
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("icloud-6-no-tags");
+    }
+
+    /** 7: and the one that really is worth trying again later. */
+    @Test
+    public void etheserviceHavingABadDay() {
+        this.openTheICloudFlow(FakeICloudService.whereTheServiceIsUnsure());
+
+        Eventually.check(() -> onView(withId(R.id.icloud_retry_container))
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("icloud-7-service-unsure");
+    }
+
+    // ---------------------------------------------------------------- sharing tags
+
+    private void seedTwoTags() {
+        final long importId = this.db.importDao().insert(Import.builder()
+                .version("0.0.2").importedAt(1_700_000_000_000L).exportedAt(1_699_000_000_000L)
+                .sourceUser(A_TEST_USER).exportedVia("OpenTagViewer.wizard:1.4.0").build());
+
+        for (final String[] tag : new String[][] {{A_TAG, A_NAME}, {ANOTHER_TAG, ANOTHER_NAME}}) {
+            this.db.ownedBeaconDao().insertAll(OwnedBeacon.builder()
+                    .id(tag[0]).importId(importId).content(A_PLIST)
+                    .version("0.0.2").fromAccount(false).isRemoved(false).build());
+            this.db.beaconNamingRecordDao().insertAll(BeaconNamingRecord.builder()
+                    .id(tag[0]).importId(importId).version("0.0.2").isRemoved(false)
+                    .content("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                            + "<plist version=\"1.0\"><dict>"
+                            + "<key>identifier</key><string>" + tag[0] + "</string>"
+                            + "<key>associatedBeacon</key><string>" + tag[0] + "</string>"
+                            + "<key>name</key><string>" + tag[1] + "</string>"
+                            + "</dict></plist>").build());
+        }
+    }
+
+    /** 8, 9 and 10: select tags, choose Export Tags, read the code. */
+    @Test
+    public void fsharingATag() {
+        this.seedTwoTags();
+
+        AppDependencies.replaceBundleBuilder((accessories, via, user, at) -> {
+            final Map<String, byte[]> entries = new LinkedHashMap<>();
+            entries.put("OPENTAGVIEWER.yml", ("via: " + via).getBytes());
+            return new BundleBuilder.Built(entries, null);
+        });
+
+        this.scenario = ActivityScenario.launch(MyDevicesListActivity.class);
+
+        Eventually.check(() -> onView(withText(A_NAME)).check(matches(isDisplayed())));
+        onView(withText(A_NAME)).perform(longClick());
+
+        // Two selected, so the screenshot shows what a multiple selection looks like rather than
+        // a single row that could be mistaken for a tap.
+        Eventually.check(() -> onView(withId(R.id.selection_menu_button))
+                .check(matches(isDisplayed())));
+        onView(withText(ANOTHER_NAME)).perform(click());
+        Shot.ofTheScreen("export-1-tags-selected");
+
+        onView(withId(R.id.selection_menu_button)).perform(click());
+        Eventually.check(() -> onView(withText(R.string.export_tags))
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("export-2-menu");
+
+        onView(withText(R.string.export_tags)).perform(click());
+
+        Eventually.check(() -> onView(withId(R.id.exported_bundle_code))
+                .check(matches(isDisplayed())));
+        Shot.ofTheScreen("export-3-the-code");
+    }
+}

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsTest.java
@@ -26,7 +26,6 @@ import androidx.test.filters.LargeTest;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -102,21 +101,28 @@ public class WikiScreenshotsTest {
     private File written;
 
     /**
-     * <b>{@code @BeforeClass}, not {@code @Before}, and that distinction is the whole of it.</b>
+     * <b>Skipped per test, and the teardown knows setup never ran.</b>
      *
-     * <p>An assumption failure in {@code @Before} skips the test body and then runs {@code @After}
-     * anyway - which tore down Intents that were never initialised and reported every test as
-     * FAILED with "init() must be called prior to using this method". Skipped tests that report as
-     * failures are worse than tests that run. From {@code @BeforeClass} the class is passed over
-     * whole, and neither hook runs.
+     * <p>Two wrong shapes were tried first, and each broke the suite a different way. In
+     * {@code @Before} alone, the assumption skips the test body but JUnit runs {@code @After}
+     * regardless, which tore down Intents that were never initialised and reported every test as
+     * FAILED. Moved to {@code @BeforeClass}, the class is passed over in silence - and the
+     * instrumentation then reports fewer results than the APK declares tests, so AGP calls the
+     * whole run aborted: "Expected 640 tests, received 623", where the 17 missing are exactly the
+     * contents of these three classes. Zero failures, and a red build that reads as a dead
+     * emulator.
+     *
+     * <p>So the assumption stays here, where each test is reported as skipped and counted, and
+     * {@link #putItBack} returns early rather than undoing work that was never done.
      */
-    @BeforeClass
-    public static void onlyWhenCapturing() {
-        OnlyWhenCapturing.wasAskedFor();
-    }
+    /** False when the assumption above skipped setup, so teardown undoes nothing. */
+    private boolean setUpRan;
 
     @Before
     public void cleanSlate() {
+        OnlyWhenCapturing.wasAskedFor();
+        this.setUpRan = true;
+
         final Context context = getInstrumentation().getTargetContext();
         this.db = OpenTagViewerDatabase.getInstance(context);
         this.written = new File(context.getCacheDir(), "wiki-shot.zip");
@@ -130,6 +136,10 @@ public class WikiScreenshotsTest {
 
     @After
     public void putItBack() {
+        if (!this.setUpRan) {
+            return;
+        }
+
         if (this.scenario != null) {
             this.scenario.close();
         }

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsTest.java
@@ -26,6 +26,7 @@ import androidx.test.filters.LargeTest;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -100,10 +101,22 @@ public class WikiScreenshotsTest {
     private OpenTagViewerDatabase db;
     private File written;
 
+    /**
+     * <b>{@code @BeforeClass}, not {@code @Before}, and that distinction is the whole of it.</b>
+     *
+     * <p>An assumption failure in {@code @Before} skips the test body and then runs {@code @After}
+     * anyway - which tore down Intents that were never initialised and reported every test as
+     * FAILED with "init() must be called prior to using this method". Skipped tests that report as
+     * failures are worse than tests that run. From {@code @BeforeClass} the class is passed over
+     * whole, and neither hook runs.
+     */
+    @BeforeClass
+    public static void onlyWhenCapturing() {
+        OnlyWhenCapturing.wasAskedFor();
+    }
+
     @Before
     public void cleanSlate() {
-        OnlyWhenCapturing.wasAskedFor();
-
         final Context context = getInstrumentation().getTargetContext();
         this.db = OpenTagViewerDatabase.getInstance(context);
         this.written = new File(context.getCacheDir(), "wiki-shot.zip");

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsTest.java
@@ -126,11 +126,28 @@ public class WikiScreenshotsTest {
         }
     }
 
+    /**
+     * Every tag, not only the ones this class wrote.
+     *
+     * <p><b>A screenshot needs a screen nobody else has touched.</b> Deleting by id is right for
+     * a test, which cares about its own rows; it is not enough here. A run abandoned half way -
+     * and several were, while this was being built - leaves another fixture's tags behind, and
+     * the next capture then finds two tags called "Bike" and dies with
+     * AmbiguousViewMatcherException, or worse photographs a list with somebody else's leftovers
+     * in it.
+     *
+     * <p><b>Safe because of what this is.</b> A documentation tool, run by hand against a
+     * throwaway emulator that {@code connectedDebugAndroidTest} uninstalls the app from anyway.
+     * It is emphatically not safe on a device holding real imported tags, which is why it lives
+     * here rather than in a shared helper an ordinary test might reach for.
+     */
     private void forgetEverything() {
         AccountBeaconsForTests.forgetThemAll();
-        for (final String id : new String[] {A_TAG, ANOTHER_TAG}) {
-            this.db.ownedBeaconDao().delete(OwnedBeacon.builder().id(id).build());
-            this.db.beaconNamingRecordDao().delete(BeaconNamingRecord.builder().id(id).build());
+
+        for (final OwnedBeacon leftover : this.db.ownedBeaconDao().getAll()) {
+            this.db.ownedBeaconDao().delete(OwnedBeacon.builder().id(leftover.id).build());
+            this.db.beaconNamingRecordDao()
+                    .delete(BeaconNamingRecord.builder().id(leftover.id).build());
         }
         for (final Import stale : this.db.importDao().getImportsFromUser(A_TEST_USER)) {
             this.db.importDao().delete(stale);

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/WikiScreenshotsTest.java
@@ -102,6 +102,8 @@ public class WikiScreenshotsTest {
 
     @Before
     public void cleanSlate() {
+        OnlyWhenCapturing.wasAskedFor();
+
         final Context context = getInstrumentation().getTargetContext();
         this.db = OpenTagViewerDatabase.getInstance(context);
         this.written = new File(context.getCacheDir(), "wiki-shot.zip");

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/AMapWithTagsOnIt.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/maps/AMapWithTagsOnIt.java
@@ -388,20 +388,28 @@ public final class AMapWithTagsOnIt {
 
     /** Call from {@code @After}, always - this overwrote the device's own settings. */
     public void putItBack() {
-        if (this.scenario != null) {
-            this.scenario.close();
-        }
-        if (this.appleDouble != null) {
-            this.appleDouble.callAttr("uninstall");
-        }
+        // **The restore runs even if the teardown above it throws.** It was last in a plain
+        // sequence, so a test that failed badly enough to upset the scenario close or the Python
+        // double took the settings and the stored session down with it - and the next class to
+        // run then met somebody signed in who should not have been, several tests away from
+        // anything that mentions a session. Whatever else goes wrong here, the device goes back
+        // to how it was found.
+        try {
+            if (this.scenario != null) {
+                this.scenario.close();
+            }
+            if (this.appleDouble != null) {
+                this.appleDouble.callAttr("uninstall");
+            }
 
-        MapProviderFactory.reset();
-        AppDependencies.reset();
+            MapProviderFactory.reset();
+            AppDependencies.reset();
 
-        this.forgetThem();
-
-        if (this.guard != null) {
-            this.guard.restore();
+            this.forgetThem();
+        } finally {
+            if (this.guard != null) {
+                this.guard.restore();
+            }
         }
     }
 

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/settings/DebugModeReachesEveryScreenTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/settings/DebugModeReachesEveryScreenTest.java
@@ -16,7 +16,11 @@ import static org.junit.Assert.assertTrue;
 import android.content.Context;
 import android.content.Intent;
 import android.view.View;
+import android.widget.ScrollView;
 
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
@@ -123,6 +127,98 @@ public class DebugModeReachesEveryScreenTest {
     // ------------------------------------------------------------------ each screen, asked
 
     /** Open Settings, tap the debug switch, and let it save. */
+    /**
+     * <b>Scrolled to the bottom, the switch is above the navigation bar rather than under it.</b>
+     *
+     * <p>The theme makes the navigation bar transparent, so the scrolling area runs underneath
+     * it. The debug switch is the last row and had nothing below it, so it came to rest behind
+     * the gesture pill: drawn, reachable by Espresso, and awkward or impossible to tap by hand -
+     * the failure this repo keeps meeting, where the build is green and the screen is wrong.
+     *
+     * <p><b>Asserted in pixels against the measured inset, not by eye and not by isDisplayed().</b>
+     * A view under a translucent navigation bar is still on screen as far as Espresso is
+     * concerned, so {@code isCompletelyDisplayed} passes for exactly the case this is about. The
+     * question is whether the switch ends above where the navigation bar begins, which is a
+     * number the device can be asked for.
+     *
+     * <p><b>Scrolled to the end, not merely scrolled to.</b> Espresso's {@code scrollTo()} moves
+     * the minimum needed to make a view visible, and
+     * {@code ScrollView.computeScrollDeltaToGetChildRectOnScreen} does that arithmetic against
+     * the full height with no regard for bottom padding - so with {@code clipToPadding="false"}
+     * it happily parks the row inside the padded strip and calls it visible. Written that way
+     * this failed against a correct fix, reporting the switch ending at exactly the screen
+     * height. What a person can do is keep scrolling, so the test does too.
+     *
+     * <p><b>And the geometry alone is not enough, which took measuring to find out.</b> On the
+     * Pixel 9 emulator with gesture navigation the row clears the bar by eleven pixels even with
+     * the fix removed, so a purely geometric assertion is green either way and says nothing. The
+     * assertion that actually holds the fix in place is the one about reserved space - see the
+     * comment on it. Both are here: the geometry is what a user experiences, the reserved space
+     * is what makes it true on a device this suite never runs on.
+     */
+    @Test
+    public void theLastRowEndsAboveTheNavigationBar() {
+        this.openTheScreen(SettingsActivity.class);
+
+        Eventually.check(() -> onView(withId(R.id.settings_app_debug_data_enabled))
+                .perform(scrollTo())
+                .check(matches(isDisplayed())));
+
+        // **The content's own height, not Integer.MAX_VALUE.** ScrollView.scrollTo clamps to the
+        // scroll range, which sounds like it makes the argument's size irrelevant - but the clamp
+        // adds the viewport height to it first, so MAX_VALUE overflows and the view lands at a
+        // huge negative offset. That reported the switch ending at -2147480706, which is below
+        // every threshold, so the assertion passed no matter what the layout did. A test that
+        // cannot fail is worse than no test; this is the shape it takes.
+        //
+        // Not fullScroll() either, which smooth-scrolls by default and would need waiting out.
+        this.screen.onActivity(activity -> {
+            final ScrollView scrollArea = activity.findViewById(R.id.settings_scroll_area);
+            scrollArea.scrollTo(0, scrollArea.getChildAt(0).getBottom());
+        });
+        getInstrumentation().waitForIdleSync();
+
+        final int[] switchEndsAt = new int[1];
+        final int[] navigationBarStartsAt = new int[1];
+        final int[] navigationBarNeeds = new int[1];
+        final int[] scrollAreaReserves = new int[1];
+        this.screen.onActivity(activity -> {
+            final View switcher = activity.findViewById(R.id.settings_app_debug_data_enabled);
+            final int[] onScreen = new int[2];
+            switcher.getLocationOnScreen(onScreen);
+            switchEndsAt[0] = onScreen[1] + switcher.getHeight();
+
+            final View decor = activity.getWindow().getDecorView();
+            final Insets bars = ViewCompat.getRootWindowInsets(decor)
+                    .getInsets(WindowInsetsCompat.Type.systemBars());
+            navigationBarStartsAt[0] = decor.getHeight() - bars.bottom;
+
+            navigationBarNeeds[0] = bars.bottom;
+            scrollAreaReserves[0] =
+                    activity.findViewById(R.id.settings_scroll_area).getPaddingBottom();
+        });
+
+        // **The reserved space, as well as the geometry, and this is the assertion that bites.**
+        // Measured on the Pixel 9 emulator, gesture navigation: without the inset the switch ends
+        // at 2350 with the bar starting at 2361 - eleven pixels clear, so the geometric check
+        // below passes and proves nothing. Three-button navigation asks for around 126px instead
+        // of 63, and those eleven pixels become a switch underneath the bar.
+        //
+        // So this asks the question that has the same answer on every device: is the scrolling
+        // area reserving at least what the navigation bar takes? Confirmed to fail without the
+        // fix - "reserves 0px, needs 63px". Zero rather than the child's 20dp because that
+        // padding is inside the scrolling content, which is why it gives the eleven pixels above
+        // and no protection at all from a bar that wants more.
+        assertTrue("the scroll area reserves " + scrollAreaReserves[0] + "px at the bottom, but "
+                        + "the navigation bar takes " + navigationBarNeeds[0] + "px - the last "
+                        + "row is one taller navigation bar away from being unreachable",
+                scrollAreaReserves[0] >= navigationBarNeeds[0]);
+
+        assertTrue("the debug switch ends at " + switchEndsAt[0] + ", but the navigation bar "
+                        + "starts at " + navigationBarStartsAt[0] + " - it is underneath it",
+                switchEndsAt[0] <= navigationBarStartsAt[0]);
+    }
+
     private void flipTheSwitchInSettings() {
         this.openTheScreen(SettingsActivity.class);
 

--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/settings/DebugModeReachesEveryScreenTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/settings/DebugModeReachesEveryScreenTest.java
@@ -188,10 +188,17 @@ public class DebugModeReachesEveryScreenTest {
             switcher.getLocationOnScreen(onScreen);
             switchEndsAt[0] = onScreen[1] + switcher.getHeight();
 
+            // **In screen coordinates, because that is what the switch was measured in.**
+            // decor.getHeight() is a height, not a screen position, and the two coincide only
+            // when the decor view starts at y=0. On the managed aosp-atd device it does not, and
+            // this reported a 54px overlap that was purely the difference between two origins -
+            // on a device whose inset is zero and which therefore has nothing to overlap with.
             final View decor = activity.getWindow().getDecorView();
+            final int[] decorOnScreen = new int[2];
+            decor.getLocationOnScreen(decorOnScreen);
             final Insets bars = ViewCompat.getRootWindowInsets(decor)
                     .getInsets(WindowInsetsCompat.Type.systemBars());
-            navigationBarStartsAt[0] = decor.getHeight() - bars.bottom;
+            navigationBarStartsAt[0] = decorOnScreen[1] + decor.getHeight() - bars.bottom;
 
             navigationBarNeeds[0] = bars.bottom;
             scrollAreaReserves[0] =
@@ -209,6 +216,12 @@ public class DebugModeReachesEveryScreenTest {
         // fix - "reserves 0px, needs 63px". Zero rather than the child's 20dp because that
         // padding is inside the scrolling content, which is why it gives the eleven pixels above
         // and no protection at all from a bar that wants more.
+        //
+        // **On the managed device this proves nothing, and that is worth saying out loud.**
+        // aosp-atd reports a systemBars bottom inset of 0 - no navigation bar - so both
+        // assertions here are vacuously true on the emulator CI actually runs. It earns its keep
+        // on a device that has one, which is every real phone and the windowed emulator the wiki
+        // captures use. Do not read a green CI run as evidence this screen is fine.
         assertTrue("the scroll area reserves " + scrollAreaReserves[0] + "px at the bottom, but "
                         + "the navigation bar takes " + navigationBarNeeds[0] + "px - the last "
                         + "row is one taller navigation bar away from being unreachable",

--- a/app/src/main/java/dev/wander/android/opentagviewer/SettingsActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/SettingsActivity.java
@@ -175,6 +175,8 @@ public class SettingsActivity extends AppCompatActivity {
 
         this.binding = DataBindingUtil.setContentView(this, R.layout.activity_settings);
         WindowPaddingUtil.insertUITopPadding(binding.getRoot());
+        // The last row is the debug switch, and the navigation bar was sitting on top of it.
+        WindowPaddingUtil.insertUIBottomPadding(this.findViewById(R.id.settings_scroll_area));
         this.binding.setHandleClickBack(this::handleEndActivity);
         this.binding.setOnClickFetchFromAccount(this::onClickFetchFromAccount);
         this.binding.setOnClickUnlinkAccount(this::onClickUnlinkAccount);

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -46,12 +46,22 @@
             Height 0 with weight 1, so the scrolling area is exactly what is left under the
             toolbar. `fillViewport` so a short list still lays out against the full height
             rather than collapsing to its content.
+
+            **The last row also has to clear the navigation bar.** The theme makes it
+            transparent, so this scrolling area runs underneath it, and the debug switch - which
+            is last - came to rest behind the gesture pill: drawn, but awkward to tap and on some
+            devices not reachable at all. The child below already leaves 20dp under its content,
+            which is the visual gap; the bar needs its own space on top of that, and how much is
+            a property of the device, so SettingsActivity applies the measured inset as padding
+            here. `clipToPadding="false"` is what makes that space scrollable rather than a strip
+            that clips the rows passing through it.
         -->
         <ScrollView
             android:id="@+id/settings_scroll_area"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
+            android:clipToPadding="false"
             android:fillViewport="true">
 
         <!--


### PR DESCRIPTION
The wiki's images came from several phones over several years, and nothing recorded how any of them was taken. This makes them reproducible, and fixes the things that turned up while doing it.

## The fix worth reviewing

**The last row of Settings sat under the navigation bar.** The theme makes it transparent, so the scrolling area runs underneath, and the debug switch is last with nothing below it.

Measured on a Pixel 9 emulator, scrolled all the way down: the switch ended at **2350** with the bar starting at **2361**. Eleven pixels, on gesture navigation. Three-button navigation asks for around 126px instead of 63, and those eleven pixels become a switch nobody can tap.

The scroll area now reserves the measured inset, and `clipToPadding="false"` makes that space scrollable rather than a strip that clips the rows passing through it. No new dimension — the child already leaves 20dp under its content, which is the visual gap; what was missing was the bar's own space.

The test asserts the reserved space **as well as** the geometry, and the reserved space is the half that bites. A purely geometric assertion is green with the fix removed, because of those eleven pixels — it would only fail on a device this suite never runs on. Checked both ways: passes with the fix, fails without it with `reserves 0px, needs 63px`.

## A real bug in a shared fixture

`AMapWithTagsOnIt.putItBack` had `guard.restore()` last in a plain sequence, so a test that failed hard enough to upset the scenario close or the Python double took the settings **and the stored session** down with it. The next class then met somebody signed in who should not have been, and failed with `NoActivityResumedException` — nowhere near anything mentioning a session. It is in a `finally` now. This affects every test using that fixture, not only the new ones.

## The captures themselves

Three classes covering 21 screens: the iCloud import route, the export flow, signing in, Settings and its dialogs, and turning on debug data to get a log out.

**They are skipped unless asked for.** Each ends in a `Shot` and asserts almost nothing, so a green run of them says nothing about the app — and they added about twenty minutes to a suite people are meant to run constantly. Same opt-in mechanism as the Anisette live tests:

```bash
ANDROID_SERIAL=emulator-5554 ./gradlew :app:connectedDebugAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.captureScreenshots=true \
  -Pandroid.testInstrumentationRunnerArguments.class=dev.wander.android.opentagviewer.ui.WikiScreenshotsTest
```

Everything on them is fabricated except the map: the session, the tags, the locations, the phone numbers and the address. The pin is the Eiffel Tower and the geocoder answers "a made-up street, in a made-up town".

`blur.py` takes bands out of a screenshot by height fraction, for the AMap key dialog — it prints the build's own package name and signing fingerprint, which is exactly what AMap's console asks you to paste, and not something to put on a public page.

## Two things measured rather than guessed, now in CONTRIBUTING

- **The map captures are slow, and it is the teardown.** ~50s per test, of which **~45s is `putItBack`**; setup is about two seconds. Recorded because the real Google map, the dialog waits and the tile sleep all look guilty and none of them is — I chased all three before measuring.
- **A PR stacked on another PR runs no checks at all.** Every workflow filters `pull_request: branches: ["main"]`, and that matches the base. The checks section is *absent* rather than red or pending, which reads as "nothing to run here" instead of "nothing ran". #153 sat like that.

## Verified

- JVM suite green; translation check green (301 strings, 9 locales)
- The padding test run both with and without the fix, confirming it can fail
- All 21 captures produced on a windowed Pixel 9 emulator
- Confirmed the capture classes now skip by default: that class went from six minutes to 14 seconds

Not verified: any physical device, and any navigation mode other than this emulator's gesture bar — the three-button figure above is Android's documented size, not something I measured here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)