### PR TITLE
Say who owns this file, and stop its voice leaking out of the repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,11 +422,6 @@ constraint it does not understand, and the argument is the payload.
 **A person reading a pull request review is a different job.** State the finding, the file and line,
 and the fix. The same goes for issue replies and anything else sent to a contributor or a reporter.
 
-This has gone wrong once already: a review of #173 was drafted in this register, and its reader was
-a first-time contributor who wanted three line numbers. The failure mode is a loop with nobody in
-it - agents write the docs, a later agent reads them as evidence of what the maintainer wants, and
-writes more of the same. Nothing in the repository contradicts that, because nothing in the
-repository is written by the maintainer.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,22 @@
 Rules for agents working on OpenTagViewer. Written for automated contributors, but the
 constraints apply to anyone.
 
+**This file is owned and maintained by agents, and keeping it current is part of the work rather
+than a favour to whoever comes next.** @parawanderer asked for that and has not read it since. No
+human reviews what lands here, so the agent writing a change is the only check on it.
+
+What that means in practice:
+
+- **If you learned something the hard way, write it down in the same change that taught you.** The
+  next agent starts here, and anything left out is an afternoon they pay for and you did not.
+- **The reason travels with the rule.** An instruction with no reasoning attached is one a later
+  agent deletes the first time it looks inconvenient. That is why the entries here argue.
+- **Earn it.** Nobody is filtering this, so a rule that has not actually cost somebody something
+  does not belong. Rule 10 has the test.
+- **Do not carry this register outside the repository.** It is written for agents who need to be
+  argued out of breaking something. A pull request review, an issue reply, or anything else a
+  person reads is a different job. See rule 16.
+
 ## What this project is
 
 An Android app that shows Apple AirTag locations without an Apple device. Tags are exported
@@ -394,6 +410,23 @@ Every one of these is tested twice: `WhichFailuresNeedAFreshSignInTest` on the J
 decision, `EveryPathAsksForAFreshSignInTest` on a device for each caller honouring it. A shared
 predicate does not stop a fourth screen being written that never asks.
 
+### 16. Do not carry this file's voice into anything a person reads
+
+**@parawanderer has not read this file**, nor most of `docs/`, most docstrings, or most commit
+messages. Agents wrote them. So an agent reading them cannot tell the maintainer's house style from
+its own predecessors' output, and by default assumes the former.
+
+These documents argue at length on purpose. The reader is a future agent deciding whether to undo a
+constraint it does not understand, and the argument is the payload.
+
+**A person reading a pull request review is a different job.** State the finding, the file and line,
+and the fix. The same goes for issue replies and anything else sent to a contributor or a reporter.
+
+This has gone wrong once already: a review of #173 was drafted in this register, and its reader was
+a first-time contributor who wanted three line numbers. The failure mode is a loop with nobody in
+it - agents write the docs, a later agent reads them as evidence of what the maintainer wants, and
+writes more of the same. Nothing in the repository contradicts that, because nothing in the
+repository is written by the maintainer.
 
 ---
 


### PR DESCRIPTION
Two gaps in `AGENTS.md`, both invisible from inside it.

## 1. Nothing said the file is agent-owned

The header names its audience ("Rules for agents working on OpenTagViewer"). Rule 10 has one table row obliging you to add a rule when a constraint would cost somebody an afternoon. Neither says the file is maintained by agents, that no human reviews it, or that keeping it current is part of the work rather than a favour to whoever comes next.

An agent picking up work here had to infer that, and both halves are load-bearing:

- if nobody is filtering, the agent writing a change is the only check on it
- if the next agent starts from this file, anything omitted is an afternoon they pay for

That now sits directly under the title, where it is read before anything it governs, rather than in a rule two hundred lines down.

## 2. Nothing warned that the register does not travel

@parawanderer has not read this file, nor most of `docs/`, most docstrings, or most commit messages. Agents wrote them. So an agent reading them cannot tell the maintainer's house style from its own predecessors' output, and by default assumes the former.

That showed up this week. A review of #173 was drafted in this file's voice, argued at length with the reasoning as the payload, and its reader was a first-time contributor who wanted three line numbers and a fix. Right register, wrong reader.

The loop has nobody in it: agents write the docs, a later agent reads them as evidence of what the maintainer wants, and writes more of the same. Nothing in the repository contradicts that, because nothing in the repository is written by the maintainer.

Rule 16 states the boundary. The reason it argues at length is the same reason it says not to: the length is for an agent about to undo a constraint, and a person reading a review is not that.

Docs only, so no checks will run.