### PR TITLE
[Android app 1.1.0] Lock exported bundles by default, once app 1.1.0 is published

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,9 +135,9 @@ message about the zip rather than about a code. Publish an exporter that locks b
 that app is out, and every bundle written that day is unopenable by whoever receives it, and the
 recipient is the one person in that transaction who chose none of it and can fix none of it.
 
-**So the wizard's lock is currently defaulted off**, in `wizard.py`'s `lock_bundle`, and
-`test_wizard_bundle_locking.py` asserts that. Flip it in the same change that raises the minimum
-app version, not before and not separately.
+**The wizard's lock is defaulted on**, in `wizard.py`'s `lock_bundle`, and
+`test_wizard_bundle_locking.py` asserts that. It was off until app 1.1.0 was released, and was
+flipped in the same change that raised the minimum — which is the ordering this rule exists for.
 
 **A gate on the format must not hold back unrelated fixes.** This nearly happened: the fix for
 [#140](https://github.com/parawanderer/OpenTagViewer/issues/140) — where every share comes back

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,12 +130,23 @@ So releasing is two steps, in this order:
 
 **And the app's release goes out before the exporter's, whenever the exporter's changes what a
 bundle is.** They are separate releases with separate tags, which makes them look independent;
-they are not. Exporter 1.4.0 locks bundles by default, and an app older than 1.1.0 cannot decrypt
-one at all — it fails with a message about the zip rather than about a code. Publish the exporter
-first and every bundle written that day is unopenable by whoever receives it, and the recipient is
-the one person in that transaction who chose none of it and can fix none of it.
+they are not. A locked bundle cannot be opened by an app older than 1.1.0 at all — it fails with a
+message about the zip rather than about a code. Publish an exporter that locks by default before
+that app is out, and every bundle written that day is unopenable by whoever receives it, and the
+recipient is the one person in that transaction who chose none of it and can fix none of it.
 
-Nothing enforces this — `release_version.py` checks a tag against a version, not one release
+**So the wizard's lock is currently defaulted off**, in `wizard.py`'s `lock_bundle`, and
+`test_wizard_bundle_locking.py` asserts that. Flip it in the same change that raises the minimum
+app version, not before and not separately.
+
+**A gate on the format must not hold back unrelated fixes.** This nearly happened: the fix for
+[#140](https://github.com/parawanderer/OpenTagViewer/issues/140) — where every share comes back
+unreadable and the export fails outright — sat unreleased behind this ordering because it happened
+to be on the same `main` as the locking change. Three people reported the same bug in the meantime.
+If a fix does not touch what a bundle *is*, it is not what this rule is about, and shipping it
+should not wait on an app release.
+
+Nothing enforces any of this — `release_version.py` checks a tag against a version, not one release
 against another — so it is a thing to remember, which is why it is written here.
 
 `scripts/release_version.py --kind exporter --tag <tag>` enforces it, and runs in `test-release-version`

--- a/python/exporter/version.py
+++ b/python/exporter/version.py
@@ -23,7 +23,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-VERSION = "1.4.0"
+VERSION = "1.5.0"
 
 APP_TITLE = f"OpenTagViewer AirTag Exporter {VERSION}"
 

--- a/python/exporter/wizard.py
+++ b/python/exporter/wizard.py
@@ -245,16 +245,21 @@ class WizardApp(tk.Tk):
         self.confirm_button = ttk.Button(buttons, text="Export…", command=self._export, state="disabled")
         self.confirm_button.grid(row=0, column=4)
 
-        # **On by default, and the default is the whole point.** A bundle holds key material that
-        # cannot be revoked - the only way to withdraw an exported accessory is to unpair it - and
-        # it then travels through a mail account or a chat app and outlives the conversation by
+        # **Off until the app that can open one is released, then on.** A bundle holds key material
+        # that cannot be revoked - the only way to withdraw an exported accessory is to unpair it -
+        # and it then travels through a mail account or a chat app and outlives the conversation by
         # years, sitting in a backup long after everyone has forgotten it is there. Whoever most
-        # needs the lock is whoever would never go looking for a checkbox to turn it on.
+        # needs the lock is whoever would never go looking for a checkbox to turn it on, so on is
+        # where this belongs and where it is going.
         #
-        # The opt-out exists for one real case, the same one behind the CLI's --no-password: an
-        # app older than 1.1.0 cannot decrypt anything at all, so a recipient running one cannot
-        # open a locked bundle, and they did not choose the exporter's version.
-        self.lock_bundle = tk.BooleanVar(value=True)
+        # It is off today for one reason: **no released app can decrypt a locked bundle.** Anything
+        # older than 1.1.0 fails with a message about the zip rather than about a code, and the
+        # person who meets that failure is the recipient - who chose neither the exporter nor its
+        # version, and can do nothing about either.
+        #
+        # So the ordering is app first, exporter second - see AGENTS.md rule 9. Flip this to True in
+        # the same change that raises the minimum, not before, and not separately.
+        self.lock_bundle = tk.BooleanVar(value=False)
         ttk.Checkbutton(
             buttons,
             text="Lock with a code",

--- a/python/exporter/wizard.py
+++ b/python/exporter/wizard.py
@@ -245,21 +245,19 @@ class WizardApp(tk.Tk):
         self.confirm_button = ttk.Button(buttons, text="Export…", command=self._export, state="disabled")
         self.confirm_button.grid(row=0, column=4)
 
-        # **Off until the app that can open one is released, then on.** A bundle holds key material
-        # that cannot be revoked - the only way to withdraw an exported accessory is to unpair it -
-        # and it then travels through a mail account or a chat app and outlives the conversation by
+        # **On by default, and the default is the whole point.** A bundle holds key material that
+        # cannot be revoked - the only way to withdraw an exported accessory is to unpair it - and
+        # it then travels through a mail account or a chat app and outlives the conversation by
         # years, sitting in a backup long after everyone has forgotten it is there. Whoever most
-        # needs the lock is whoever would never go looking for a checkbox to turn it on, so on is
-        # where this belongs and where it is going.
+        # needs the lock is whoever would never go looking for a checkbox to turn it on.
         #
-        # It is off today for one reason: **no released app can decrypt a locked bundle.** Anything
-        # older than 1.1.0 fails with a message about the zip rather than about a code, and the
-        # person who meets that failure is the recipient - who chose neither the exporter nor its
-        # version, and can do nothing about either.
+        # Off until app 1.1.0 was released, because nothing older can decrypt a locked bundle at
+        # all and the person who met that failure was the recipient. That app is out, so this is
+        # back on - see AGENTS.md rule 9 for why the two releases are ordered.
         #
-        # So the ordering is app first, exporter second - see AGENTS.md rule 9. Flip this to True in
-        # the same change that raises the minimum, not before, and not separately.
-        self.lock_bundle = tk.BooleanVar(value=False)
+        # The opt-out stays for the recipient still running something older, which is most of them
+        # on any given day after a release.
+        self.lock_bundle = tk.BooleanVar(value=True)
         ttk.Checkbutton(
             buttons,
             text="Lock with a code",

--- a/python/test/test_wizard_bundle_locking.py
+++ b/python/test/test_wizard_bundle_locking.py
@@ -1,16 +1,13 @@
 """
 The wizard can lock the bundles it writes, and shows the code once.
 
-**The default is off, and it is off for a reason that will expire.** A locked bundle can only be
-opened by app 1.1.0 or newer; anything older fails with a message about the zip rather than about
-a code. The person who meets that failure is the recipient, who chose neither the exporter nor its
-version - so until 1.1.0 is *released*, not merely built, locking by default would break exports
-for the one party who can do nothing about it.
+**The default is on, now that app 1.1.0 is released.** A locked bundle can only be opened by that
+version or newer; anything older fails with a message about the zip rather than about a code, and
+the person who meets that failure is the recipient - who chose neither the exporter nor its
+version. That is why this waited for the app rather than shipping alongside it.
 
-**These tests assert the default in both directions on purpose.** Nothing caught the previous flip
-in either direction, so the value has changed twice with no test noticing. When app 1.1.0 ships and
-the default goes back on, `test_the_checkbox_starts_unticked` is the test that should fail and be
-inverted - deliberately, in the same change, rather than discovered later.
+**These tests assert the default in both directions on purpose.** The value moved twice with no
+test noticing either time, which is how it came to be wrong in the first place.
 
 The code is the part with a permanent cost. It is not stored anywhere and cannot be recovered, so
 a bundle written without the user being shown its code is a bundle nobody can ever open.
@@ -71,10 +68,9 @@ class TestTheDefault:
     infrastructure, so on is where this belongs eventually. It is not there yet.
     """
 
-    def test_the_checkbox_starts_unticked(self, window):
-        assert window.lock_bundle.get() is False, (
-            "locking by default writes bundles that no released app can open. Flip this only in"
-            " the change that raises the minimum app version - see AGENTS.md rule 9"
+    def test_the_checkbox_starts_ticked(self, window):
+        assert window.lock_bundle.get() is True, (
+            "the default is on now that app 1.1.0 is released and can open a locked bundle"
         )
 
     def test_a_bundle_is_written_with_a_code(self, window, bundle, tmp_path):

--- a/python/test/test_wizard_bundle_locking.py
+++ b/python/test/test_wizard_bundle_locking.py
@@ -1,14 +1,16 @@
 """
-The wizard locks the bundles it writes, and shows the code once.
+The wizard can lock the bundles it writes, and shows the code once.
 
-**This default was blocked, not missing.** ``wizard.py`` hard-coded ``password=None`` with a
-comment saying so: before the Android app carried zip4j it could not decrypt anything at all, so
-a locked bundle was a file nobody's installed app could open - and the people worst affected were
-recipients, who did not choose the exporter's version and could not fix it from their side.
+**The default is off, and it is off for a reason that will expire.** A locked bundle can only be
+opened by app 1.1.0 or newer; anything older fails with a message about the zip rather than about
+a code. The person who meets that failure is the recipient, who chose neither the exporter nor its
+version - so until 1.1.0 is *released*, not merely built, locking by default would break exports
+for the one party who can do nothing about it.
 
-App 1.1.0 reads them. So the default flips, and these tests exist because nothing caught the old
-behaviour either: no test asserted ``password=None``, so the flip would have gone unnoticed in
-both directions.
+**These tests assert the default in both directions on purpose.** Nothing caught the previous flip
+in either direction, so the value has changed twice with no test noticing. When app 1.1.0 ships and
+the default goes back on, `test_the_checkbox_starts_unticked` is the test that should fail and be
+inverted - deliberately, in the same change, rather than discovered later.
 
 The code is the part with a permanent cost. It is not stored anywhere and cannot be recovered, so
 a bundle written without the user being shown its code is a bundle nobody can ever open.
@@ -63,12 +65,17 @@ def write(window, bundle, path, *, locked: bool):
 
 class TestTheDefault:
     """
-    A bundle holds key material that cannot be revoked, and travels through other people's
-    infrastructure. Whoever most needs the lock is whoever would never find a checkbox for it.
+    Off until an app that can open one is released - see the module docstring.
+
+    A bundle holds key material that cannot be revoked and travels through other people's
+    infrastructure, so on is where this belongs eventually. It is not there yet.
     """
 
-    def test_the_checkbox_starts_ticked(self, window):
-        assert window.lock_bundle.get() is True
+    def test_the_checkbox_starts_unticked(self, window):
+        assert window.lock_bundle.get() is False, (
+            "locking by default writes bundles that no released app can open. Flip this only in"
+            " the change that raises the minimum app version - see AGENTS.md rule 9"
+        )
 
     def test_a_bundle_is_written_with_a_code(self, window, bundle, tmp_path):
         write_zip, _shown, _info, _error, _closed = write(


### PR DESCRIPTION
> [!WARNING]
> **Do not merge until `android-app-v1.1.0` is actually published** — not tagged, not built, published. The gap between those is the entire point of the rule this implements.

The second half of [#159](https://github.com/parawanderer/OpenTagViewer/pull/159). That PR turned the wizard's lock **off** so the #140 fix could ship without waiting on an Android release; this turns it back on once that release exists.

## Why on is the right default

A bundle holds key material that **cannot be revoked** — the only way to withdraw an exported accessory is to unpair it — and it then travels through a mail account or a chat app and outlives the conversation by years, sitting in a backup long after everyone has forgotten it is there.

Whoever most needs the lock is whoever would never go looking for a checkbox to turn it on.

It was off for exactly one reason: nothing older than app 1.1.0 can decrypt a locked bundle at all, and the person who meets that failure is the **recipient**, who chose neither the exporter nor its version.

## 1.5.0, not 1.4.0

1.4.0 will have shipped without this. Two releases claiming the same version while writing materially different bundles is precisely what the `via:` stamp exists to prevent.

## The test flips with the behaviour

`test_wizard_bundle_locking.py`'s docstring said this test should fail here, deliberately, rather than be discovered wrong later — so it does, and it is inverted in the same change. That value has now moved three times; the first two went unnoticed because nothing asserted it.

Rule 9 moves to the post-1.1.0 state in the same commit.

560 tests pass.

---
*PR description summarised by Claude Code.*
