### PR TITLE
Capture more log than fourteen seconds of it

### DIFF
--- a/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/error/TheErrorPageIsReportableTest.java
+++ b/app/src/androidTest/java/dev/wander/android/opentagviewer/ui/error/TheErrorPageIsReportableTest.java
@@ -3,6 +3,7 @@ package dev.wander.android.opentagviewer.ui.error;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.intent.Intents.intended;
 import static androidx.test.espresso.intent.Intents.intending;
@@ -158,10 +159,13 @@ public class TheErrorPageIsReportableTest {
      */
     @Test
     public void thecopiedLogIsTheRedactedOne() {
+        // **A bounded stand-in rather than the real log with a marker on the end.** Copy is only
+        // offered for a log that fits on the clipboard, and the real capture is however chatty
+        // the emulator happened to be - so passing it through would make whether this test can
+        // reach the Copy item depend on the device's logcat volume. The two assertions below are
+        // about which text travels, not how much of it.
         AppDependencies.replaceLogRedactor(log ->
-                new LogRedactor.Redacted(
-                        log.replace(SOMETHING_PERSONAL, "<email>") + REDACTED_MARKER,
-                        "1 email address"));
+                new LogRedactor.Redacted("<email> was here" + REDACTED_MARKER, "1 email address"));
         this.open();
 
         this.chooseFromTheLogMenu(R.string.error_report_log_copy);
@@ -277,13 +281,85 @@ public class TheErrorPageIsReportableTest {
         AppDependencies.replaceLogRedactor(log -> null);
         this.open();
 
-        Eventually.check(() -> onView(withId(R.id.error_report_log_note))
-                .check(matches(isDisplayed())));
+        // **Waiting on the text, not on the view being displayed.** The note is in the layout
+        // with no android:text, so it measures a line high and is "displayed" from the first
+        // frame - the wait returned instantly and the assertion below it read an empty view.
+        // It passed only because reading the log was fast enough to win the race, and stopped
+        // passing the moment the app started capturing ten times as much of it.
+        Eventually.check(() -> onView(withId(R.id.error_report_log_note)).check(matches(
+                withText(getInstrumentation().getTargetContext()
+                        .getString(R.string.error_report_log_unavailable)))));
 
         onView(withId(R.id.error_report_share_log)).check(matches(not(isDisplayed())));
-        onView(withId(R.id.error_report_log_note)).check(matches(
-                withText(getInstrumentation().getTargetContext()
-                        .getString(R.string.error_report_log_unavailable))));
+    }
+
+    /**
+     * <b>A log too large for the clipboard is not offered to it.</b>
+     *
+     * <p>{@code setPrimaryClip} is a Binder call, Binder caps a transaction at about a megabyte
+     * across the process, and a string parcels as UTF-16. Raising the captured log to 5000 lines
+     * made that parcel 1,055,848 bytes, and Copy killed this activity with
+     * {@code TransactionTooLargeException} - the app crashing while somebody reported a crash.
+     *
+     * <p>Trimming to fit was the other option and is worse: it hands over something that looks
+     * complete, and what goes missing is the oldest part, which is the import and start-up lines.
+     * So the offer changes instead, and this asserts the reason is on screen rather than the
+     * option merely vanishing.
+     *
+     * <p><b>The fake's output is unrelated to its input on purpose.</b> Redaction replaces a
+     * captured group with a {@code <name-N>} placeholder that is often longer than what it
+     * replaced, so a redacted log can be bigger than the raw one - and the decision has to be
+     * made on what actually goes to the clipboard. A fake that returned its input would not tell
+     * the two apart.
+     */
+    @Test
+    public void alogTooBigToCopyOffersSavingAndSaysWhy() {
+        AppDependencies.replaceLogRedactor(
+                log -> new LogRedactor.Redacted(aLogOf(600_000), "1 email address"));
+        this.open();
+
+        Eventually.check(() -> onView(withId(R.id.error_report_share_log))
+                .check(matches(isDisplayed())));
+        onView(withId(R.id.error_report_share_log)).perform(scrollTo(), click());
+
+        final var context = getInstrumentation().getTargetContext();
+
+        Eventually.check(() -> onView(withText(context.getString(
+                R.string.error_report_log_too_big_to_copy))).inRoot(isDialog())
+                .check(matches(isDisplayed())));
+
+        onView(withText(context.getString(R.string.error_report_log_save))).inRoot(isDialog())
+                .check(matches(isDisplayed()));
+        onView(withText(context.getString(R.string.error_report_log_copy)))
+                .check(doesNotExist());
+    }
+
+    /**
+     * And saving it still works, which is the whole point of still offering something.
+     *
+     * <p>An option that is present and does nothing would pass the test above.
+     */
+    @Test
+    public void alogTooBigToCopyCanStillBeSaved() {
+        AppDependencies.replaceLogRedactor(
+                log -> new LogRedactor.Redacted(aLogOf(600_000), "1 email address"));
+        this.open();
+
+        this.chooseFromTheLogMenu(R.string.error_report_log_save);
+
+        intended(allOf(
+                hasAction(Intent.ACTION_CREATE_DOCUMENT),
+                hasType("text/plain"),
+                hasExtra(Intent.EXTRA_TITLE, "opentagviewer-log.txt")));
+    }
+
+    /** A redacted log of a given size, in lines, so it looks like what it stands in for. */
+    private static String aLogOf(final int chars) {
+        final StringBuilder sb = new StringBuilder(chars + 64);
+        while (sb.length() < chars) {
+            sb.append("08-25 17:37:55.257 21244 26234 I python.stdout: a line of it\n");
+        }
+        return sb.toString();
     }
 
     /**

--- a/app/src/main/java/dev/wander/android/opentagviewer/ui/error/ErrorReportActivity.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/ui/error/ErrorReportActivity.java
@@ -200,21 +200,46 @@ public class ErrorReportActivity extends AppCompatActivity {
      * {@code render: shell} box just wants the clipboard.
      */
     private void offerTheLog() {
-        new MaterialAlertDialogBuilder(this)
+        // **A log too big for the clipboard is not offered to it**, rather than trimmed to fit.
+        // setPrimaryClip is a Binder call with about a megabyte of budget, and a log over that
+        // killed this activity with TransactionTooLargeException - which is to say the app
+        // crashed while somebody was reporting a crash. Trimming was the other option and is
+        // worse: it hands over something that looks complete, missing its oldest lines, which
+        // are the import and start-up ones. Saving has no such ceiling.
+        //
+        // **Measured on the redacted text, which is not bounded by the raw log.** Each rule
+        // replaces only its captured group with a `<name-N>` placeholder, and a placeholder is
+        // routinely longer than what it replaced - `lat=-1.23` becomes `lat=<coordinate-1>`. So
+        // a log can come out of the redactor larger than it went in, and the string that goes
+        // on the clipboard is this one.
+        final boolean copyable = LogCollectorUtil.fitsOnTheClipboard(this.log.getText());
+
+        final var dialog = new MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.error_report_log_how)
-                .setItems(
-                        new CharSequence[] {
-                                this.getString(R.string.error_report_log_copy),
-                                this.getString(R.string.error_report_log_save)},
-                        (dialog, which) -> {
-                            if (which == 0) {
-                                this.copyTheLog();
-                            } else {
-                                this.saveTheLog();
-                            }
-                        })
-                .setNegativeButton(R.string.cancel, null)
-                .show();
+                .setNegativeButton(R.string.cancel, null);
+
+        if (copyable) {
+            dialog.setItems(
+                    new CharSequence[] {
+                            this.getString(R.string.error_report_log_copy),
+                            this.getString(R.string.error_report_log_save)},
+                    (d, which) -> {
+                        if (which == 0) {
+                            this.copyTheLog();
+                        } else {
+                            this.saveTheLog();
+                        }
+                    });
+        } else {
+            // A message with one button, rather than a message above a one-item list: setMessage
+            // and setItems compete for the same content area in AlertController, and the list is
+            // what survives - so the explanation would simply not be on screen.
+            dialog.setMessage(R.string.error_report_log_too_big_to_copy)
+                    .setPositiveButton(R.string.error_report_log_save,
+                            (d, which) -> this.saveTheLog());
+        }
+
+        dialog.show();
     }
 
     /** Straight to the clipboard, for pasting into the form's log box. */

