### PR TITLE
Credit a contributor when their PR merges, not up to a week later

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -11,17 +11,57 @@ name: Update contributors
 
 on:
   schedule:
-    # Weekly. Contributor lists do not move fast enough to warrant more.
+    # Still weekly, and still worth keeping. It catches avatar changes, a merge this workflow
+    # was not running for yet, and any run below that found GitHub's stats cache stale.
     - cron: '0 4 * * 1'
   workflow_dispatch:
+
+  # **And immediately when somebody else's pull request is merged**, because a week is a long
+  # time to go uncredited after contributing to something. The gap was real: an author could
+  # merge, be thanked in the PR, and then not appear in the app for another six days.
+  #
+  # `pull_request_target` rather than `pull_request` because a fork's `pull_request` run gets a
+  # read-only token and no secrets, and this job has to push a branch and open a PR. That trade
+  # is the well-known footgun, so to be explicit about why it is safe here: this workflow is read
+  # from the base branch, `actions/checkout` below takes the base and is given no `ref`, and
+  # nothing here builds or executes anything out of the pull request. **Do not add a `ref:` that
+  # points at the PR's head** - that is the whole vulnerability, and it would hand a write token
+  # to code from an arbitrary fork.
+  pull_request_target:
+    types: [closed]
 
 permissions:
   contents: write
   pull-requests: write
 
+# Two merges close together would otherwise race for the same `chore/update-contributors` branch.
+# The later one is the one worth having - it sees both authors - so the earlier is cancelled.
+concurrency:
+  group: update-contributors
+  cancel-in-progress: true
+
 jobs:
   update:
     runs-on: ubuntu-latest
+
+    # Merged, by somebody who is not the owner, and not a bot.
+    #
+    # `!= github.repository_owner` is the point of the trigger: the owner's merges are most of
+    # them, they change nobody's standing in a list they already top, and a PR opened for every
+    # one would be noise that gets ignored - including on the day it matters.
+    #
+    # The bot check is not hypothetical either. This workflow's own PR is opened by
+    # github-actions[bot], which is not the owner, so without it merging one would trigger the
+    # next. That settles after a round with no diff, but "settles eventually" is a poor thing to
+    # rely on when the alternative is one expression.
+    #
+    # Schedule and manual runs are unconditional - hence the first line, which is what lets them
+    # through a condition written for pull requests.
+    if: |
+      github.event_name != 'pull_request_target'
+      || (github.event.pull_request.merged == true
+          && github.event.pull_request.user.login != github.repository_owner
+          && github.event.pull_request.user.type != 'Bot')
 
     steps:
       - uses: actions/checkout@v4
@@ -30,10 +70,33 @@ jobs:
         with:
           python-version: '3.12'
 
+      # `--expect-contributor` only on the merge trigger, and it is the honest part of this.
+      #
+      # GitHub computes `/stats/contributors` asynchronously and caches it. Merging invalidates
+      # that cache, so this run gets either a 202 it waits out or a cached 200 from before the
+      # merge - and the second looks exactly like success: no diff, no pull request, green tick.
+      # Naming who this run was fired for turns that into a failed run somebody can see.
+      #
+      # It is not a gate on anything, and a red run here means only "the weekly schedule will
+      # credit them instead". Failing loudly is the point; it is the difference between knowing
+      # this trigger works and assuming it does.
+      # **The login goes through `env:`, never interpolated into the command line.** It is a
+      # value an outside person chooses, this job runs with a write token, and `${{ }}` inside
+      # `run:` is textual substitution into the shell - which is the standard injection route
+      # into a `pull_request_target` workflow. GitHub restricts logins to letters, digits and
+      # hyphens, so this particular field is not exploitable today; the habit is what matters,
+      # because the next field somebody adds here might be a title or a branch name.
       - name: Regenerate the contributor list
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python scripts/fetch_contributors.py
+          EXPECT_CONTRIBUTOR: ${{ github.event_name == 'pull_request_target'
+                                  && github.event.pull_request.user.login || '' }}
+        run: |
+          if [ -n "$EXPECT_CONTRIBUTOR" ]; then
+            python scripts/fetch_contributors.py --expect-contributor "$EXPECT_CONTRIBUTOR"
+          else
+            python scripts/fetch_contributors.py
+          fi
 
       - name: Open a PR if anything changed
         uses: peter-evans/create-pull-request@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -527,7 +527,7 @@ python -m pytest scripts/test -v
 ```
 
 Most of `scripts/` is one-shot utilities where a failure is loud and immediate to whoever ran
-them, and tests would not earn their keep. These three are different, because each one guards
+them, and tests would not earn their keep. These are different, because each one guards
 something else and a bug in a guard reports green while protecting nothing:
 
 | Script | What it gates |
@@ -535,6 +535,15 @@ something else and a bug in a guard reports green while protecting nothing:
 | `add_strings.py` | CI's translation check |
 | `exporter_version.py` | whether a release tag may disagree with the version in the source |
 | `release_notes.py` | the notes of a *published* release, so a parsing mistake is visible to everyone |
+| `fetch_contributors.py` | whether a merge actually credited the contributor, or quietly did not |
+
+The last is the odd one, and worth a sentence. It fails nothing and gates nobody's build - it
+regenerates a credits page. What its tests protect is the *reporting*: GitHub computes
+`/stats/contributors` asynchronously and caches it, merging invalidates that cache, and a run
+answered from the stale cache writes no diff, opens no pull request and goes green having
+credited nobody. `--expect-contributor` turns that into a visible failure, and these tests are
+what keep it honest - including the case where the expected login is one of `EXCLUDED_LOGINS`
+and its absence is correct rather than a fault.
 
 ### Which Python each tree targets
 
@@ -756,7 +765,7 @@ run regardless: each AES entry carries a fresh random salt.
 | `macos-scripts-python.yml` | `python/**` changes | Exporter and shared-package tests across Python 3.10–3.13 on macOS 14 |
 | `macos-exporter-python.yml` | on release | Tag/version check, exporter tests, and the PyInstaller build for macOS (both architectures), Windows and Linux |
 | `exporter-build-check.yml` | PR and push to `main`, `python/**` | Builds the Windows binary and starts it. The release workflow above only runs on `release: published`, so without this a broken bundle is first run by whoever downloads it |
-| `update-contributors.yml` | weekly | Regenerates the contributor list on the Information page, opens a PR if it changed |
+| `update-contributors.yml` | weekly, **and on merging a PR by anyone but the owner** | Regenerates the contributor list on the Information page, opens a PR if it changed. The merge run names who it expected to find and fails if GitHub's cached stats did not have them yet — the weekly run is still the guarantee |
 | `check-adi-libraries.yml` | weekly | Checks Apple's ADI libraries still match what is checked in, opens an issue if they drifted |
 
 The instrumented job needs KVM on the runner; the workflow enables it first. It runs the same

--- a/scripts/fetch_contributors.py
+++ b/scripts/fetch_contributors.py
@@ -36,6 +36,7 @@ Usage:
 
 from __future__ import annotations
 
+import argparse
 import json
 import math
 import os
@@ -84,8 +85,20 @@ SECONDS_PER_WEEK = 7 * 24 * 60 * 60
 
 # GitHub computes contributor stats asynchronously and answers 202 with an empty body while
 # it does. It is expected on a cold cache, not an error.
-STATS_RETRIES = 6
-STATS_RETRY_DELAY_S = 3
+#
+# **Two minutes, because a cold cache is now the normal case rather than the rare one.** This
+# used to run only on a weekly schedule, by which time GitHub had long since computed the answer
+# and served it from cache. It now also runs the moment somebody's pull request is merged - and
+# merging pushes to the default branch, which is exactly what invalidates that cache. So the run
+# whose entire purpose is crediting the person who just contributed is the run most likely to
+# arrive while GitHub is still working the numbers out.
+#
+# Running out of retries is not loud: main() keeps the previous list and exits 0, because a
+# missing credits refresh is not worth failing over. That is the right behaviour and it is also
+# why the budget has to be generous - the failure mode is nobody being credited and nothing
+# saying so until the weekly run catches it.
+STATS_RETRIES = 20
+STATS_RETRY_DELAY_S = 6
 
 
 def _request(url: str, accept: str = "application/vnd.github+json"):
@@ -180,20 +193,67 @@ def is_creditable(author: dict, commits: int) -> bool:
     return True
 
 
-def main() -> int:
+def missing_from(contributors: list[dict], expected: str | None) -> bool:
+    """
+    Whether the person this run was fired for is absent from what it just wrote.
+
+    <b>Because the run that credits somebody is the one most likely to come back stale.</b>
+    `/stats/contributors` is computed asynchronously and cached, and merging invalidates that
+    cache - so a run triggered by a merge can be answered with either a 202 it waits out or a
+    cached 200 from before the merge, and the second is indistinguishable from success. Nothing
+    changes, no pull request opens, and the run is green.
+
+    So the merge-triggered run says who it expected to find. Absent means the weekly schedule is
+    what will actually credit them, and that is worth a failed run on the Actions tab rather than
+    a green one that did nothing.
+
+    An excluded login is not missing - it was never going to be there. Without this, merging a
+    pull request authored by one of the tool accounts in EXCLUDED_LOGINS would fail every time,
+    correctly by the letter and uselessly in practice.
+    """
+    if not expected or expected.lower() in EXCLUDED_LOGINS:
+        return False
+
+    return not any(c["login"].lower() == expected.lower() for c in contributors)
+
+
+def _keep_what_we_have(error: Exception) -> int:
+    """
+    What to do when the stats never arrived: nothing, and say so.
+
+    <b>Exits 0 on purpose.</b> The credits page being a week out of date is not worth failing a
+    build over, and the previously generated files are still correct - just older. Overwriting
+    them with an empty list because GitHub had a bad minute would be strictly worse.
+
+    The empty-manifest branch is for a checkout that has never generated one, where writing
+    nothing would leave the app with no file to read at all.
+    """
+    print(f"\nCould not get contributor stats ({error}).", file=sys.stderr)
+
+    if MANIFEST.is_file():
+        print("Keeping the previously generated contributor list.", file=sys.stderr)
+        return 0
+
+    print("No previously generated list exists; writing an empty one.", file=sys.stderr)
+    ASSETS.mkdir(parents=True, exist_ok=True)
+    MANIFEST.write_text(json.dumps({"contributors": []}, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--expect-contributor",
+        metavar="LOGIN",
+        help="fail if this login is absent from the generated list - see missing_from()")
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
     print(f"Fetching contributors for {REPO} ...")
 
     try:
         stats = fetch_stats()
     except Exception as error:  # noqa: BLE001 - never fail the build over this
-        print(f"\nCould not reach GitHub ({error}).", file=sys.stderr)
-        if MANIFEST.is_file():
-            print("Keeping the previously generated contributor list.", file=sys.stderr)
-            return 0
-        print("No previously generated list exists; writing an empty one.", file=sys.stderr)
-        ASSETS.mkdir(parents=True, exist_ok=True)
-        MANIFEST.write_text(json.dumps({"contributors": []}, indent=2) + "\n", encoding="utf-8")
-        return 0
+        return _keep_what_we_have(error)
 
     now_s = time.time()
     ranked = []
@@ -241,6 +301,16 @@ def main() -> int:
 
     print(f"\nWrote {len(contributors)} contributor(s) to "
           f"{MANIFEST.relative_to(REPO_ROOT)}")
+
+    if missing_from(contributors, args.expect_contributor):
+        print(f"\n{args.expect_contributor} is not in the list this run generated.",
+              file=sys.stderr)
+        print("GitHub's contributor stats are computed asynchronously and cached, so a run "
+              "fired by a merge can be answered from before it. The weekly schedule will pick "
+              "them up; this is a failed run rather than a green one that credited nobody.",
+              file=sys.stderr)
+        return 1
+
     return 0
 
 

--- a/scripts/test/test_fetch_contributors.py
+++ b/scripts/test/test_fetch_contributors.py
@@ -1,0 +1,176 @@
+"""
+What a run fired by a merge is allowed to call success.
+
+**Because the run that credits somebody is the one most likely to come back stale.**
+`/stats/contributors` is computed asynchronously and cached; merging a pull request invalidates
+that cache, so the run triggered by the merge gets either a 202 it has to wait out or a cached
+200 from before the merge. The second is indistinguishable from success - nothing changes, no
+pull request opens, and the workflow is green having credited nobody.
+
+`--expect-contributor` is what makes that visible, and this is the predicate behind it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import fetch_contributors as fc  # noqa: E402
+
+
+def listing(*logins: str) -> list[dict]:
+    return [{"login": login, "profileUrl": "", "avatar": None, "commits": 1} for login in logins]
+
+
+def test_somebody_who_is_in_the_list_is_not_missing():
+    assert not fc.missing_from(listing("ubrt", "parawanderer"), "ubrt")
+
+
+def test_somebody_who_is_absent_is_missing():
+    """The whole point: a stale cache produces a list without the person just merged."""
+    assert fc.missing_from(listing("parawanderer"), "ubrt")
+
+
+def test_the_comparison_ignores_case():
+    """
+    GitHub logins are case-insensitive and the API is not consistent about which case it hands
+    back, so a case-sensitive check would fail runs at random.
+    """
+    assert not fc.missing_from(listing("Fayupable"), "fayupable")
+    assert not fc.missing_from(listing("fayupable"), "Fayupable")
+
+
+def test_expecting_nobody_never_fails():
+    """The scheduled and manual runs pass no expectation, and must not be able to fail here."""
+    assert not fc.missing_from(listing("parawanderer"), None)
+    assert not fc.missing_from([], None)
+
+
+@pytest.mark.parametrize("login", sorted(fc.EXCLUDED_LOGINS))
+def test_an_excluded_login_is_never_missing(login):
+    """
+    <b>An excluded account was never going to be in the list, so its absence is not a failure.</b>
+
+    Without this, merging a pull request authored by one of the tool accounts in EXCLUDED_LOGINS
+    would fail this workflow every single time - correct by the letter, useless in practice, and
+    the sort of permanently-red run that teaches people to ignore a red run.
+    """
+    assert not fc.missing_from(listing("parawanderer"), login)
+    assert not fc.missing_from(listing("parawanderer"), login.upper())
+
+
+def test_the_retry_budget_outlasts_a_cold_cache():
+    """
+    <b>The budget has to be long enough to be worth having.</b>
+
+    A merge is exactly when the cache is cold, so the run whose purpose is crediting somebody is
+    the one most likely to meet a 202. At the previous six retries three seconds apart it gave up
+    after eighteen seconds - and gave up silently, keeping the old list and exiting 0.
+
+    Pinned as a total rather than as the two constants, so either can be tuned without a test
+    failing over arithmetic that did not change the answer.
+    """
+    assert fc.STATS_RETRIES * fc.STATS_RETRY_DELAY_S >= 60
+
+
+def test_a_cold_cache_is_waited_out_rather_than_failed(monkeypatch):
+    """
+    202 is not an error, and the caller must not see one until the budget is spent.
+
+    Asserted on the number of attempts as well as the result: a loop that happened to return on
+    its first pass would pass an assertion that only checked the value.
+    """
+    attempts = []
+
+    class Response:
+        def __init__(self, status, body):
+            self.status, self._body = status, body
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    def fake_request(url, accept="application/vnd.github+json"):
+        attempts.append(url)
+        if len(attempts) < 3:
+            return Response(202, b"")
+        return Response(200, b'[{"author": {"login": "ubrt"}, "total": 3, "weeks": []}]')
+
+    monkeypatch.setattr(fc, "_request", fake_request)
+    monkeypatch.setattr(fc.time, "sleep", lambda _seconds: None)
+
+    stats = fc.fetch_stats()
+
+    assert len(attempts) == 3, "it gave up or never retried"
+    assert stats[0]["author"]["login"] == "ubrt"
+
+
+def test_an_empty_body_is_retried_too(monkeypatch):
+    """
+    <b>A 200 with an empty body means the same thing as a 202 and does not say so.</b>
+
+    GitHub answers that way while computing as well, and `json.loads(b"")` would raise - turning
+    a cold cache into a crash rather than a wait.
+    """
+    attempts = []
+
+    class Response:
+        def __init__(self, status, body):
+            self.status, self._body = status, body
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    def fake_request(url, accept="application/vnd.github+json"):
+        attempts.append(url)
+        if len(attempts) < 2:
+            return Response(200, b"   \n")
+        return Response(200, b"[]")
+
+    monkeypatch.setattr(fc, "_request", fake_request)
+    monkeypatch.setattr(fc.time, "sleep", lambda _seconds: None)
+
+    assert fc.fetch_stats() == []
+    assert len(attempts) == 2
+
+
+def test_giving_up_raises_rather_than_returning_nothing(monkeypatch):
+    """
+    <b>Exhausting the budget must not look like "no contributors".</b>
+
+    An empty list would be written to the manifest as the truth, wiping the credits page. The
+    RuntimeError is what sends main() down the keep-what-we-have path instead.
+    """
+    class Response:
+        status = 202
+
+        def read(self):
+            return b""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    monkeypatch.setattr(fc, "_request", lambda *_args, **_kwargs: Response())
+    monkeypatch.setattr(fc.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(fc, "STATS_RETRIES", 3)
+
+    with pytest.raises(RuntimeError):
+        fc.fetch_stats()


### PR DESCRIPTION
The contributor list on the Information page is regenerated weekly, so somebody can contribute, be thanked in the PR, and then not appear in the app for another six days. This adds a merge trigger.

## What runs it

`pull_request_target: [closed]`, gated to **merged, by someone who is not the owner, and not a bot**.

- **Not the owner** — those are most merges, they change nobody's standing in a list @parawanderer already tops, and a PR for every one is noise that gets ignored, including on the day it matters.
- **Not a bot** — concretely: this workflow's own PR is opened by `github-actions[bot]`, which is not the owner. Without the check, merging one would trigger the next.

Schedule and manual runs are unconditional, which is what the first line of the `if` is for.

## About `pull_request_target`

It's needed because a fork's `pull_request` run gets a read-only token and no secrets, and this job pushes a branch and opens a PR. That trade is the well-known footgun, so the file says why it's safe here: the workflow is read from the base branch, `actions/checkout` takes the base and is given **no `ref`**, and nothing builds or executes anything from the PR.

The contributor's login reaches the script through `env:`, not `${{ }}` inside `run:`. A GitHub login can't carry a shell metacharacter today, so this specific field isn't exploitable — but that is the injection route into this trigger, and the next field someone adds here might be a title or a branch name.

## The honest part: it may not work on any given merge

**GitHub computes `/stats/contributors` asynchronously and caches it, and merging invalidates that cache.** So this run gets either a 202 it waits out, or a cached 200 from before the merge — and the second is indistinguishable from success. No diff, no PR opened, green tick, nobody credited.

Two things follow:

- **The retry budget goes from 18 seconds to two minutes.** A cold cache used to be the rare case on a weekly cron; on this trigger it's the normal one.
- **The merge run passes `--expect-contributor`.** If that login is absent from what was just generated, the run **fails** instead of passing silently.

That failure gates nothing. A red run there means only *"the weekly schedule will credit them instead"* — which is worth being able to see, rather than assuming a trigger works because it never complains.

An excluded login is not missing: merging a PR authored by one of the tool accounts in `EXCLUDED_LOGINS` would otherwise fail every single time, correct by the letter and the sort of permanently-red run that teaches people to ignore a red run.

## Tests

Eleven, in `scripts/test/`, which `static-checks.yml` already runs. **All verified failable:**

| Break | Turns red |
| --- | --- |
| remove the `EXCLUDED_LOGINS` escape | 3 |
| make the login comparison case-sensitive | 1 |
| restore the 18-second retry budget | 1 |

They cover the predicate and the retry loop: a 202 waited out rather than failed, an empty-bodied 200 treated the same way (`json.loads(b"")` would otherwise raise), and exhaustion raising rather than returning `[]` — an empty list would be written to the manifest as truth and wipe the credits page.

## Also

- Extracts the keep-what-we-have branch out of `main()` to stay under flake8's `max-complexity = 10`, which it was already at.
- Fixes that branch's message: it said *"Could not reach GitHub"* for a GitHub that answered perfectly well and simply wasn't ready.
- CI table and tooling-test table in `CONTRIBUTING.md`, per rule 10.

## Not verified

**Whether GitHub's stats cache actually refreshes within the two-minute budget.** I can't establish that without watching a real merge, and it's the one thing this change depends on. The `--expect-contributor` failure is how we find out rather than assume — and the weekly schedule remains the actual guarantee either way.

`scripts/test` passes locally (125 tests), flake8 and pyright are clean on what this touches. The pre-existing `C901` in `check_export_compatibility.py` is untouched.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)