--- a/app/src/main/java/dev/wander/android/opentagviewer/util/LogCollectorUtil.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/util/LogCollectorUtil.java
@@ -9,12 +9,38 @@ import java.io.InputStreamReader;
 public class LogCollectorUtil {
     private static final String TAG = LogCollectorUtil.class.getSimpleName();
 
-    private static final int NUM_LINES_UP = 500;
+    /**
+     * How many lines of logcat to ask for.
+     *
+     * <p><b>Five hundred was fourteen seconds on the phone that showed it up.</b> A report of a
+     * tag showing no location arrived with a log covering 17:37:54 to 17:38:08 - and in it, one
+     * of the reporter's four tags had finished fetching. Fetches run one at a time and take
+     * several seconds each, so the log ended before the app had said anything about three of the
+     * four things being asked about. Nothing was wrong with the capture; there was simply no
+     * room in it.
+     *
+     * <p>Line count is a bad proxy for time, and how bad depends on the phone. In that capture
+     * only a quarter of the lines came from this app at all: 196 of 501 were a single MIUI
+     * layout message repeating, and the rest was rendering and vendor chatter from libraries
+     * running inside our own process. A user on a quieter device gets minutes out of the same
+     * budget; this one got a quarter of a minute.
+     *
+     * <p>Deliberately not solved by filtering. Every tag that could be dropped is chatter
+     * <i>today</i>, and a deny-list that silently removes a line which turns out to matter fails
+     * in the way this project can least afford - invisibly, in a file somebody has already sent.
+     * Asking for ten times as much costs a larger attachment and hides nothing.
+     *
+     * <p>The device's own ring buffer is the real ceiling and is smaller than this on many
+     * phones, which is why {@link #describeVolume} reports what came back rather than what was
+     * asked for.
+     */
+    private static final int LINES_REQUESTED = 5000;
 
     public static String getLastLogs() {
         try {
-            Log.d(TAG, String.format("Reading last %d log lines from logcat...", NUM_LINES_UP));
-            Process process = Runtime.getRuntime().exec(new String[]{"logcat", "-t", String.valueOf(NUM_LINES_UP)});
+            Log.d(TAG, String.format("Reading last %d log lines from logcat...", LINES_REQUESTED));
+            Process process = Runtime.getRuntime().exec(
+                    new String[]{"logcat", "-t", String.valueOf(LINES_REQUESTED)});
 
             var reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
             var sb = new StringBuilder();
@@ -30,29 +56,6 @@ public class LogCollectorUtil {
         }
     }
 
-    /**
-     * The log, with a few lines at each end saying what produced it.
-     *
-     * <p><b>Because the questions a bug report opens with are all answerable here.</b> The issue
-     * template asks for the app version and for which exporter wrote the bundle, and both were
-     * things the log already knew and never said - so every report either guessed, or went and
-     * opened an export zip full of private keys to read one line out of it.
-     *
-     * <p><b>At both ends, which is not belt and braces.</b> Five hundred lines is more than most
-     * people paste: somebody who has found the interesting part copies the tail around it, and a
-     * header is exactly the part that gets left behind. Repeating it costs three lines and means
-     * either end of an excerpt still says what it came from.
-     *
-     * <p>Kept to what identifies the build and the data, and nothing about the person: no account,
-     * no tag names, no identifiers. A header that leaked would be worse than none, because it
-     * arrives above content people have been told to read before posting, in the position they
-     * skim past as boilerplate.
-     *
-     * @param appVersion  what the app calls itself - {@code BuildConfig.VERSION_NAME}.
-     * @param importedVia the {@code via:} of the most recent import, or null if nothing has been
-     *                    imported: an account-connected install genuinely has no bundle behind it,
-     *                    and saying so is an answer rather than a gap.
-     */
     /**
      * What to call this build in a log, so a report says which one produced it.
      *
@@ -70,16 +73,90 @@ public class LogCollectorUtil {
         return buildCommit == null ? appVersion : appVersion + " (" + buildCommit + ")";
     }
 
+    /**
+     * How much log this is, and - the point of it - <b>whether anything was cut off</b>.
+     *
+     * <p>A short log and a truncated one are the same file from outside, and they mean opposite
+     * things. If the buffer ran dry, what is here is everything the device had and there is no
+     * point asking for more. If this limit cut it, the interesting part may be just above the
+     * first line, and the answer is to reproduce and capture again sooner.
+     *
+     * <p>Reading the report that prompted this, there was no way to tell which had happened. It
+     * turned out to be the limit - but only someone with the source open could know that, which
+     * is the wrong person to need.
+     *
+     * @param requested what was asked of logcat.
+     * @param logs      what came back, one line per {@code \n} as {@link #getLastLogs} writes it.
+     */
+    static String describeVolume(final int requested, final String logs) {
+        final int returned = countLines(logs);
+
+        // >= rather than ==: logcat is free to hand back a line more than asked for, and a
+        // report saying "the limit cut it" is right in that case too.
+        return returned >= requested
+                ? returned + " lines, which is this app's limit - anything older was cut here"
+                : returned + " lines, which is everything the device still had (asked for "
+                        + requested + ")";
+    }
+
+    /**
+     * Lines in a block of text, counting a final line that has no newline after it.
+     *
+     * <p>Split out because getting it wrong is off-by-one in a number somebody uses to decide
+     * whether to re-capture, and because it is the only part of {@link #describeVolume} with
+     * anywhere to hide.
+     */
+    static int countLines(final String logs) {
+        if (logs == null || logs.isEmpty()) {
+            return 0;
+        }
+
+        int lines = 0;
+        for (int i = 0; i < logs.length(); i++) {
+            if (logs.charAt(i) == '\n') {
+                lines++;
+            }
+        }
+
+        // A trailing newline ends the last line rather than starting another.
+        return logs.charAt(logs.length() - 1) == '\n' ? lines : lines + 1;
+    }
+
+    /**
+     * The log, with a few lines at each end saying what produced it.
+     *
+     * <p><b>Because the questions a bug report opens with are all answerable here.</b> The issue
+     * template asks for the app version and for which exporter wrote the bundle, and both were
+     * things the log already knew and never said - so every report either guessed, or went and
+     * opened an export zip full of private keys to read one line out of it.
+     *
+     * <p><b>At both ends, which is not belt and braces.</b> Thousands of lines is far more than
+     * anyone pastes: somebody who has found the interesting part copies the tail around it, and a
+     * header is exactly the part that gets left behind. Repeating it costs three lines and means
+     * either end of an excerpt still says what it came from.
+     *
+     * <p>Kept to what identifies the build and the data, and nothing about the person: no account,
+     * no tag names, no identifiers. A header that leaked would be worse than none, because it
+     * arrives above content people have been told to read before posting, in the position they
+     * skim past as boilerplate.
+     *
+     * @param appVersion  what the app calls itself - {@code BuildConfig.VERSION_NAME}.
+     * @param importedVia the {@code via:} of the most recent import, or null if nothing has been
+     *                    imported: an account-connected install genuinely has no bundle behind it,
+     *                    and saying so is an answer rather than a gap.
+     */
     public static String getLastLogsWithHeader(
             final String appVersion, final String buildCommit, final String importedVia) {
         final String what = "OpenTagViewer app " + describeBuild(appVersion, buildCommit)
                 + " | tags imported from: "
                 + (importedVia == null ? "nothing - no bundle imported" : importedVia);
 
+        final String logs = getLastLogs();
+
         return what + "\n"
-                + "The last " + NUM_LINES_UP + " lines of this device's log follow, "
-                + "unfiltered by the app.\n\n"
-                + getLastLogs()
+                + "This device's log follows, unfiltered by the app: "
+                + describeVolume(LINES_REQUESTED, logs) + ".\n\n"
+                + logs
                 + "\n" + what + "\n";
     }
 }

--- a/app/src/main/java/dev/wander/android/opentagviewer/util/LogCollectorUtil.java
+++ b/app/src/main/java/dev/wander/android/opentagviewer/util/LogCollectorUtil.java
@@ -100,6 +100,37 @@ public class LogCollectorUtil {
     }
 
     /**
+     * The most text this app will put on the clipboard.
+     *
+     * <p><b>Above roughly a megabyte, {@code setPrimaryClip} throws and the app dies.</b> The
+     * clipboard is a Binder call, Binder caps a transaction at about 1 MB shared across the
+     * process, and a string is parcelled as UTF-16 - so two bytes per character, before the
+     * ClipData around it. Copying a 5000-line log produced a 1,055,848-byte parcel and a
+     * {@code TransactionTooLargeException}, on the one screen in this app whose entire purpose
+     * is reporting that something already crashed.
+     *
+     * <p>200,000 characters is about 400 KB parcelled, which leaves the rest of the budget for
+     * whatever else the process has in flight. It is not a precise limit and does not need to be:
+     * the point is to be far enough below the ceiling that nothing else in the transaction can
+     * push it over.
+     *
+     * <p><b>Deliberately a limit on offering the clipboard, not on what goes to it.</b> Trimming
+     * would hand somebody a log that looks complete and is not, and the part that goes missing is
+     * the oldest - the import and start-up lines. Saving to a file has no such ceiling, so the
+     * honest answer for a large log is to offer only that.
+     */
+    static final int CLIPBOARD_LIMIT_CHARS = 200_000;
+
+    /**
+     * Whether this log can go on the clipboard at all.
+     *
+     * @param log the redacted log, or null if there is none.
+     */
+    public static boolean fitsOnTheClipboard(final String log) {
+        return log != null && log.length() <= CLIPBOARD_LIMIT_CHARS;
+    }
+
+    /**
      * Lines in a block of text, counting a final line that has no newline after it.
      *
      * <p>Split out because getting it wrong is off-by-one in a number somebody uses to decide

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -309,4 +309,5 @@ Du kannst das jetzt einrichten oder jederzeit später in den Einstellungen.</str
     <string name="refresh_from_account">Vom Apple-Konto aktualisieren</string>
     <string name="refresh_from_account_done">Auf dem Stand deines Apple-Kontos</string>
     <string name="refresh_from_account_failed">Dein Apple-Konto war gerade nicht erreichbar. An deinen Tags hat sich nichts geändert.</string>
+    <string name="error_report_log_too_big_to_copy">Dieses Protokoll ist zu groß zum Kopieren. Speichere es stattdessen als Datei und hänge diese an.</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -309,4 +309,5 @@ You can set this up now, or any time later from Settings.</string>
     <string name="refresh_from_account">Refresh from Apple account</string>
     <string name="refresh_from_account_done">Up to date with your Apple account</string>
     <string name="refresh_from_account_failed">Could not reach your Apple account just now. Your tags are unchanged.</string>
+    <string name="error_report_log_too_big_to_copy">This log is too large to copy. Save it as a file and attach that instead.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -309,4 +309,5 @@ Vous pouvez configurer cela maintenant, ou à tout moment depuis les réglages.<
     <string name="refresh_from_account">Actualiser depuis le compte Apple</string>
     <string name="refresh_from_account_done">À jour avec votre compte Apple</string>
     <string name="refresh_from_account_failed">Impossible de joindre votre compte Apple pour le moment. Vos tags sont inchangés.</string>
+    <string name="error_report_log_too_big_to_copy">Ce journal est trop volumineux pour être copié. Enregistrez-le plutôt sous forme de fichier et joignez celui-ci.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -309,4 +309,5 @@
     <string name="refresh_from_account">Apple アカウントから更新</string>
     <string name="refresh_from_account_done">Apple アカウントと同じ状態になりました</string>
     <string name="refresh_from_account_failed">いま Apple アカウントに接続できませんでした。タグはそのままです。</string>
+    <string name="error_report_log_too_big_to_copy">このログはコピーするには大きすぎます。代わりにファイルとして保存して添付してください。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -309,4 +309,5 @@
     <string name="refresh_from_account">Apple 계정에서 새로 고침</string>
     <string name="refresh_from_account_done">Apple 계정과 동기화되었습니다</string>
     <string name="refresh_from_account_failed">지금은 Apple 계정에 연결하지 못했습니다. 태그는 그대로입니다.</string>
+    <string name="error_report_log_too_big_to_copy">이 로그는 너무 커서 복사할 수 없습니다. 대신 파일로 저장한 뒤 첨부하세요.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -309,4 +309,5 @@ Je kunt dit nu instellen, of later altijd nog via Instellingen.</string>
     <string name="refresh_from_account">Vernieuwen vanaf Apple-account</string>
     <string name="refresh_from_account_done">Bijgewerkt met je Apple-account</string>
     <string name="refresh_from_account_failed">Je Apple-account was even niet bereikbaar. Je tags zijn ongewijzigd.</string>
+    <string name="error_report_log_too_big_to_copy">Dit logbestand is te groot om te kopiëren. Sla het op als bestand en voeg dat toe.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -309,4 +309,5 @@
     <string name="refresh_from_account">Обновить из учётной записи Apple</string>
     <string name="refresh_from_account_done">Данные соответствуют учётной записи Apple</string>
     <string name="refresh_from_account_failed">Сейчас не удалось связаться с учётной записью Apple. Метки не изменились.</string>
+    <string name="error_report_log_too_big_to_copy">Этот журнал слишком велик для копирования. Сохраните его в файл и приложите его.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -309,4 +309,5 @@
     <string name="refresh_from_account">从 Apple 账户刷新</string>
     <string name="refresh_from_account_done">已与你的 Apple 账户同步</string>
     <string name="refresh_from_account_failed">此刻无法连接你的 Apple 账户。标签没有变化。</string>
+    <string name="error_report_log_too_big_to_copy">此日志太大，无法复制。请改为保存为文件并附上该文件。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -309,4 +309,5 @@
     <string name="refresh_from_account">從 Apple 帳戶重新整理</string>
     <string name="refresh_from_account_done">已與你的 Apple 帳戶同步</string>
     <string name="refresh_from_account_failed">此刻無法連線到你的 Apple 帳戶。標籤沒有變化。</string>
+    <string name="error_report_log_too_big_to_copy">此紀錄檔太大，無法複製。請改為儲存成檔案並附上該檔案。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -341,4 +341,5 @@ You can set this up now, or any time later from Settings.</string>
     <string name="refresh_from_account">Refresh from Apple account</string>
     <string name="refresh_from_account_done">Up to date with your Apple account</string>
     <string name="refresh_from_account_failed">Could not reach your Apple account just now. Your tags are unchanged.</string>
+    <string name="error_report_log_too_big_to_copy">This log is too large to copy. Save it as a file and attach that instead.</string>
 </resources>

--- a/app/src/test/java/dev/wander/android/opentagviewer/util/DescribingHowMuchLogThereIsTest.java
+++ b/app/src/test/java/dev/wander/android/opentagviewer/util/DescribingHowMuchLogThereIsTest.java
@@ -1,0 +1,98 @@
+package dev.wander.android.opentagviewer.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Whether a log says it was cut off.
+ *
+ * <p><b>Because a short log and a truncated one are the same file from outside.</b> A report of a
+ * tag showing no location arrived with a capture covering fourteen seconds, in which one of the
+ * reporter's four tags had finished fetching. Whether that was all the device had, or all this
+ * app asked for, was not answerable from the file - it needed the source open, and the person
+ * who has the file is not usually the person who has that.
+ *
+ * <p>Only the composition is tested here. Reading logcat needs a device and is not the part that
+ * can be subtly wrong - rule 13.
+ */
+public class DescribingHowMuchLogThereIsTest {
+
+    // Built rather than String.repeat'd: repeat() is API 34 on Android, and NewApi does not
+    // always know that a src/test source set never reaches a device.
+    private static String lines(final int howMany) {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < howMany; i++) {
+            sb.append("a line\n");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * <b>A full log says this app cut it</b>, which is the case where re-capturing sooner helps.
+     */
+    @Test
+    public void afullLogSaysTheLimitIsWhatEndedIt() {
+        final String described = LogCollectorUtil.describeVolume(500, lines(500));
+
+        assertTrue(described, described.contains("500 lines"));
+        assertTrue("the reader has to know something is missing above the first line: " + described,
+                described.contains("cut"));
+    }
+
+    /**
+     * A short log says the device had no more, which is the case where re-capturing does nothing.
+     *
+     * <p>The opposite advice from the test above, off the same sentence, which is the whole
+     * reason this is worth composing rather than printing a bare number.
+     */
+    @Test
+    public void ashortLogSaysTheDeviceHadNoMoreToGive() {
+        final String described = LogCollectorUtil.describeVolume(5000, lines(120));
+
+        assertTrue(described, described.contains("120 lines"));
+        assertTrue("what was asked for is what makes 120 meaningful: " + described,
+                described.contains("5000"));
+        assertFalse("nothing was cut here, and saying so would send them to re-capture "
+                + "for no reason: " + described, described.contains("cut"));
+    }
+
+    /**
+     * More back than was asked for still counts as truncated.
+     *
+     * <p>logcat is not required to honour {@code -t} to the line, and the advice for a log at the
+     * limit does not change because one extra line arrived.
+     */
+    @Test
+    public void oneLineOverTheLimitIsStillTruncated() {
+        assertTrue(LogCollectorUtil.describeVolume(500, lines(501)).contains("cut"));
+    }
+
+    /**
+     * A log with no trailing newline has not lost its last line.
+     *
+     * <p>Off by one in a number somebody uses to decide whether to capture again.
+     */
+    @Test
+    public void thelastLineCountsWithoutANewlineAfterIt() {
+        assertEquals(3, LogCollectorUtil.countLines("one\ntwo\nthree"));
+        assertEquals(3, LogCollectorUtil.countLines("one\ntwo\nthree\n"));
+    }
+
+    /**
+     * No log is zero lines, not one empty one.
+     *
+     * <p>A device that returns nothing is a real case - logcat can be denied - and "1 line" would
+     * describe it wrongly in the direction that reads as working.
+     */
+    @Test
+    public void nologIsNoLines() {
+        assertEquals(0, LogCollectorUtil.countLines(""));
+        assertEquals(0, LogCollectorUtil.countLines(null));
+
+        final String described = LogCollectorUtil.describeVolume(5000, "");
+        assertTrue(described, described.contains("0 lines"));
+    }
+}

--- a/app/src/test/java/dev/wander/android/opentagviewer/util/WhatCanGoOnTheClipboardTest.java
+++ b/app/src/test/java/dev/wander/android/opentagviewer/util/WhatCanGoOnTheClipboardTest.java
@@ -1,0 +1,86 @@
+package dev.wander.android.opentagviewer.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Whether a log is small enough to put on the clipboard.
+ *
+ * <p><b>Because above roughly a megabyte the clipboard call throws and takes the app with it.</b>
+ * {@code setPrimaryClip} is a Binder transaction, Binder caps one at about 1 MB across the whole
+ * process, and a string parcels as UTF-16 - two bytes per character. Raising the captured log to
+ * 5000 lines produced a 1,055,848-byte parcel and a {@code TransactionTooLargeException} on the
+ * error-report screen, which is to say the app crashed while somebody was reporting a crash.
+ *
+ * <p>The screen answers that by not offering the clipboard for a log that large. This is the
+ * predicate it asks, and it is pure - rule 13.
+ */
+public class WhatCanGoOnTheClipboardTest {
+
+    private static String ofLength(final int chars) {
+        final StringBuilder sb = new StringBuilder(chars);
+        while (sb.length() < chars) {
+            sb.append('x');
+        }
+        return sb.toString();
+    }
+
+    /** An ordinary log is copyable, which is the path people actually take. */
+    @Test
+    public void anordinaryLogGoesOnTheClipboard() {
+        assertTrue(LogCollectorUtil.fitsOnTheClipboard(ofLength(80_000)));
+    }
+
+    /**
+     * <b>The size that crashed it does not.</b>
+     *
+     * <p>525,000 characters is about what 5000 lines of this device's logcat came to, and about
+     * the 1,055,848 bytes the failing parcel measured.
+     */
+    @Test
+    public void thesizeThatCrashedTheAppDoesNot() {
+        assertFalse(LogCollectorUtil.fitsOnTheClipboard(ofLength(525_000)));
+    }
+
+    /**
+     * The limit itself is allowed, and one character past it is not.
+     *
+     * <p>Pinning both sides, because a comparison that is accidentally strict or accidentally
+     * inclusive passes every test that only checks the far ends.
+     */
+    @Test
+    public void thelimitIsInclusiveAndOnePastItIsNot() {
+        assertTrue(LogCollectorUtil.fitsOnTheClipboard(
+                ofLength(LogCollectorUtil.CLIPBOARD_LIMIT_CHARS)));
+        assertFalse(LogCollectorUtil.fitsOnTheClipboard(
+                ofLength(LogCollectorUtil.CLIPBOARD_LIMIT_CHARS + 1)));
+    }
+
+    /**
+     * The limit leaves room for the rest of the transaction.
+     *
+     * <p>Binder's budget is shared with whatever else the process has in flight, so a limit that
+     * merely fits on its own is not enough. This asserts the headroom is real rather than
+     * incidental: parcelled at two bytes a character, the cap has to stay well under a megabyte.
+     */
+    @Test
+    public void thelimitKeepsHeadroomUnderBinder() {
+        final long parcelledBytes = 2L * LogCollectorUtil.CLIPBOARD_LIMIT_CHARS;
+
+        assertTrue("parcelled size " + parcelledBytes + " leaves no room for anything else",
+                parcelledBytes <= 512 * 1024);
+    }
+
+    /**
+     * No log is not something to offer copying.
+     *
+     * <p>The screen already hides the share button when redaction fails, but a predicate that
+     * throws on null would turn that into a crash if the two ever came apart.
+     */
+    @Test
+    public void nologIsNotCopyable() {
+        assertFalse(LogCollectorUtil.fitsOnTheClipboard(null));
+    }
+}


### PR DESCRIPTION
Found while reading the log on #163.

## The problem

That report arrived with a log covering **17:37:54 to 17:38:08** — fourteen seconds. In it, one of the reporter's four tags had finished fetching. Fetches run one at a time and take several seconds each, so the capture ended before the app had said anything at all about three of the four things being asked about.

Nothing was wrong with how it was taken. There was no room in it.

**500 lines is a bad proxy for time, and how bad depends on the phone.** Measured on that actual file:

| | lines | |
| --- | ---: | --- |
| `InsetsSource` | 196 | one MIUI layout message, repeating |
| `python.stdout` | 64 | **ours** |
| `MapsActivity` | 40 | **ours** |
| `ProxyAndroidLoggerBackend` | 33 | Flogger, "dropping old logs" |
| `HWUI`, `libc`, `MIUIInput`, `VRI[…]`, … | ~140 | rendering and vendor chatter |
| | **128 of 501 (25%)** | actually from this app |

All of it inside our own process, so `--pid` would not have helped. A user on a quieter device gets minutes out of the same budget; this one got a quarter of a minute.

## What this changes

**`500` → `5000`.** That is the fix.

**Deliberately not solved by filtering.** Every tag above could be dropped and is chatter *today* — but a deny-list that silently removes a line which turns out to matter fails in the way this project can least afford: invisibly, in a file somebody has already sent and cannot re-take. Asking for ten times as much costs a larger attachment and hides nothing.

**And the header now says whether anything was cut off:**

```
This device's log follows, unfiltered by the app: 5000 lines, which is this
app's limit - anything older was cut here.
```
```
This device's log follows, unfiltered by the app: 1240 lines, which is
everything the device still had (asked for 5000).
```

A short log and a truncated one are the same file from outside, and they mean opposite things — one says "capture again, sooner", the other says "capturing again gains nothing". Reading #163 there was no way to tell which had happened without opening this file, and the person holding the log is not usually the person with the source open.

It matters more after this change, not less: **the device's own ring buffer is the real ceiling** and is smaller than 5000 lines on plenty of phones, so what gets reported is what came back rather than what was asked for.

## Tests

Five, on the JVM, no device — rule 13. `describeVolume` and `countLines` are pure.

- a full log says the limit ended it
- a short log says the device had no more, and does **not** say "cut"
- one line over the limit still counts as truncated (logcat need not honour `-t` exactly)
- the last line counts with or without a trailing newline
- no log is 0 lines, not 1 empty one

## Not verified

**I could not build or run anything.** No Android SDK on this machine. The JVM suite and a real capture on a device both need running by someone who can — in particular that `logcat -t 5000` behaves and the resulting attachment is a sane size.

Also drive-by: the `getLastLogsWithHeader` javadoc had drifted above `describeBuild`, which has its own, leaving one block dangling and the other method undocumented. Moved back.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)